### PR TITLE
Harden fiscal period lock rule handling

### DIFF
--- a/.github/workflows/settings-management-ci.yml
+++ b/.github/workflows/settings-management-ci.yml
@@ -25,7 +25,5 @@ jobs:
           coverage: xdebug
       - name: Install dependencies
         run: composer install
-      - name: Run tests
-        run: composer test
       - name: Run coverage text
         run: composer test-coverage

--- a/.github/workflows/settings-management-ci.yml
+++ b/.github/workflows/settings-management-ci.yml
@@ -23,6 +23,15 @@ jobs:
         with:
           php-version: "8.3"
           coverage: xdebug
+      - name: Cache Composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.composer/cache/files
+            orchestrators/SettingsManagement/vendor
+          key: ${{ runner.os }}-settings-management-composer-${{ hashFiles('orchestrators/SettingsManagement/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-settings-management-composer-
       - name: Install dependencies
         run: composer install
       - name: Run coverage text

--- a/.github/workflows/settings-management-ci.yml
+++ b/.github/workflows/settings-management-ci.yml
@@ -1,0 +1,31 @@
+name: SettingsManagement CI
+
+on:
+  pull_request:
+    paths:
+      - "orchestrators/SettingsManagement/**"
+      - ".github/workflows/settings-management-ci.yml"
+  push:
+    branches: [main]
+    paths:
+      - "orchestrators/SettingsManagement/**"
+      - ".github/workflows/settings-management-ci.yml"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: orchestrators/SettingsManagement
+    steps:
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.3"
+          coverage: xdebug
+      - name: Install dependencies
+        run: composer install
+      - name: Run tests
+        run: composer test
+      - name: Run coverage text
+        run: composer test-coverage

--- a/docs/superpowers/plans/2026-04-10-settings-management-minimal-productionization-implementation-plan.md
+++ b/docs/superpowers/plans/2026-04-10-settings-management-minimal-productionization-implementation-plan.md
@@ -10,7 +10,7 @@
 
 ---
 
-### Task 1: Add package test scripts and PHPUnit config
+## Task 1: Add package test scripts and PHPUnit config
 
 **Files:**
 - Modify: `orchestrators/SettingsManagement/composer.json`
@@ -88,7 +88,7 @@ git add orchestrators/SettingsManagement/composer.json orchestrators/SettingsMan
 git commit -m "chore(settings-management): add package test and coverage scripts"
 ```
 
-### Task 2: Align README with actual runnable commands
+## Task 2: Align README with actual runnable commands
 
 **Files:**
 - Modify: `orchestrators/SettingsManagement/README.md`
@@ -126,7 +126,7 @@ git add orchestrators/SettingsManagement/README.md
 git commit -m "docs(settings-management): align testing docs with composer scripts"
 ```
 
-### Task 3: Add package-scoped CI workflow
+## Task 3: Add package-scoped CI workflow
 
 **Files:**
 - Create: `.github/workflows/settings-management-ci.yml`
@@ -185,7 +185,7 @@ git add .github/workflows/settings-management-ci.yml
 git commit -m "ci(settings-management): add package-scoped test workflow"
 ```
 
-### Task 4: Final verification and handoff
+## Task 4: Final verification and handoff
 
 **Files:**
 - Modify: `orchestrators/SettingsManagement/IMPLEMENTATION_SUMMARY.md`

--- a/docs/superpowers/plans/2026-04-10-settings-management-minimal-productionization-implementation-plan.md
+++ b/docs/superpowers/plans/2026-04-10-settings-management-minimal-productionization-implementation-plan.md
@@ -161,6 +161,15 @@ jobs:
         with:
           php-version: "8.3"
           coverage: xdebug
+      - name: Cache Composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.composer/cache/files
+            orchestrators/SettingsManagement/vendor
+          key: ${{ runner.os }}-settings-management-composer-${{ hashFiles('orchestrators/SettingsManagement/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-settings-management-composer-
       - name: Install dependencies
         run: composer install
       - name: Run coverage text

--- a/docs/superpowers/plans/2026-04-10-settings-management-minimal-productionization-implementation-plan.md
+++ b/docs/superpowers/plans/2026-04-10-settings-management-minimal-productionization-implementation-plan.md
@@ -161,9 +161,8 @@ jobs:
         with:
           php-version: "8.3"
           coverage: xdebug
-      - uses: ramsey/composer-install@v3
-      - name: Run tests
-        run: composer test
+      - name: Install dependencies
+        run: composer install
       - name: Run coverage text
         run: composer test-coverage
 ```

--- a/docs/superpowers/plans/2026-04-10-settings-management-minimal-productionization-implementation-plan.md
+++ b/docs/superpowers/plans/2026-04-10-settings-management-minimal-productionization-implementation-plan.md
@@ -1,0 +1,218 @@
+# SettingsManagement Minimal Productionization Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `orchestrators/SettingsManagement` presentable for alpha by aligning documented test commands, package scripts, and package-scoped CI.
+
+**Architecture:** Keep runtime code untouched and focus on packaging quality surfaces: `composer.json` scripts, package-local `phpunit.xml`, README parity, and a path-scoped GitHub workflow. Validation is intentionally narrow and fast to preserve alpha delivery velocity.
+
+**Tech Stack:** PHP 8.3, Composer, PHPUnit 10, GitHub Actions.
+
+---
+
+### Task 1: Add package test scripts and PHPUnit config
+
+**Files:**
+- Modify: `orchestrators/SettingsManagement/composer.json`
+- Create: `orchestrators/SettingsManagement/phpunit.xml`
+- Test: `orchestrators/SettingsManagement/tests/Unit/FiscalPeriodLockedRuleTest.php`
+
+- [ ] **Step 1: Add failing expectation for missing script command (pre-check)**
+
+Run:
+
+```bash
+cd orchestrators/SettingsManagement
+composer test
+```
+
+Expected before change: `Command "test" is not defined.`
+
+- [ ] **Step 2: Add Composer scripts in package composer.json**
+
+Add this `scripts` block:
+
+```json
+"scripts": {
+  "test": "vendor/bin/phpunit -c phpunit.xml",
+  "test-coverage": "vendor/bin/phpunit -c phpunit.xml --coverage-text"
+}
+```
+
+- [ ] **Step 3: Create phpunit.xml with stable package-local defaults**
+
+Create `orchestrators/SettingsManagement/phpunit.xml`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="vendor/autoload.php" cacheDirectory=".phpunit.cache" colors="true">
+  <testsuites>
+    <testsuite name="SettingsManagement Unit">
+      <directory suffix="Test.php">tests</directory>
+    </testsuite>
+  </testsuites>
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+  </coverage>
+</phpunit>
+```
+
+- [ ] **Step 4: Run package tests through the new script**
+
+Run:
+
+```bash
+cd orchestrators/SettingsManagement
+composer test
+```
+
+Expected: PHPUnit passes and executes all package tests.
+
+- [ ] **Step 5: Run coverage script**
+
+Run:
+
+```bash
+cd orchestrators/SettingsManagement
+composer test-coverage
+```
+
+Expected: PHPUnit runs tests and prints text coverage summary.
+
+- [ ] **Step 6: Commit Task 1**
+
+```bash
+git add orchestrators/SettingsManagement/composer.json orchestrators/SettingsManagement/phpunit.xml
+git commit -m "chore(settings-management): add package test and coverage scripts"
+```
+
+### Task 2: Align README with actual runnable commands
+
+**Files:**
+- Modify: `orchestrators/SettingsManagement/README.md`
+
+- [ ] **Step 1: Update testing section to package-local command flow**
+
+Ensure README includes:
+
+```md
+## Testing
+
+~~~bash
+cd orchestrators/SettingsManagement
+composer install
+composer test
+composer test-coverage
+~~~
+```
+
+- [ ] **Step 2: Verify README command parity with composer scripts**
+
+Run:
+
+```bash
+cd orchestrators/SettingsManagement
+composer run --list | rg "test|test-coverage"
+```
+
+Expected output includes both script names exactly as documented.
+
+- [ ] **Step 3: Commit Task 2**
+
+```bash
+git add orchestrators/SettingsManagement/README.md
+git commit -m "docs(settings-management): align testing docs with composer scripts"
+```
+
+### Task 3: Add package-scoped CI workflow
+
+**Files:**
+- Create: `.github/workflows/settings-management-ci.yml`
+
+- [ ] **Step 1: Create package-scoped workflow**
+
+Create `.github/workflows/settings-management-ci.yml`:
+
+```yaml
+name: SettingsManagement CI
+
+on:
+  pull_request:
+    paths:
+      - "orchestrators/SettingsManagement/**"
+      - ".github/workflows/settings-management-ci.yml"
+  push:
+    branches: [main]
+    paths:
+      - "orchestrators/SettingsManagement/**"
+      - ".github/workflows/settings-management-ci.yml"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: orchestrators/SettingsManagement
+    steps:
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.3"
+          coverage: xdebug
+      - uses: ramsey/composer-install@v3
+      - name: Run tests
+        run: composer test
+      - name: Run coverage text
+        run: composer test-coverage
+```
+
+- [ ] **Step 2: Validate workflow file is discoverable by GitHub CLI**
+
+Run:
+
+```bash
+gh workflow list | rg "SettingsManagement CI"
+```
+
+Expected: workflow name appears in output.
+
+- [ ] **Step 3: Commit Task 3**
+
+```bash
+git add .github/workflows/settings-management-ci.yml
+git commit -m "ci(settings-management): add package-scoped test workflow"
+```
+
+### Task 4: Final verification and handoff
+
+**Files:**
+- Modify: `orchestrators/SettingsManagement/IMPLEMENTATION_SUMMARY.md`
+
+- [ ] **Step 1: Run final local verification**
+
+Run:
+
+```bash
+cd orchestrators/SettingsManagement
+composer test
+composer test-coverage
+```
+
+Expected: both commands succeed.
+
+- [ ] **Step 2: Update implementation summary**
+
+Append a short entry with:
+- scripts added (`test`, `test-coverage`),
+- `phpunit.xml` introduced,
+- README test section aligned,
+- CI workflow added.
+
+- [ ] **Step 3: Commit Task 4**
+
+```bash
+git add orchestrators/SettingsManagement/IMPLEMENTATION_SUMMARY.md
+git commit -m "docs(settings-management): record minimal productionization baseline"
+```

--- a/docs/superpowers/specs/2026-04-10-settings-management-minimal-productionization-design.md
+++ b/docs/superpowers/specs/2026-04-10-settings-management-minimal-productionization-design.md
@@ -1,0 +1,78 @@
+# SettingsManagement Minimal Productionization Design
+
+**Topic:** Make `orchestrators/SettingsManagement` presentable for Atomy-Q alpha without expanding runtime feature scope.
+**Date:** 2026-04-10
+**Status:** Approved
+
+## 1. Executive Summary
+`orchestrators/SettingsManagement` currently has runnable PHPUnit tests, but package ergonomics are inconsistent: README documents `composer test` and `composer test-coverage`, while `composer.json` does not define those scripts. This creates avoidable friction and weakens confidence during review.
+
+This design introduces a minimal packaging-quality baseline:
+- working Composer test scripts,
+- stable PHPUnit configuration file,
+- README command parity,
+- lightweight package-scoped CI workflow.
+
+The goal is presentation and reliability of developer workflow, not runtime feature expansion.
+
+## 2. Goals and Success Criteria
+- **Goal:** Ensure README test commands run exactly as documented.
+- **Goal:** Provide one clear command path for local verification and CI verification.
+- **Goal:** Keep changes low-risk and isolated to package quality tooling.
+
+**Success Criteria**
+- `composer test` succeeds in `orchestrators/SettingsManagement`.
+- `composer test-coverage` succeeds and emits text coverage summary.
+- README test section exactly matches package scripts.
+- GitHub Actions workflow runs package install and tests on relevant path changes.
+
+## 3. Scope Boundaries
+### In Scope
+- `composer.json` scripts alignment.
+- `phpunit.xml` creation for package-local defaults.
+- README test section correction.
+- New CI workflow file in `.github/workflows/` scoped to this package.
+
+### Out of Scope
+- Runtime/business logic changes in `src/`.
+- Additional tooling that may introduce churn (e.g., strict PHPStan rollout).
+- Cross-package monorepo test unification.
+- Large coverage artifact publication/reporting stack.
+
+## 4. Architecture and Workflow
+The package remains a standalone orchestrator library with local Composer and PHPUnit execution.
+
+Quality flow after this design:
+1. Engineer runs `composer install` in package.
+2. Engineer runs `composer test` for default unit checks.
+3. Engineer runs `composer test-coverage` for text coverage signal.
+4. CI performs the same install + test path on pull requests touching the package.
+
+No application runtime dependencies or service bindings change.
+
+## 5. File-Level Changes
+- `orchestrators/SettingsManagement/composer.json`
+  - Add `scripts.test` and `scripts.test-coverage`.
+- `orchestrators/SettingsManagement/phpunit.xml` (new)
+  - Define bootstrap, testsuite path, and basic coverage include path.
+- `orchestrators/SettingsManagement/README.md`
+  - Keep test instructions synchronized with scripts and add explicit package-local usage.
+- `.github/workflows/settings-management-ci.yml` (new)
+  - Package-scoped workflow using path filters and running Composer + PHPUnit commands.
+
+## 6. Error Handling and Risk Controls
+- If coverage driver (Xdebug/PCOV) is missing, `composer test-coverage` should fail clearly with PHPUnit output; no silent fallback.
+- CI scope remains narrow via path filters to avoid slowing broader alpha pipelines.
+- No runtime code path changes reduce regression risk for Atomy-Q alpha.
+
+## 7. Testing Strategy
+- Local verification:
+  - `composer test`
+  - `composer test-coverage`
+- CI verification:
+  - Push a branch touching package files and confirm workflow passes.
+
+## 8. Rollout
+- Merge as one small PR.
+- Announce new canonical package test commands in PR description.
+- Use this package as baseline template for similar orchestrators only after alpha-critical work settles.

--- a/orchestrators/SettingsManagement/IMPLEMENTATION_SUMMARY.md
+++ b/orchestrators/SettingsManagement/IMPLEMENTATION_SUMMARY.md
@@ -2,6 +2,13 @@
 
 ## Hardening (2026-04-08)
 
+### Files Changed
+
+- `src/Rules/FiscalPeriodLockedRule.php`: fixed closed-status detection, normalized status parsing, and hardened operation-type normalization for string/enum inputs.
+- `src/DTOs/FiscalPeriod/PeriodOperationType.php`: moved period operation enum into its own autoload-safe DTO file.
+- `src/DTOs/FiscalPeriod/PeriodValidationRequest.php`: removed inline enum declaration after extraction to dedicated enum file.
+- `tests/Unit/FiscalPeriodLockedRuleTest.php`: added regression tests for open/closed status handling and locked-period operation behavior.
+
 - Fixed fiscal-period closure detection in `FiscalPeriodLockedRule` by removing an operator-precedence bug that treated any non-empty status (including `"open"`) as closed.
 - Normalized period status parsing (`trim` + lowercase) before evaluating closure to reduce brittle behavior from casing/whitespace differences.
 - Hardened operation-type handling in `FiscalPeriodLockedRule` so it safely accepts both enum and string operation values from coordinator contexts, preventing adjustment-path misclassification.

--- a/orchestrators/SettingsManagement/IMPLEMENTATION_SUMMARY.md
+++ b/orchestrators/SettingsManagement/IMPLEMENTATION_SUMMARY.md
@@ -19,6 +19,15 @@
   - locked-period adjustment behavior is correctly enforced for both string and enum operation inputs.
   - non-adjustment operations on locked periods are rejected.
 
+## Minimal Productionization Baseline (2026-04-10)
+
+- Added package-level Composer scripts in `composer.json`:
+  - `composer test`
+  - `composer test-coverage`
+- Introduced `phpunit.xml` with package-local defaults (autoload bootstrap, testsuite, coverage include for `src/`).
+- Updated `README.md` testing commands to the exact package-local flow (`cd`, `composer install`, `composer test`, `composer test-coverage`).
+- Added package-scoped CI workflow in `.github/workflows/settings-management-ci.yml` to run install + test + coverage-text on SettingsManagement changes.
+
 ## Last updated
 
-2026-04-08
+2026-04-10

--- a/orchestrators/SettingsManagement/IMPLEMENTATION_SUMMARY.md
+++ b/orchestrators/SettingsManagement/IMPLEMENTATION_SUMMARY.md
@@ -1,0 +1,17 @@
+# SettingsManagement - Implementation Summary
+
+## Hardening (2026-04-08)
+
+- Fixed fiscal-period closure detection in `FiscalPeriodLockedRule` by removing an operator-precedence bug that treated any non-empty status (including `"open"`) as closed.
+- Normalized period status parsing (`trim` + lowercase) before evaluating closure to reduce brittle behavior from casing/whitespace differences.
+- Hardened operation-type handling in `FiscalPeriodLockedRule` so it safely accepts both enum and string operation values from coordinator contexts, preventing adjustment-path misclassification.
+- Added regression unit tests in `tests/Unit/FiscalPeriodLockedRuleTest.php` to assert:
+  - `"open"` status passes validation.
+  - missing status defaults to open.
+  - `"closed"` status still blocks modifications.
+  - locked-period adjustment behavior is correctly enforced for both string and enum operation inputs.
+  - non-adjustment operations on locked periods are rejected.
+
+## Last updated
+
+2026-04-08

--- a/orchestrators/SettingsManagement/README.md
+++ b/orchestrators/SettingsManagement/README.md
@@ -216,6 +216,9 @@ This package depends only on:
 ## Testing
 
 ```bash
+cd orchestrators/SettingsManagement
+composer install
+
 # Run unit tests
 composer test
 

--- a/orchestrators/SettingsManagement/composer.json
+++ b/orchestrators/SettingsManagement/composer.json
@@ -22,6 +22,10 @@
             "Nexus\\SettingsManagement\\Tests\\": "tests/"
         }
     },
+    "scripts": {
+        "test": "vendor/bin/phpunit -c phpunit.xml",
+        "test-coverage": "vendor/bin/phpunit -c phpunit.xml --coverage-text"
+    },
     "repositories": [
         {
             "type": "path",

--- a/orchestrators/SettingsManagement/phpunit.xml
+++ b/orchestrators/SettingsManagement/phpunit.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="vendor/autoload.php" cacheDirectory=".phpunit.cache" colors="true">
+  <testsuites>
+    <testsuite name="SettingsManagement Unit">
+      <directory suffix="Test.php">tests</directory>
+    </testsuite>
+  </testsuites>
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+  </coverage>
+</phpunit>

--- a/orchestrators/SettingsManagement/src/DTOs/FiscalPeriod/PeriodOperationType.php
+++ b/orchestrators/SettingsManagement/src/DTOs/FiscalPeriod/PeriodOperationType.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nexus\SettingsManagement\DTOs\FiscalPeriod;
+
+/**
+ * Operation types for period validation.
+ */
+enum PeriodOperationType: string
+{
+    case TRANSACTION = 'transaction';
+    case ADJUSTMENT = 'adjustment';
+    case CLOSING = 'closing';
+    case REPORTING = 'reporting';
+}

--- a/orchestrators/SettingsManagement/src/DTOs/FiscalPeriod/PeriodValidationRequest.php
+++ b/orchestrators/SettingsManagement/src/DTOs/FiscalPeriod/PeriodValidationRequest.php
@@ -5,17 +5,6 @@ declare(strict_types=1);
 namespace Nexus\SettingsManagement\DTOs\FiscalPeriod;
 
 /**
- * Operation types for period validation.
- */
-enum PeriodOperationType: string
-{
-    case TRANSACTION = 'transaction';
-    case ADJUSTMENT = 'adjustment';
-    case CLOSING = 'closing';
-    case REPORTING = 'reporting';
-}
-
-/**
  * Request DTO for validating fiscal period status.
  */
 final class PeriodValidationRequest

--- a/orchestrators/SettingsManagement/src/Rules/FiscalPeriodLockedRule.php
+++ b/orchestrators/SettingsManagement/src/Rules/FiscalPeriodLockedRule.php
@@ -7,7 +7,6 @@ namespace Nexus\SettingsManagement\Rules;
 use Nexus\SettingsManagement\Contracts\RuleValidationInterface;
 use Nexus\SettingsManagement\Contracts\RuleValidationResult;
 use Nexus\SettingsManagement\DTOs\FiscalPeriod\PeriodOperationType;
-
 /**
  * Validates that a fiscal period is not locked for the requested operation.
  */

--- a/orchestrators/SettingsManagement/src/Rules/FiscalPeriodLockedRule.php
+++ b/orchestrators/SettingsManagement/src/Rules/FiscalPeriodLockedRule.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Nexus\SettingsManagement\Rules;
 
+use BackedEnum;
+use UnitEnum;
 use Nexus\SettingsManagement\Contracts\RuleValidationInterface;
 use Nexus\SettingsManagement\Contracts\RuleValidationResult;
 use Nexus\SettingsManagement\DTOs\FiscalPeriod\PeriodOperationType;
@@ -27,7 +29,7 @@ final class FiscalPeriodLockedRule implements RuleValidationInterface
         }
 
         $isLocked = $period['isLocked'] ?? false;
-        $status = is_string($period['status'] ?? null) ? strtolower(trim((string) $period['status'])) : 'open';
+        $status = $this->normalizeStatus($period['status'] ?? null);
         $isClosed = $status === 'closed';
 
         if ($isClosed) {
@@ -65,16 +67,40 @@ final class FiscalPeriodLockedRule implements RuleValidationInterface
         }
 
         if (is_string($operationType)) {
-            $normalized = strtolower(trim($operationType));
-            if ($normalized !== '') {
-                try {
-                    return PeriodOperationType::from($normalized);
-                } catch (\ValueError) {
-                    // Fall back to transaction when callers send unknown operation values.
-                }
+            $trimmed = trim($operationType);
+            if ($trimmed !== '') {
+                return PeriodOperationType::tryFrom($trimmed)
+                    ?? PeriodOperationType::tryFrom(strtolower($trimmed))
+                    ?? PeriodOperationType::TRANSACTION;
             }
         }
 
         return PeriodOperationType::TRANSACTION;
+    }
+
+    private function normalizeStatus(mixed $status): string
+    {
+        if (is_string($status)) {
+            $normalized = strtolower(trim($status));
+            if ($normalized !== '') {
+                return $normalized;
+            }
+        }
+
+        if ($status instanceof BackedEnum && is_string($status->value)) {
+            $normalized = strtolower(trim($status->value));
+            if ($normalized !== '') {
+                return $normalized;
+            }
+        }
+
+        if ($status instanceof UnitEnum) {
+            $normalized = strtolower(trim($status->name));
+            if ($normalized !== '') {
+                return $normalized;
+            }
+        }
+
+        return 'open';
     }
 }

--- a/orchestrators/SettingsManagement/src/Rules/FiscalPeriodLockedRule.php
+++ b/orchestrators/SettingsManagement/src/Rules/FiscalPeriodLockedRule.php
@@ -20,7 +20,7 @@ final class FiscalPeriodLockedRule implements RuleValidationInterface
         }
 
         $periodId = $context['periodId'] ?? null;
-        $operationType = $context['operationType'] ?? PeriodOperationType::TRANSACTION;
+        $operationType = $this->normalizeOperationType($context['operationType'] ?? PeriodOperationType::TRANSACTION);
         $period = $context['period'] ?? null;
 
         if (!$periodId || !$period) {
@@ -28,7 +28,8 @@ final class FiscalPeriodLockedRule implements RuleValidationInterface
         }
 
         $isLocked = $period['isLocked'] ?? false;
-        $isClosed = $period['status'] ?? 'open' === 'closed';
+        $status = is_string($period['status'] ?? null) ? strtolower(trim((string) $period['status'])) : 'open';
+        $isClosed = $status === 'closed';
 
         if ($isClosed) {
             return RuleValidationResult::failure(
@@ -56,5 +57,25 @@ final class FiscalPeriodLockedRule implements RuleValidationInterface
         }
 
         return RuleValidationResult::success();
+    }
+
+    private function normalizeOperationType(mixed $operationType): PeriodOperationType
+    {
+        if ($operationType instanceof PeriodOperationType) {
+            return $operationType;
+        }
+
+        if (is_string($operationType)) {
+            $normalized = strtolower(trim($operationType));
+            if ($normalized !== '') {
+                try {
+                    return PeriodOperationType::from($normalized);
+                } catch (\ValueError) {
+                    // Fall back to transaction when callers send unknown operation values.
+                }
+            }
+        }
+
+        return PeriodOperationType::TRANSACTION;
     }
 }

--- a/orchestrators/SettingsManagement/tests/Unit/FiscalPeriodLockedRuleTest.php
+++ b/orchestrators/SettingsManagement/tests/Unit/FiscalPeriodLockedRuleTest.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nexus\SettingsManagement\Tests\Unit;
+
+use Nexus\SettingsManagement\DTOs\FiscalPeriod\PeriodOperationType;
+use Nexus\SettingsManagement\Rules\FiscalPeriodLockedRule;
+use PHPUnit\Framework\TestCase;
+
+final class FiscalPeriodLockedRuleTest extends TestCase
+{
+    public function testEvaluateTreatsOpenStatusAsNotClosed(): void
+    {
+        $rule = new FiscalPeriodLockedRule();
+
+        $result = $rule->evaluate([
+            'periodId' => 'FY2026-P01',
+            'operationType' => PeriodOperationType::TRANSACTION,
+            'period' => [
+                'status' => 'open',
+                'isLocked' => false,
+            ],
+        ]);
+
+        self::assertTrue($result->passed);
+        self::assertNull($result->error);
+    }
+
+    public function testEvaluateTreatsMissingStatusAsOpenByDefault(): void
+    {
+        $rule = new FiscalPeriodLockedRule();
+
+        $result = $rule->evaluate([
+            'periodId' => 'FY2026-P02',
+            'operationType' => PeriodOperationType::TRANSACTION,
+            'period' => [
+                'isLocked' => false,
+            ],
+        ]);
+
+        self::assertTrue($result->passed);
+        self::assertNull($result->error);
+    }
+
+    public function testEvaluateFailsWhenPeriodIsClosed(): void
+    {
+        $rule = new FiscalPeriodLockedRule();
+
+        $result = $rule->evaluate([
+            'periodId' => 'FY2026-P03',
+            'operationType' => PeriodOperationType::TRANSACTION,
+            'period' => [
+                'status' => 'closed',
+                'isLocked' => false,
+            ],
+        ]);
+
+        self::assertFalse($result->passed);
+        self::assertSame("Period 'FY2026-P03' is closed and cannot be modified", $result->error);
+        self::assertSame(['period_id' => 'FY2026-P03', 'is_closed' => true], $result->details);
+    }
+
+    public function testEvaluateAllowsLockedPeriodAdjustmentWhenAllowedUsingStringOperationType(): void
+    {
+        $rule = new FiscalPeriodLockedRule();
+
+        $result = $rule->evaluate([
+            'periodId' => 'FY2026-P04',
+            'operationType' => 'adjustment',
+            'period' => [
+                'status' => 'open',
+                'isLocked' => true,
+                'allowsAdjustment' => true,
+            ],
+        ]);
+
+        self::assertTrue($result->passed);
+        self::assertNull($result->error);
+    }
+
+    public function testEvaluateFailsLockedPeriodAdjustmentWhenNotAllowed(): void
+    {
+        $rule = new FiscalPeriodLockedRule();
+
+        $result = $rule->evaluate([
+            'periodId' => 'FY2026-P05',
+            'operationType' => PeriodOperationType::ADJUSTMENT,
+            'period' => [
+                'status' => 'open',
+                'isLocked' => true,
+                'allowsAdjustment' => false,
+            ],
+        ]);
+
+        self::assertFalse($result->passed);
+        self::assertSame("Period 'FY2026-P05' is locked and does not allow adjustments", $result->error);
+        self::assertSame(['period_id' => 'FY2026-P05', 'is_locked' => true], $result->details);
+    }
+
+    public function testEvaluateFailsLockedPeriodForNonAdjustmentOperation(): void
+    {
+        $rule = new FiscalPeriodLockedRule();
+
+        $result = $rule->evaluate([
+            'periodId' => 'FY2026-P06',
+            'operationType' => 'transaction',
+            'period' => [
+                'status' => 'open',
+                'isLocked' => true,
+                'allowsAdjustment' => true,
+            ],
+        ]);
+
+        self::assertFalse($result->passed);
+        self::assertSame("Period 'FY2026-P06' is locked", $result->error);
+        self::assertSame(['period_id' => 'FY2026-P06', 'is_locked' => true], $result->details);
+    }
+}

--- a/orchestrators/SettingsManagement/tests/Unit/FiscalPeriodLockedRuleTest.php
+++ b/orchestrators/SettingsManagement/tests/Unit/FiscalPeriodLockedRuleTest.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 namespace Nexus\SettingsManagement\Tests\Unit;
 
+use PHPUnit\Framework\TestCase;
+
 use Nexus\SettingsManagement\DTOs\FiscalPeriod\PeriodOperationType;
 use Nexus\SettingsManagement\Rules\FiscalPeriodLockedRule;
-use PHPUnit\Framework\TestCase;
 
 final class FiscalPeriodLockedRuleTest extends TestCase
 {

--- a/orchestrators/SettingsManagement/tests/Unit/FiscalPeriodLockedRuleTest.php
+++ b/orchestrators/SettingsManagement/tests/Unit/FiscalPeriodLockedRuleTest.php
@@ -44,6 +44,40 @@ final class FiscalPeriodLockedRuleTest extends TestCase
         self::assertNull($result->error);
     }
 
+    /**
+     * @dataProvider blankStatusProvider
+     */
+    public function testEvaluateTreatsBlankOrWhitespaceStatusAsOpenByDefault(string $status): void
+    {
+        $rule = new FiscalPeriodLockedRule();
+
+        $result = $rule->evaluate([
+            'periodId' => 'FY2026-P02B',
+            'operationType' => PeriodOperationType::TRANSACTION->value,
+            'period' => [
+                'isLocked' => false,
+                'status' => $status,
+            ],
+        ]);
+
+        self::assertTrue($result->passed);
+        self::assertNull($result->error);
+    }
+
+    /**
+     * @return array<string, array<string>>
+     */
+    public static function blankStatusProvider(): array
+    {
+        return [
+            'empty string' => [''],
+            'whitespace' => ['   '],
+            'tab' => ["\t"],
+            'newline' => ["\n"],
+            'mixed whitespace' => [" \t\n "],
+        ];
+    }
+
     public function testEvaluateFailsWhenPeriodIsClosed(): void
     {
         $rule = new FiscalPeriodLockedRule();

--- a/orchestrators/SettingsManagement/tests/Unit/FiscalPeriodLockedRuleTest.php
+++ b/orchestrators/SettingsManagement/tests/Unit/FiscalPeriodLockedRuleTest.php
@@ -16,7 +16,7 @@ final class FiscalPeriodLockedRuleTest extends TestCase
 
         $result = $rule->evaluate([
             'periodId' => 'FY2026-P01',
-            'operationType' => PeriodOperationType::TRANSACTION,
+            'operationType' => PeriodOperationType::TRANSACTION->value,
             'period' => [
                 'status' => 'open',
                 'isLocked' => false,
@@ -33,7 +33,7 @@ final class FiscalPeriodLockedRuleTest extends TestCase
 
         $result = $rule->evaluate([
             'periodId' => 'FY2026-P02',
-            'operationType' => PeriodOperationType::TRANSACTION,
+            'operationType' => PeriodOperationType::TRANSACTION->value,
             'period' => [
                 'isLocked' => false,
             ],
@@ -49,7 +49,7 @@ final class FiscalPeriodLockedRuleTest extends TestCase
 
         $result = $rule->evaluate([
             'periodId' => 'FY2026-P03',
-            'operationType' => PeriodOperationType::TRANSACTION,
+            'operationType' => PeriodOperationType::TRANSACTION->value,
             'period' => [
                 'status' => 'closed',
                 'isLocked' => false,
@@ -85,7 +85,7 @@ final class FiscalPeriodLockedRuleTest extends TestCase
 
         $result = $rule->evaluate([
             'periodId' => 'FY2026-P05',
-            'operationType' => PeriodOperationType::ADJUSTMENT,
+            'operationType' => PeriodOperationType::ADJUSTMENT->value,
             'period' => [
                 'status' => 'open',
                 'isLocked' => true,
@@ -104,7 +104,7 @@ final class FiscalPeriodLockedRuleTest extends TestCase
 
         $result = $rule->evaluate([
             'periodId' => 'FY2026-P06',
-            'operationType' => 'transaction',
+            'operationType' => PeriodOperationType::TRANSACTION->value,
             'period' => [
                 'status' => 'open',
                 'isLocked' => true,


### PR DESCRIPTION
## Summary
- harden operation normalization in FiscalPeriodLockedRule using safe enum parsing
- normalize period status values with explicit blank-value fallback to open
- align import ordering and update implementation summary file list

## Validation
- ./vendor/bin/phpunit tests/Unit/FiscalPeriodLockedRuleTest.php
- ./vendor/bin/phpunit tests
- php -l orchestrators/SettingsManagement/src/Rules/FiscalPeriodLockedRule.php
- php -l orchestrators/SettingsManagement/tests/Unit/FiscalPeriodLockedRuleTest.php

## Notes
- CodeRabbit review loop was run (cr --agent) and fixes were applied from reported findings before this PR was opened.