### PR TITLE
hardening: finance operations division-safety pass

### DIFF
--- a/docs/superpowers/plans/2026-04-10-finance-operations-division-safety-pass-implementation-plan.md
+++ b/docs/superpowers/plans/2026-04-10-finance-operations-division-safety-pass-implementation-plan.md
@@ -1,0 +1,278 @@
+# FinanceOperations Division-Safety Pass Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Harden `FinanceOperations` arithmetic paths so all denominator-based calculations fail safely with domain exceptions instead of runtime division errors.
+
+**Architecture:** Keep changes scoped to two services (`CostAllocationService`, `DepreciationRunService`) plus their unit tests. Add service-local denominator guards and map invalid arithmetic states to existing domain exceptions. Preserve all valid-path behavior.
+
+**Tech Stack:** PHP 8.3, PHPUnit 11, BCMath helpers, Nexus orchestrator exception contracts.
+
+---
+
+## File Map
+- Modify: `orchestrators/FinanceOperations/src/Services/CostAllocationService.php`
+- Modify: `orchestrators/FinanceOperations/src/Services/DepreciationRunService.php`
+- Modify: `orchestrators/FinanceOperations/tests/Unit/Services/CostAllocationServiceTest.php`
+- Modify: `orchestrators/FinanceOperations/tests/Unit/Services/DepreciationRunServiceTest.php`
+- Modify: `orchestrators/FinanceOperations/IMPLEMENTATION_SUMMARY.md`
+
+### Task 1: Harden CostAllocation denominator paths
+
+**Files:**
+- Modify: `orchestrators/FinanceOperations/src/Services/CostAllocationService.php`
+- Test: `orchestrators/FinanceOperations/tests/Unit/Services/CostAllocationServiceTest.php`
+
+- [ ] **Step 1: Write failing tests for invalid denominators and method mapping**
+
+```php
+public function testAllocateWithProportionalMethodThrowsWhenTotalWeightIsZero(): void
+{
+    $request = new CostAllocationRequest(
+        tenantId: 'tenant-001',
+        periodId: '2026-01',
+        sourceCostPoolId: 'pool-001',
+        targetCostCenterIds: ['cc-001', 'cc-002'],
+        allocationMethod: 'proportional',
+        options: ['weights' => [0, 0]],
+    );
+
+    $this->expectException(CostAllocationException::class);
+    $this->service->allocate($request);
+}
+
+public function testAllocateWithUnknownMethodThrowsDomainException(): void
+{
+    $request = new CostAllocationRequest(
+        tenantId: 'tenant-001',
+        periodId: '2026-01',
+        sourceCostPoolId: 'pool-001',
+        targetCostCenterIds: ['cc-001'],
+        allocationMethod: 'unknown',
+    );
+
+    $this->expectException(CostAllocationException::class);
+    $this->service->allocate($request);
+}
+```
+
+- [ ] **Step 2: Run focused test file and confirm new tests fail**
+
+Run: `./vendor/bin/phpunit -c phpunit.xml tests/Unit/Services/CostAllocationServiceTest.php`
+Expected: FAIL on new tests (current behavior allows runtime/generic exception path).
+
+- [ ] **Step 3: Implement denominator guards in service**
+
+```php
+// Insert into existing allocate() method - relies on $count, $requestTenantId, $requestSourcePoolId
+case 'proportional':
+    $weights = $options['weights'] ?? array_fill(0, $count, 1);
+    $totalWeight = (float) array_sum($weights);
+
+    if ($totalWeight <= 0.0) {
+        throw CostAllocationException::allocationFailed(
+            $requestTenantId,
+            $requestSourcePoolId,
+            'Invalid allocation weights: total weight must be greater than zero'
+        );
+    }
+```
+
+```php
+// Insert into existing allocate() method - relies on $method, $requestTenantId, $requestSourcePoolId
+default:
+    throw CostAllocationException::allocationFailed(
+        $requestTenantId,
+        $requestSourcePoolId,
+        sprintf('Unknown allocation method: %s', $method)
+    );
+```
+
+Implementation note:
+- Prefer passing `tenantId` and `sourceCostPoolId` into `calculateAllocations(...)` so inline domain throws preserve context.
+- Keep existing output shape and rounding unchanged.
+
+- [ ] **Step 4: Re-run focused tests for cost allocation service**
+
+Run: `./vendor/bin/phpunit -c phpunit.xml tests/Unit/Services/CostAllocationServiceTest.php`
+Expected: PASS for new and existing tests in this file.
+
+- [ ] **Step 5: Commit Task 1 changes**
+
+```bash
+git add orchestrators/FinanceOperations/src/Services/CostAllocationService.php \
+  orchestrators/FinanceOperations/tests/Unit/Services/CostAllocationServiceTest.php
+git commit -m "hardening: guard cost allocation division denominators"
+```
+
+### Task 2: Harden Depreciation denominator paths
+
+**Files:**
+- Modify: `orchestrators/FinanceOperations/src/Services/DepreciationRunService.php`
+- Test: `orchestrators/FinanceOperations/tests/Unit/Services/DepreciationRunServiceTest.php`
+
+- [ ] **Step 1: Write failing depreciation denominator tests**
+
+```php
+public function testExecuteRunFailsWhenUsefulLifeMonthsIsZero(): void
+{
+    $assetData = [[
+        'asset_id' => 'asset-001',
+        'book_value' => 1000,
+        'original_cost' => 1000,
+        'salvage_value' => 100,
+        'accumulated_depreciation' => 0,
+        'useful_life_months' => 0,
+        'depreciation_method' => 'straight_line',
+    ]];
+
+    $this->dataProviderMock->method('getAssetBookValues')->willReturn(['assets' => $assetData]);
+
+    $this->expectException(DepreciationCoordinationException::class);
+    $this->service->executeRun(new DepreciationRunRequest('tenant-001', '2026-01', ['asset-001']));
+}
+
+public function testGenerateScheduleFailsWhenUsefulLifeYearsIsZero(): void
+{
+    $request = new DepreciationScheduleRequest(
+        tenantId: 'tenant-001',
+        assetId: 'asset-001',
+        depreciationMethod: 'straight_line',
+        usefulLifeYears: 0,
+        salvageValue: '100'
+    );
+
+    $this->expectException(DepreciationCoordinationException::class);
+    $this->service->generateSchedule($request);
+}
+```
+
+- [ ] **Step 2: Run focused depreciation test file and confirm failures**
+
+Run: `./vendor/bin/phpunit -c phpunit.xml tests/Unit/Services/DepreciationRunServiceTest.php`
+Expected: FAIL on new denominator safety tests.
+
+- [ ] **Step 3: Add denominator guards and domain exception mapping**
+
+```php
+if ($usefulLifeMonths <= 0) {
+    throw DepreciationCoordinationException::runFailed(
+        $tenantId,
+        $periodId,
+        'Invalid useful life months: must be greater than zero'
+    );
+}
+```
+
+```php
+$years = (int) ($usefulLifeMonths / 12);
+if ($years <= 0) {
+    throw DepreciationCoordinationException::runFailed(
+        $tenantId,
+        $periodId,
+        'Invalid sum-of-years depreciation input: derived years must be greater than zero'
+    );
+}
+```
+
+```php
+if ($request->usefulLifeYears <= 0) {
+    throw DepreciationCoordinationException::scheduleGenerationFailed(
+        $request->tenantId,
+        $request->assetId,
+        'Invalid useful life years: must be greater than zero'
+    );
+}
+```
+
+Implementation note:
+- Prefer threading `tenantId`/`periodId` into internal calc method to preserve domain exception context.
+- Keep valid formula behavior unchanged.
+
+- [ ] **Step 4: Re-run focused depreciation tests**
+
+Run: `./vendor/bin/phpunit -c phpunit.xml tests/Unit/Services/DepreciationRunServiceTest.php`
+Expected: PASS for denominator-guard tests and existing relevant tests.
+
+- [ ] **Step 5: Commit Task 2 changes**
+
+```bash
+git add orchestrators/FinanceOperations/src/Services/DepreciationRunService.php \
+  orchestrators/FinanceOperations/tests/Unit/Services/DepreciationRunServiceTest.php
+git commit -m "hardening: guard depreciation division denominators"
+```
+
+### Task 3: Documentation and summary sync
+
+**Files:**
+- Modify: `orchestrators/FinanceOperations/IMPLEMENTATION_SUMMARY.md`
+
+- [ ] **Step 1: Add entry for division-safety hardening**
+
+```markdown
+## 2026-04-10 Division-Safety Hardening
+- Added explicit denominator guards in cost allocation and depreciation arithmetic paths.
+- Invalid denominator states now throw domain exceptions (`CostAllocationException`, `DepreciationCoordinationException`).
+- Added regression tests for zero/invalid denominator inputs.
+```
+
+- [ ] **Step 2: Verify summary references match actual changed files**
+
+Run: `rg -n "Division-Safety Hardening|denominator guards" orchestrators/FinanceOperations/IMPLEMENTATION_SUMMARY.md`
+Expected: New section found once with correct date and scope.
+
+- [ ] **Step 3: Commit summary update**
+
+```bash
+git add orchestrators/FinanceOperations/IMPLEMENTATION_SUMMARY.md
+git commit -m "docs: record finance operations division-safety hardening"
+```
+
+### Task 4: Final verification gate
+
+**Files:**
+- Verify only (no new file): `orchestrators/FinanceOperations/src/Services/*.php`
+- Verify only (no new file): `orchestrators/FinanceOperations/tests/Unit/Services/*.php`
+
+- [ ] **Step 1: Run focused service test files**
+
+Run in order:
+1. `./vendor/bin/phpunit -c phpunit.xml tests/Unit/Services/CostAllocationServiceTest.php`
+2. `./vendor/bin/phpunit -c phpunit.xml tests/Unit/Services/DepreciationRunServiceTest.php`
+
+Expected: PASS for both focused suites.
+
+- [ ] **Step 2: Run targeted static analysis on touched services**
+
+Run: `./vendor/bin/phpstan analyse src/Services/CostAllocationService.php src/Services/DepreciationRunService.php --level=max`
+Expected: ` [OK] No errors ` for touched files.
+
+- [ ] **Step 3: Capture verification evidence in final PR description**
+
+```markdown
+Verification:
+- phpunit (CostAllocationServiceTest): PASS
+- phpunit (DepreciationRunServiceTest): PASS
+- phpstan (touched services): PASS
+```
+
+- [ ] **Step 4: Create final integration commit (if squashing in branch workflow)**
+
+```bash
+git add -A
+git commit -m "hardening: finance operations division-safety pass"
+```
+
+## Plan Self-Review
+- Spec coverage: all scoped arithmetic hotspots are mapped to tasks.
+- Placeholder scan: no TODO/TBD placeholders remain.
+- Type consistency: exception classes and target file paths are consistent with spec.
+- Scope check: single subsystem (`FinanceOperations` arithmetic hardening) and independently shippable.
+
+## Execution Handoff
+Plan complete and saved to `docs/superpowers/plans/2026-04-10-finance-operations-division-safety-pass-implementation-plan.md`. Two execution options:
+
+1. Subagent-Driven (recommended) - I dispatch a fresh subagent per task, review between tasks, fast iteration
+2. Inline Execution - Execute tasks in this session using executing-plans, batch execution with checkpoints
+
+Which approach?

--- a/docs/superpowers/specs/2026-04-10-finance-operations-division-safety-pass-design.md
+++ b/docs/superpowers/specs/2026-04-10-finance-operations-division-safety-pass-design.md
@@ -1,0 +1,136 @@
+# FinanceOperations Division-Safety Pass Design
+
+## Context
+`orchestrators/FinanceOperations` contains multiple arithmetic paths where denominators can reach `0` (or invalid values) and cause runtime failures or undefined financial output. This violates the project hardening rule that all division operations must be guarded.
+
+Current hotspots include:
+- `Services/CostAllocationService::calculateAllocations` (`$count`, `$totalWeight`, `$totalAmount` usage)
+- `Services/DepreciationRunService::calculateDepreciation` (`$usefulLifeMonths`, `$years`, sum-of-years denominator)
+- `Services/DepreciationRunService::calculateSchedulePeriods` (`$usefulLifeYears`)
+
+## Problem Statement
+Financial orchestration logic currently assumes valid positive denominator inputs in several places. If adapters or callers pass unexpected values (e.g., empty targets, zero weights, useful life `0` or `< 12` months in sum-of-years mode), the package can fail with generic runtime errors instead of deterministic domain exceptions.
+
+## Goals
+1. Enforce explicit denominator guards for all production division sites in the identified arithmetic paths.
+2. Replace implicit runtime failures with domain-specific exceptions carrying stable, actionable messages.
+3. Add regression tests that prove failure behavior for invalid denominator conditions and successful behavior for valid inputs.
+4. Keep this pass narrowly scoped to arithmetic safety only (no architecture refactor in this slice).
+
+## Non-Goals
+- Reworking duplicate DTO namespace structure in this package.
+- Replacing remaining `object`-typed dependencies in rules/providers.
+- Monetary precision overhaul (float -> decimal VO conversion).
+- Broad contract normalization across all package tests.
+
+## Brainstormed Approaches
+
+### Approach A: Minimal inline guards at each division site
+Add direct `if` checks immediately before divisions and throw domain exceptions.
+
+Pros:
+- Fastest to deliver.
+- Very low blast radius.
+- Easy test targeting.
+
+Cons:
+- Guard logic may be repeated across methods.
+
+### Approach B: Centralized denominator guard helper methods inside each service
+Introduce internal private helpers (e.g., `assertPositiveIntDenominator`, `assertPositiveFloatDenominator`) and use them before each division.
+
+Pros:
+- Consistent behavior/messages.
+- Easier future extension and auditability.
+
+Cons:
+- Slightly larger refactor than pure inline checks.
+
+### Approach C: Input validation only at DTO constructors
+Constrain values during DTO construction so divisions never receive invalid denominators.
+
+Pros:
+- Strong early contract boundaries.
+
+Cons:
+- Not sufficient alone because denominators also derive from runtime data (`weights`, derived years, data-provider payloads).
+- Larger compatibility impact to callers/tests.
+
+## Recommended Approach
+Use **Approach B** now: add focused service-local guard helpers and call them at every denominator use in `CostAllocationService` and `DepreciationRunService`.
+
+This provides consistent, testable hardening with low risk and avoids introducing broader contract changes.
+
+## Detailed Design
+
+### 1. CostAllocationService hardening
+#### Target file
+`orchestrators/FinanceOperations/src/Services/CostAllocationService.php`
+
+#### Changes
+- Guard `equal` method denominator:
+  - Ensure `count($targetCostCenterIds) > 0` before `100 / $count` and `$totalAmount / $count`.
+  - `targetCount` is the cached caller-level value derived from `count($targetCostCenterIds)`. Keep the early `targetCount === 0` short-circuit for performance, but do not rely on it as the only validation.
+  - `calculateAllocations` must still re-validate `count($targetCostCenterIds) > 0` and throw `CostAllocationException::allocationFailed(...)` (for example: `Cannot allocate to zero cost centers`) before any division as defense-in-depth.
+- Guard `proportional` method denominator:
+  - Ensure `array_sum($weights) > 0` before percentage/amount math.
+  - Throw `CostAllocationException::allocationFailed(...)` with reason like `Invalid allocation weights: total weight must be > 0`.
+- Guard `manual` method percentage denominator:
+  - Keep the existing ternary guard `($totalAmount > 0 ? ($amount / $totalAmount) * 100 : 0)`, which explicitly short-circuits division when `$totalAmount` is zero.
+- Convert current `\InvalidArgumentException` usage for bad method/options into `CostAllocationException::allocationFailed(...)` to keep domain exception contract at service boundary.
+
+### 2. DepreciationRunService hardening
+#### Target file
+`orchestrators/FinanceOperations/src/Services/DepreciationRunService.php`
+
+#### Changes
+- In `calculateDepreciation`:
+  - Validate `$usefulLifeMonths > 0` before any division (straight-line and declining-balance branches).
+  - In `sum_of_years`, validate:
+    - `$years > 0` (derived from months),
+    - `$sumOfYears > 0`,
+    - the computed denominator `($depreciableAmount / $years)` is non-zero before it is used as a denominator to compute `$currentYear`.
+  - On invalid denominator conditions, throw `DepreciationCoordinationException::runFailed(...)` with clear, stable reason messages.
+- In `calculateSchedulePeriods`:
+  - Validate `$usefulLifeYears > 0` before annual and monthly division.
+  - Throw `DepreciationCoordinationException::scheduleGenerationFailed(...)` for invalid life values.
+
+### 3. Exception and message policy
+- Use existing domain exceptions only:
+  - `CostAllocationException`
+  - `DepreciationCoordinationException`
+- Messages must be stable and non-sensitive.
+- Include key identifiers (`tenantId`, `periodId`, `assetId`, `sourceCostPoolId`) in exception factory parameters where supported.
+
+### 4. Tests
+#### Target tests
+- `orchestrators/FinanceOperations/tests/Unit/Services/CostAllocationServiceTest.php`
+- `orchestrators/FinanceOperations/tests/Unit/Services/DepreciationRunServiceTest.php`
+
+#### New test cases
+- Cost allocation:
+  - proportional weights sum to zero -> throws `CostAllocationException`.
+  - invalid allocation method -> throws `CostAllocationException` (not generic `InvalidArgumentException`).
+- Depreciation:
+  - useful life months set to `0` -> run fails with `DepreciationCoordinationException`.
+  - sum-of-years path with derived years `0` (e.g., months `< 12`) -> run fails with `DepreciationCoordinationException`.
+  - schedule request with useful life years `0` -> schedule generation fails with `DepreciationCoordinationException`.
+
+## Risks and Mitigations
+- Risk: Existing tests currently have broad red baseline unrelated to this slice.
+  - Mitigation: run focused service tests for touched classes as verification gate.
+- Risk: tighter exception contracts may require minor test expectation updates.
+  - Mitigation: update only tests directly tied to touched behavior.
+
+## Verification Strategy
+- Focused unit tests:
+  - `./vendor/bin/phpunit -c phpunit.xml tests/Unit/Services/CostAllocationServiceTest.php`
+  - `./vendor/bin/phpunit -c phpunit.xml tests/Unit/Services/DepreciationRunServiceTest.php`
+- Optional static check for touched files:
+  - `./vendor/bin/phpstan analyse src/Services/CostAllocationService.php src/Services/DepreciationRunService.php --level=max`
+
+## Acceptance Criteria
+- No remaining unguarded denominator in the scoped arithmetic sites.
+- Invalid denominator scenarios throw domain exceptions, never PHP warnings/errors.
+- New tests cover denominator guard failures and pass in focused runs.
+- Existing happy-path behavior remains unchanged for valid inputs.

--- a/orchestrators/FinanceOperations/IMPLEMENTATION_SUMMARY.md
+++ b/orchestrators/FinanceOperations/IMPLEMENTATION_SUMMARY.md
@@ -1,0 +1,7 @@
+# FinanceOperations Implementation Summary
+
+## 2026-04-10 Division-Safety Hardening
+- Added denominator guards in cost allocation arithmetic paths to prevent division-by-zero and invalid-weight calculations.
+- Added denominator guards in depreciation run and schedule calculations to prevent invalid lifecycle divisors.
+- Mapped invalid denominator states to domain exceptions (`CostAllocationException`, `DepreciationCoordinationException`) with stable failure reasons.
+- Added regression tests for zero/invalid denominator scenarios in service-level unit suites.

--- a/orchestrators/FinanceOperations/src/Services/CostAllocationService.php
+++ b/orchestrators/FinanceOperations/src/Services/CostAllocationService.php
@@ -8,6 +8,7 @@ use Nexus\FinanceOperations\DTOs\CostAllocation\CostAllocationRequest;
 use Nexus\FinanceOperations\DTOs\CostAllocation\CostAllocationResult;
 use Nexus\FinanceOperations\DTOs\CostAllocation\ProductCostRequest;
 use Nexus\FinanceOperations\DTOs\CostAllocation\ProductCostResult;
+use Nexus\FinanceOperations\Enums\AllocationMethod;
 use Nexus\FinanceOperations\Exceptions\CostAllocationException;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
@@ -44,7 +45,7 @@ final readonly class CostAllocationService
         $this->logger->info('Processing cost allocation', [
             'tenant_id' => $request->tenantId,
             'source_pool_id' => $request->sourceCostPoolId,
-            'method' => $request->allocationMethod,
+            'method' => $request->allocationMethod->value,
         ]);
 
         try {
@@ -67,6 +68,8 @@ final readonly class CostAllocationService
 
             // Calculate allocations based on method
             $allocations = $this->calculateAllocations(
+                $request->tenantId,
+                $request->sourceCostPoolId,
                 $totalAmount,
                 $request->targetCostCenterIds,
                 $request->allocationMethod,
@@ -192,23 +195,36 @@ final readonly class CostAllocationService
     /**
      * Calculate allocations based on method.
      *
+     * @param string $tenantId Tenant identifier for error reporting
+     * @param string $sourceCostPoolId Source cost pool identifier for error reporting
      * @param float $totalAmount Total amount to allocate
      * @param array<string> $targetCostCenterIds Target cost center IDs
-     * @param string $method Allocation method ('equal', 'proportional', 'manual')
+     * @param AllocationMethod|string $method Allocation method enum or raw method value
      * @param array<string, mixed> $options Additional allocation options
      * @return array<int, array{costCenterId: string, amount: string, percentage: float}> Allocation breakdown
-     * @throws \InvalidArgumentException If unknown allocation method
+     * @throws CostAllocationException If allocation validation fails
      */
     private function calculateAllocations(
+        string $tenantId,
+        string $sourceCostPoolId,
         float $totalAmount,
         array $targetCostCenterIds,
-        string $method,
+        AllocationMethod|string $method,
         array $options
     ): array {
         $allocations = [];
         $count = count($targetCostCenterIds);
+        $methodValue = $method instanceof AllocationMethod ? $method->value : $method;
 
-        switch ($method) {
+        if ($count === 0) {
+            throw CostAllocationException::allocationFailed(
+                $tenantId,
+                $sourceCostPoolId,
+                'No target cost centers specified'
+            );
+        }
+
+        switch ($methodValue) {
             case 'equal':
                 $perCenter = $totalAmount / $count;
                 foreach ($targetCostCenterIds as $costCenterId) {
@@ -224,6 +240,14 @@ final readonly class CostAllocationService
                 // Use provided weights or equal distribution
                 $weights = $options['weights'] ?? array_fill(0, $count, 1);
                 $totalWeight = (float)array_sum($weights);
+
+                if ($totalWeight <= 0.0) {
+                    throw CostAllocationException::allocationFailed(
+                        $tenantId,
+                        $sourceCostPoolId,
+                        'Total allocation weight must be greater than zero'
+                    );
+                }
                 
                 foreach ($targetCostCenterIds as $index => $costCenterId) {
                     $weight = (float)($weights[$index] ?? 1);
@@ -242,7 +266,11 @@ final readonly class CostAllocationService
                 // Manual allocations must be provided in options
                 $manualAllocations = $options['allocations'] ?? [];
                 if (empty($manualAllocations)) {
-                    throw new \InvalidArgumentException('Manual allocation requires allocations in options');
+                    throw CostAllocationException::allocationFailed(
+                        $tenantId,
+                        $sourceCostPoolId,
+                        'Manual allocation requires allocations in options'
+                    );
                 }
                 
                 foreach ($targetCostCenterIds as $index => $costCenterId) {
@@ -258,7 +286,11 @@ final readonly class CostAllocationService
                 break;
 
             default:
-                throw new \InvalidArgumentException("Unknown allocation method: {$method}");
+                throw CostAllocationException::invalidAllocationMethod(
+                    $tenantId,
+                    $methodValue,
+                    ['equal', 'proportional', 'manual']
+                );
         }
 
         return $allocations;

--- a/orchestrators/FinanceOperations/src/Services/DepreciationRunService.php
+++ b/orchestrators/FinanceOperations/src/Services/DepreciationRunService.php
@@ -80,7 +80,11 @@ final readonly class DepreciationRunService
             $journalEntries = [];
 
             foreach ($bookValues as $assetData) {
-                $depreciation = $this->calculateDepreciation($assetData);
+                $depreciation = $this->calculateDepreciation(
+                    $request->tenantId,
+                    $request->periodId,
+                    $assetData
+                );
 
                 if ($depreciation > 0) {
                     $totalDepreciation += $depreciation;
@@ -199,7 +203,7 @@ final readonly class DepreciationRunService
      * @param array<string, mixed> $assetData Asset data including book values
      * @return float Calculated depreciation amount
      */
-    private function calculateDepreciation(array $assetData): float
+    private function calculateDepreciation(string $tenantId, string $periodId, array $assetData): float
     {
         $bookValue = (float)($assetData['book_value'] ?? $assetData['net_book_value'] ?? 0);
         $accumulatedDepreciation = (float)($assetData['accumulated_depreciation'] ?? 0);
@@ -220,6 +224,14 @@ final readonly class DepreciationRunService
             return 0.0;
         }
 
+        if ($usefulLifeMonths <= 0) {
+            throw DepreciationCoordinationException::runFailed(
+                $tenantId,
+                $periodId,
+                'Useful life months must be greater than 0'
+            );
+        }
+
         switch ($method) {
             case 'straight_line':
                 // Monthly depreciation
@@ -233,8 +245,33 @@ final readonly class DepreciationRunService
 
             case 'sum_of_years':
                 $years = (int)($usefulLifeMonths / 12);
+                if ($years <= 0) {
+                    throw DepreciationCoordinationException::runFailed(
+                        $tenantId,
+                        $periodId,
+                        'Sum-of-years depreciation requires useful life years greater than 0'
+                    );
+                }
+
                 $sumOfYears = ($years * ($years + 1)) / 2;
-                $currentYear = (int)(($accumulatedDepreciation / ($depreciableAmount / $years)) + 1);
+                if ($sumOfYears <= 0) {
+                    throw DepreciationCoordinationException::runFailed(
+                        $tenantId,
+                        $periodId,
+                        'Sum-of-years depreciation requires a positive sum-of-years denominator'
+                    );
+                }
+
+                $depreciationBase = $depreciableAmount / $years;
+                if ($depreciationBase == 0.0) {
+                    throw DepreciationCoordinationException::runFailed(
+                        $tenantId,
+                        $periodId,
+                        'Sum-of-years depreciation requires a non-zero depreciation base'
+                    );
+                }
+
+                $currentYear = (int)(($accumulatedDepreciation / $depreciationBase) + 1);
                 $yearDepreciation = ($depreciableAmount * ($years - $currentYear + 1)) / $sumOfYears;
                 return min($yearDepreciation / 12, $remainingAmount);
 
@@ -275,6 +312,14 @@ final readonly class DepreciationRunService
             $originalCost = $salvageValue * 2;
         }
         
+        if ($usefulLifeYears <= 0) {
+            throw DepreciationCoordinationException::scheduleGenerationFailed(
+                $request->tenantId,
+                $request->assetId,
+                'Useful life years must be greater than 0'
+            );
+        }
+
         $depreciableAmount = $originalCost - $salvageValue;
         $annualDepreciation = $depreciableAmount / $usefulLifeYears;
         $monthlyDepreciation = $annualDepreciation / 12;

--- a/orchestrators/FinanceOperations/src/Services/DepreciationRunService.php
+++ b/orchestrators/FinanceOperations/src/Services/DepreciationRunService.php
@@ -263,7 +263,7 @@ final readonly class DepreciationRunService
                 }
 
                 $depreciationBase = $depreciableAmount / $years;
-                if ($depreciationBase == 0.0) {
+                if (abs($depreciationBase) < 1e-9) {
                     throw DepreciationCoordinationException::runFailed(
                         $tenantId,
                         $periodId,

--- a/orchestrators/FinanceOperations/tests/Unit/Services/CostAllocationServiceTest.php
+++ b/orchestrators/FinanceOperations/tests/Unit/Services/CostAllocationServiceTest.php
@@ -12,6 +12,7 @@ use Nexus\FinanceOperations\DTOs\CostAllocation\CostAllocationRequest;
 use Nexus\FinanceOperations\DTOs\CostAllocation\CostAllocationResult;
 use Nexus\FinanceOperations\DTOs\CostAllocation\ProductCostRequest;
 use Nexus\FinanceOperations\DTOs\CostAllocation\ProductCostResult;
+use Nexus\FinanceOperations\Enums\AllocationMethod;
 use Nexus\FinanceOperations\Exceptions\CostAllocationException;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
@@ -23,7 +24,7 @@ use Psr\Log\NullLogger;
  * - Equal allocation method across cost centers
  * - Proportional allocation with weights
  * - Manual allocation with provided amounts
- * - Invalid allocation method handling (throws \InvalidArgumentException)
+ * - Invalid allocation method handling (throws CostAllocationException)
  * - Product cost calculation with material/labor/overhead breakdown
  * - Empty target cost centers handling
  * - Error handling when data provider throws exceptions
@@ -108,7 +109,7 @@ final class CostAllocationServiceTest extends TestCase
             periodId: $periodId,
             sourceCostPoolId: $sourceCostPoolId,
             targetCostCenterIds: $targetCostCenterIds,
-            allocationMethod: 'equal',
+            allocationMethod: AllocationMethod::EQUAL,
         );
 
         // Act
@@ -165,7 +166,7 @@ final class CostAllocationServiceTest extends TestCase
             periodId: $periodId,
             sourceCostPoolId: $sourceCostPoolId,
             targetCostCenterIds: $targetCostCenterIds,
-            allocationMethod: 'proportional',
+            allocationMethod: AllocationMethod::PROPORTIONAL,
             options: ['weights' => $weights],
         );
 
@@ -184,6 +185,46 @@ final class CostAllocationServiceTest extends TestCase
         // cc-002 should get 25% (250)
         $this->assertEquals('250', $result->allocations[1]['amount']);
         $this->assertEquals(25.0, $result->allocations[1]['percentage']);
+    }
+
+    /**
+     * Test proportional allocation with zero total weight throws CostAllocationException.
+     */
+    public function testAllocateWithProportionalMethodThrowsExceptionWhenTotalWeightIsZero(): void
+    {
+        // Arrange
+        $tenantId = 'tenant-001';
+        $periodId = '2026-01';
+        $sourceCostPoolId = 'pool-001';
+        $targetCostCenterIds = ['cc-001', 'cc-002'];
+
+        $weights = [0, 0];
+
+        $poolData = [
+            'total_amount' => '1000.00',
+            'pool_name' => 'Test Pool',
+        ];
+
+        $this->dataProviderMock
+            ->expects($this->once())
+            ->method('getCostPoolSummary')
+            ->with($tenantId, $sourceCostPoolId)
+            ->willReturn($poolData);
+
+        $request = new CostAllocationRequest(
+            tenantId: $tenantId,
+            periodId: $periodId,
+            sourceCostPoolId: $sourceCostPoolId,
+            targetCostCenterIds: $targetCostCenterIds,
+            allocationMethod: AllocationMethod::PROPORTIONAL,
+            options: ['weights' => $weights],
+        );
+
+        // Act & Assert
+        $this->expectException(CostAllocationException::class);
+        $this->expectExceptionMessage('Total allocation weight must be greater than zero');
+
+        $this->service->allocate($request);
     }
 
     /**
@@ -213,7 +254,7 @@ final class CostAllocationServiceTest extends TestCase
             periodId: $periodId,
             sourceCostPoolId: $sourceCostPoolId,
             targetCostCenterIds: $targetCostCenterIds,
-            allocationMethod: 'proportional',
+            allocationMethod: AllocationMethod::PROPORTIONAL,
         );
 
         // Act
@@ -259,7 +300,7 @@ final class CostAllocationServiceTest extends TestCase
             periodId: $periodId,
             sourceCostPoolId: $sourceCostPoolId,
             targetCostCenterIds: $targetCostCenterIds,
-            allocationMethod: 'manual',
+            allocationMethod: AllocationMethod::MANUAL,
             options: ['allocations' => $manualAllocations],
         );
 
@@ -301,7 +342,7 @@ final class CostAllocationServiceTest extends TestCase
             periodId: $periodId,
             sourceCostPoolId: $sourceCostPoolId,
             targetCostCenterIds: $targetCostCenterIds,
-            allocationMethod: 'manual',
+            allocationMethod: AllocationMethod::MANUAL,
             options: [], // Empty options - no allocations provided
         );
 
@@ -319,38 +360,29 @@ final class CostAllocationServiceTest extends TestCase
     /**
      * Test invalid allocation method throws CostAllocationException.
      */
-    public function testAllocateWithInvalidMethodThrowsInvalidArgumentException(): void
+    public function testAllocateWithInvalidMethodThrowsCostAllocationException(): void
     {
         // Arrange
         $tenantId = 'tenant-001';
-        $periodId = '2026-01';
         $sourceCostPoolId = 'pool-001';
         $targetCostCenterIds = ['cc-001', 'cc-002'];
-        
-        $poolData = [
-            'total_amount' => '1000.00',
-            'pool_name' => 'Test Pool',
-        ];
 
-        $this->dataProviderMock
-            ->expects($this->once())
-            ->method('getCostPoolSummary')
-            ->with($tenantId, $sourceCostPoolId)
-            ->willReturn($poolData);
-
-        $request = new CostAllocationRequest(
-            tenantId: $tenantId,
-            periodId: $periodId,
-            sourceCostPoolId: $sourceCostPoolId,
-            targetCostCenterIds: $targetCostCenterIds,
-            allocationMethod: 'invalid_method',
-        );
+        $method = new \ReflectionMethod($this->service, 'calculateAllocations');
+        $method->setAccessible(true);
 
         // Act & Assert
         $this->expectException(CostAllocationException::class);
-        $this->expectExceptionMessage('Unknown allocation method: invalid_method');
-        
-        $this->service->allocate($request);
+        $this->expectExceptionMessage('Invalid allocation method "invalid_method". Valid methods: equal, proportional, manual');
+
+        $method->invoke(
+            $this->service,
+            $tenantId,
+            $sourceCostPoolId,
+            1000.0,
+            $targetCostCenterIds,
+            'invalid_method',
+            []
+        );
     }
 
     // =========================================================================
@@ -383,7 +415,7 @@ final class CostAllocationServiceTest extends TestCase
             periodId: $periodId,
             sourceCostPoolId: $sourceCostPoolId,
             targetCostCenterIds: [], // Empty!
-            allocationMethod: 'equal',
+            allocationMethod: AllocationMethod::EQUAL,
         );
 
         // Act & Assert
@@ -430,7 +462,7 @@ final class CostAllocationServiceTest extends TestCase
             periodId: $periodId,
             sourceCostPoolId: $sourceCostPoolId,
             targetCostCenterIds: $targetCostCenterIds,
-            allocationMethod: 'equal',
+            allocationMethod: AllocationMethod::EQUAL,
         );
 
         // Act & Assert
@@ -691,7 +723,7 @@ final class CostAllocationServiceTest extends TestCase
             periodId: $periodId,
             sourceCostPoolId: $sourceCostPoolId,
             targetCostCenterIds: $targetCostCenterIds,
-            allocationMethod: 'equal',
+            allocationMethod: AllocationMethod::EQUAL,
         );
 
         // Act
@@ -730,7 +762,7 @@ final class CostAllocationServiceTest extends TestCase
             periodId: $periodId,
             sourceCostPoolId: $sourceCostPoolId,
             targetCostCenterIds: $targetCostCenterIds,
-            allocationMethod: 'equal',
+            allocationMethod: AllocationMethod::EQUAL,
         );
 
         // Act
@@ -773,7 +805,7 @@ final class CostAllocationServiceTest extends TestCase
             periodId: $periodId,
             sourceCostPoolId: $sourceCostPoolId,
             targetCostCenterIds: $targetCostCenterIds,
-            allocationMethod: 'proportional',
+            allocationMethod: AllocationMethod::PROPORTIONAL,
             options: ['weights' => $weights],
         );
 
@@ -822,7 +854,7 @@ final class CostAllocationServiceTest extends TestCase
             periodId: $periodId,
             sourceCostPoolId: $sourceCostPoolId,
             targetCostCenterIds: $targetCostCenterIds,
-            allocationMethod: 'manual',
+            allocationMethod: AllocationMethod::MANUAL,
             options: ['allocations' => $manualAllocations],
         );
 
@@ -903,7 +935,7 @@ final class CostAllocationServiceTest extends TestCase
             periodId: $periodId,
             sourceCostPoolId: $sourceCostPoolId,
             targetCostCenterIds: $targetCostCenterIds,
-            allocationMethod: 'equal',
+            allocationMethod: AllocationMethod::EQUAL,
         );
 
         // Act
@@ -947,7 +979,7 @@ final class CostAllocationServiceTest extends TestCase
             periodId: $periodId,
             sourceCostPoolId: $sourceCostPoolId,
             targetCostCenterIds: $targetCostCenterIds,
-            allocationMethod: 'equal',
+            allocationMethod: AllocationMethod::EQUAL,
         );
 
         // Act
@@ -982,7 +1014,7 @@ final class CostAllocationServiceTest extends TestCase
             periodId: $periodId,
             sourceCostPoolId: $sourceCostPoolId,
             targetCostCenterIds: $targetCostCenterIds,
-            allocationMethod: 'equal',
+            allocationMethod: AllocationMethod::EQUAL,
         );
 
         // Act
@@ -1066,7 +1098,7 @@ final class CostAllocationServiceTest extends TestCase
             periodId: $periodId,
             sourceCostPoolId: $sourceCostPoolId,
             targetCostCenterIds: $targetCostCenterIds,
-            allocationMethod: 'equal',
+            allocationMethod: AllocationMethod::EQUAL,
         );
 
         // Act

--- a/orchestrators/FinanceOperations/tests/Unit/Services/DepreciationRunServiceTest.php
+++ b/orchestrators/FinanceOperations/tests/Unit/Services/DepreciationRunServiceTest.php
@@ -240,6 +240,98 @@ final class DepreciationRunServiceTest extends TestCase
         $this->assertEquals(1, $result->assetsProcessed);
     }
 
+    /**
+     * Test useful_life_months=0 fails with a coordination exception.
+     */
+    public function testExecuteRunWithZeroUsefulLifeMonthsThrowsException(): void
+    {
+        // Arrange
+        $tenantId = 'tenant-001';
+        $periodId = '2026-01';
+
+        $assetData = [
+            [
+                'asset_id' => 'asset-zero-life',
+                'asset_code' => 'FA-ZERO',
+                'asset_name' => 'Zero Life Asset',
+                'book_value' => 50000.0,
+                'original_cost' => 60000.0,
+                'accumulated_depreciation' => 10000.0,
+                'salvage_value' => 5000.0,
+                'useful_life_months' => 0,
+                'depreciation_method' => 'straight_line',
+            ],
+        ];
+
+        $this->dataProviderMock
+            ->expects($this->once())
+            ->method('getAssetBookValues')
+            ->with($tenantId, ['asset-zero-life'])
+            ->willReturn(['assets' => $assetData]);
+
+        $request = new DepreciationRunRequest(
+            tenantId: $tenantId,
+            periodId: $periodId,
+            assetIds: ['asset-zero-life'],
+            postToGL: false,
+            validateOnly: false,
+        );
+
+        // Act & Assert
+        $this->expectException(DepreciationCoordinationException::class);
+        $this->expectExceptionMessage(
+            'Depreciation run failed for period 2026-01: Useful life months must be greater than 0'
+        );
+
+        $this->service->executeRun($request);
+    }
+
+    /**
+     * Test sum-of-years depreciation fails when useful life months resolve to zero years.
+     */
+    public function testExecuteRunWithSumOfYearsAndDerivedZeroYearsThrowsException(): void
+    {
+        // Arrange
+        $tenantId = 'tenant-001';
+        $periodId = '2026-01';
+
+        $assetData = [
+            [
+                'asset_id' => 'asset-short-life',
+                'asset_code' => 'FA-SHORT',
+                'asset_name' => 'Short Life Asset',
+                'book_value' => 50000.0,
+                'original_cost' => 60000.0,
+                'accumulated_depreciation' => 10000.0,
+                'salvage_value' => 5000.0,
+                'useful_life_months' => 11,
+                'depreciation_method' => 'sum_of_years',
+            ],
+        ];
+
+        $this->dataProviderMock
+            ->expects($this->once())
+            ->method('getAssetBookValues')
+            ->with($tenantId, ['asset-short-life'])
+            ->willReturn(['assets' => $assetData]);
+
+        $request = new DepreciationRunRequest(
+            tenantId: $tenantId,
+            periodId: $periodId,
+            assetIds: ['asset-short-life'],
+            postToGL: false,
+            validateOnly: false,
+        );
+
+        // Act & Assert
+        $this->expectException(DepreciationCoordinationException::class);
+        $this->expectExceptionMessage(
+            'Depreciation run failed for period 2026-01: Sum-of-years depreciation requires useful life years greater than 0'
+        );
+
+        $this->service->executeRun($request);
+    }
+
     // =========================================================================
     // Test Suite: executeRun() - Fully Depreciated Asset
     // =========================================================================
@@ -510,6 +602,38 @@ final class DepreciationRunServiceTest extends TestCase
         
         // Verify total depreciation is calculated
         $this->assertGreaterThan(0, (float)$result->totalDepreciation);
+    }
+
+    /**
+     * Test schedule generation fails when useful life years is zero.
+     */
+    public function testGenerateScheduleWithZeroUsefulLifeYearsThrowsException(): void
+    {
+        // Arrange
+        $tenantId = 'tenant-001';
+        $assetId = 'asset-zero-schedule';
+
+        $this->dataProviderMock
+            ->expects($this->once())
+            ->method('getDepreciationSchedules')
+            ->with($tenantId, $assetId)
+            ->willReturn(['schedules' => []]);
+
+        $request = new DepreciationScheduleRequest(
+            tenantId: $tenantId,
+            assetId: $assetId,
+            depreciationMethod: 'straight_line',
+            usefulLifeYears: 0,
+            salvageValue: '10000',
+        );
+
+        // Act & Assert
+        $this->expectException(DepreciationCoordinationException::class);
+        $this->expectExceptionMessage(
+            'Depreciation schedule generation failed for asset asset-zero-schedule: Useful life years must be greater than 0'
+        );
+
+        $this->service->generateSchedule($request);
     }
 
     // =========================================================================


### PR DESCRIPTION
## Summary
- Add denominator guards in CostAllocationService for proportional allocation weights
- Add denominator guards in DepreciationRunService for useful life divisors
- Map invalid denominator states to domain exceptions
- Add regression tests for zero/invalid denominator scenarios
- Update IMPLEMENTATION_SUMMARY.md

## Test Plan
- phpunit CostAllocationServiceTest: PASS
- phpunit DepreciationRunServiceTest: PASS