### PR TITLE
feat(gap-9): make live-mode fail loudly - close mock fallback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -334,3 +334,12 @@ After each resolved PR review comment, append a new entry below using this templ
 - **Root cause:** I optimized for resilient demo behavior without enforcing a strict separation between mock-only data paths and live-query error semantics, and I did not keep seed ID pools centrally aligned.
 - **Action taken:** Aligned `SEED_PROJECTS` IDs to the RFQ generator `01J...` pool; removed fabricated pending-approval counts; moved approvals seed usage into explicit mock branches; removed hidden seed fallback from RFQ overview live path; removed duplicate readiness/live refetch fallback; kept seed fallbacks only where explicitly required for mock mode (quote submissions, RFQ invitations); and cleaned related import/typing/test-format issues.
 - **Follow-up tasks:** Before future frontend merges, run a checklist for (1) mock-vs-live branch separation, (2) no synthetic fallback values in live hooks, (3) canonical seed ID reuse across generators/accessors, and (4) nullable hook return types reflected in consumers.
+
+---
+
+- **Date:** 2026-04-15
+- **PR/Issue ID:** WEB PR review follow-up (readiness/mock gating and seed pool completeness)
+- **Summary of mistake:** Comparison-run readiness handling treated mock-mode `fetchLiveOrFail` undefined as a hard error, seed projects still missed two IDs from the RFQ generator pool, and navigation child-record badges retained hardcoded placeholder counts.
+- **Root cause:** I applied fail-loud behavior without preserving an explicit mock-mode guard for readiness and did not re-check all project IDs or placeholder UI counts after the previous remediation pass.
+- **Action taken:** Added mock-mode query disabling in `use-comparison-run-readiness`, kept live-mode fail-loud behavior for undefined responses, added the two missing seed project IDs, removed unsupported hardcoded child-record badges in `active-record-menu`, and tightened implementation summary wording to explicitly document `use-comparison-run.ts` fetch-retry behavior across mock vs live mode.
+- **Follow-up tasks:** For future review closures, run a final matrix check across (1) mock-mode enabled behavior, (2) live-mode fail-loud behavior, (3) central seed ID pool completeness, and (4) removal or wiring of placeholder UI counters before declaring comments resolved.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -325,3 +325,12 @@ After each resolved PR review comment, append a new entry below using this templ
 - **Root cause:** I accepted earlier "working" behavior without re-checking contract boundaries and determinism assumptions against the latest reviewer concerns and current code paths.
 - **Action taken:** Threaded tenant context through `IdentityOperationsAdapter::mapUserToArray` into permission/role lookups, updated `AuthenticatorInterface` status typing to Layer-2-safe scalar docs, added explicit non-empty name validation in `EloquentPermissionRepository::create`, removed dead `findUserOrFail` from `EloquentUserRepository`, and hardened `TotpManagerTest` with fixed timestamps, mutated-invalid code assertions, and a boundary-sensitive custom-period check.
 - **Follow-up tasks:** For identity review closures, add a mandatory pass for (1) tenant context propagation in all adapter hydration paths, (2) Layer 2 contract isolation from Layer 1 types, and (3) deterministic time-based test vectors that can fail the wrong implementation.
+
+---
+
+- **Date:** 2026-04-15
+- **PR/Issue ID:** WEB PR review follow-up (seed/live fallback hygiene)
+- **Summary of mistake:** Several hooks mixed live-mode and mock-mode behaviors by silently falling back to seed data (or fabricated counts) when live responses were unavailable, while seed project IDs also diverged from the RFQ seed project ID pool.
+- **Root cause:** I optimized for resilient demo behavior without enforcing a strict separation between mock-only data paths and live-query error semantics, and I did not keep seed ID pools centrally aligned.
+- **Action taken:** Aligned `SEED_PROJECTS` IDs to the RFQ generator `01J...` pool; removed fabricated pending-approval counts; moved approvals seed usage into explicit mock branches; removed hidden seed fallback from RFQ overview live path; removed duplicate readiness/live refetch fallback; kept seed fallbacks only where explicitly required for mock mode (quote submissions, RFQ invitations); and cleaned related import/typing/test-format issues.
+- **Follow-up tasks:** Before future frontend merges, run a checklist for (1) mock-vs-live branch separation, (2) no synthetic fallback values in live hooks, (3) canonical seed ID reuse across generators/accessors, and (4) nullable hook return types reflected in consumers.

--- a/apps/atomy-q/WEB/IMPLEMENTATION_SUMMARY.md
+++ b/apps/atomy-q/WEB/IMPLEMENTATION_SUMMARY.md
@@ -36,3 +36,14 @@
 - Project ACL save flow now blocks empty ACL submissions both in button-disabled state and at click handler guard.
 - `use-update-project-acl` now validates mapped roles at runtime against canonical allowed roles and fails fast on invalid payloads.
 - Seed data now includes realistic enterprise RFQ presets (software renewal, SOC services, WAN upgrade, facilities maintenance, HRIS partner) in addition to generated lifecycle data.
+
+## 2026-04-15 PR Review Remediation
+- Aligned seeded project IDs with the RFQ generator project ID pool (`01J...`) so project-linked seed lookups no longer miss.
+- Removed duplicate `fetchLiveOrFail` import in `use-award.ts`.
+- Stopped fabricated approval pending-count values (`2`) and propagated unavailable live data as `undefined` instead.
+- Removed live-path seed fallbacks in approvals list/detail and RFQ overview hooks; seed logic now runs only in explicit mock mode.
+- Removed duplicate readiness fetch + mock fallback in `use-comparison-run-readiness.ts`; live unavailability now surfaces as an error.
+- Removed duplicate fetch retry in `use-comparison-run.ts`; undefined live responses now fall back directly to the mock builder.
+- Added seeded fallbacks for mock mode in quote submissions and RFQ invitations so normalizers always receive valid payloads.
+- Corrected `FetchResponseType` to use Axios-compatible `'arraybuffer'`.
+- Cleaned unused imports and fixed assertion indentation consistency in comparison run test files.

--- a/apps/atomy-q/WEB/IMPLEMENTATION_SUMMARY.md
+++ b/apps/atomy-q/WEB/IMPLEMENTATION_SUMMARY.md
@@ -38,12 +38,13 @@
 - Seed data now includes realistic enterprise RFQ presets (software renewal, SOC services, WAN upgrade, facilities maintenance, HRIS partner) in addition to generated lifecycle data.
 
 ## 2026-04-15 PR Review Remediation
+
 - Aligned seeded project IDs with the RFQ generator project ID pool (`01J...`) so project-linked seed lookups no longer miss.
 - Removed duplicate `fetchLiveOrFail` import in `use-award.ts`.
 - Stopped fabricated approval pending-count values (`2`) and propagated unavailable live data as `undefined` instead.
 - Removed live-path seed fallbacks in approvals list/detail and RFQ overview hooks; seed logic now runs only in explicit mock mode.
 - Removed duplicate readiness fetch + mock fallback in `use-comparison-run-readiness.ts`; live unavailability now surfaces as an error.
-- Removed duplicate fetch retry in `use-comparison-run.ts`; undefined live responses now fall back directly to the mock builder.
+- Removed duplicate fetch retry in `use-comparison-run.ts`; in mock mode undefined responses now fall back directly to the mock builder, while live mode keeps fail-loud behavior and does not fallback on undefined/error responses.
 - Added seeded fallbacks for mock mode in quote submissions and RFQ invitations so normalizers always receive valid payloads.
 - Corrected `FetchResponseType` to use Axios-compatible `'arraybuffer'`.
 - Cleaned unused imports and fixed assertion indentation consistency in comparison run test files.

--- a/apps/atomy-q/WEB/src/components/workspace/active-record-menu.tsx
+++ b/apps/atomy-q/WEB/src/components/workspace/active-record-menu.tsx
@@ -45,12 +45,12 @@ export function ActiveRecordMenu({ record }: { record: ActiveRfqRecord }) {
 
   const childLinks = [
     { id: 'quote-intake', label: 'Quote Intake', href: `${rfqBase}/quote-intake`, icon: <Inbox size={14} />, badge: record.quotesCount },
-    { id: 'comparison-runs', label: 'Comparison Runs', href: `${rfqBase}/comparison-runs`, icon: <GitCompareArrows size={14} />, badge: 3 },
+    { id: 'comparison-runs', label: 'Comparison Runs', href: `${rfqBase}/comparison-runs`, icon: <GitCompareArrows size={14} /> },
     { id: 'approvals', label: 'Approvals', href: `${rfqBase}/approvals`, icon: <ShieldCheck size={14} />, badge: approvalsBadge },
-    { id: 'negotiations', label: 'Negotiations', href: `${rfqBase}/negotiations`, icon: <HandCoins size={14} />, badge: 1 },
-    { id: 'documents', label: 'Documents', href: `${rfqBase}/documents`, icon: <FolderArchive size={14} />, badge: 12 },
+    { id: 'negotiations', label: 'Negotiations', href: `${rfqBase}/negotiations`, icon: <HandCoins size={14} /> },
+    { id: 'documents', label: 'Documents', href: `${rfqBase}/documents`, icon: <FolderArchive size={14} /> },
     { id: 'risk', label: 'Risk & Compliance', href: `${rfqBase}/risk`, icon: <ShieldAlert size={14} />, statusDot: 'green' as const },
-    { id: 'decision-trail', label: 'Decision Trail', href: `${rfqBase}/decision-trail`, icon: <List size={14} />, badge: 5 },
+    { id: 'decision-trail', label: 'Decision Trail', href: `${rfqBase}/decision-trail`, icon: <List size={14} /> },
   ];
 
   return (

--- a/apps/atomy-q/WEB/src/components/workspace/active-record-menu.tsx
+++ b/apps/atomy-q/WEB/src/components/workspace/active-record-menu.tsx
@@ -3,10 +3,10 @@
 import React from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { Eye, FileText, List, Users, Inbox, GitCompareArrows, ShieldCheck, HandCoins, FolderArchive, ShieldAlert, History, Award } from 'lucide-react';
+import { Eye, FileText, List, Users, Inbox, GitCompareArrows, ShieldCheck, HandCoins, FolderArchive, ShieldAlert, Award } from 'lucide-react';
 
 import { Button } from '@/components/ds/Button';
-import { CountBadge, StatusBadge, StatusDot } from '@/components/ds/Badge';
+import { StatusBadge } from '@/components/ds/Badge';
 import { NavigationLink } from '@/components/layout/sidebar';
 import { type RfqStatus } from '@/hooks/use-rfqs';
 import { useRfqPendingApprovalCount } from '@/hooks/use-approvals';
@@ -26,10 +26,8 @@ export interface ActiveRfqRecord {
 export function ActiveRecordMenu({ record }: { record: ActiveRfqRecord }) {
   const pathname = usePathname();
   const { data: pendingApprovalCount } = useRfqPendingApprovalCount(record.id);
-  const useMocks = process.env.NEXT_PUBLIC_USE_MOCKS === 'true';
-  const normalizedPending = useMocks
-    ? 2
-    : typeof pendingApprovalCount === 'number' && Number.isFinite(pendingApprovalCount)
+  const normalizedPending =
+    typeof pendingApprovalCount === 'number' && Number.isFinite(pendingApprovalCount)
       ? pendingApprovalCount
       : undefined;
   const approvalsBadge =
@@ -119,4 +117,3 @@ export function ActiveRecordMenu({ record }: { record: ActiveRfqRecord }) {
     </div>
   );
 }
-

--- a/apps/atomy-q/WEB/src/data/seed.ts
+++ b/apps/atomy-q/WEB/src/data/seed.ts
@@ -437,6 +437,50 @@ function buildSeed(): NonNullable<typeof cachedSeed> {
   return cachedSeed;
 }
 
+export interface SeedProject {
+  id: string;
+  name: string;
+  status: string;
+  clientId?: string;
+  clientName?: string;
+  startDate?: string;
+  endDate?: string;
+}
+
+const SEED_PROJECTS: SeedProject[] = [
+  {
+    id: 'proj-001',
+    name: 'Q2 Server Infrastructure Refresh',
+    status: 'active',
+    clientId: 'client-001',
+    clientName: 'Acme Corp',
+    startDate: '2024-04-01',
+    endDate: '2024-09-30',
+  },
+  {
+    id: 'proj-002',
+    name: 'Office Renovation 2024',
+    status: 'planning',
+    clientId: 'client-002',
+    clientName: 'TechStart Inc',
+    startDate: '2024-06-01',
+    endDate: '2024-12-31',
+  },
+  {
+    id: 'proj-003',
+    name: 'Cloud Migration Phase 2',
+    status: 'active',
+    clientId: 'client-001',
+    clientName: 'Acme Corp',
+    startDate: '2024-03-15',
+    endDate: '2024-08-15',
+  },
+];
+
+export function getSeedProjects(): SeedProject[] {
+  return SEED_PROJECTS;
+}
+
 export function getSeedRfqs(): SeedRfq[] {
   return buildSeed().rfqs;
 }

--- a/apps/atomy-q/WEB/src/data/seed.ts
+++ b/apps/atomy-q/WEB/src/data/seed.ts
@@ -449,7 +449,7 @@ export interface SeedProject {
 
 const SEED_PROJECTS: SeedProject[] = [
   {
-    id: 'proj-001',
+    id: '01JNE4ZHT9S0VQ7E2GQW1QYJ7B',
     name: 'Q2 Server Infrastructure Refresh',
     status: 'active',
     clientId: 'client-001',
@@ -458,7 +458,7 @@ const SEED_PROJECTS: SeedProject[] = [
     endDate: '2024-09-30',
   },
   {
-    id: 'proj-002',
+    id: '01JNE4ZHTA4H0W8S8P3H7C9X2M',
     name: 'Office Renovation 2024',
     status: 'planning',
     clientId: 'client-002',
@@ -467,7 +467,7 @@ const SEED_PROJECTS: SeedProject[] = [
     endDate: '2024-12-31',
   },
   {
-    id: 'proj-003',
+    id: '01JNE4ZHTB0RZ3W2F6N9J5K1Q8',
     name: 'Cloud Migration Phase 2',
     status: 'active',
     clientId: 'client-001',

--- a/apps/atomy-q/WEB/src/data/seed.ts
+++ b/apps/atomy-q/WEB/src/data/seed.ts
@@ -475,6 +475,24 @@ const SEED_PROJECTS: SeedProject[] = [
     startDate: '2024-03-15',
     endDate: '2024-08-15',
   },
+  {
+    id: '01JNE4ZHTC7D1P6M3T8V2R0L5N',
+    name: 'Regional Network Reliability Upgrade',
+    status: 'active',
+    clientId: 'client-003',
+    clientName: 'Northwind Logistics',
+    startDate: '2024-05-01',
+    endDate: '2024-11-30',
+  },
+  {
+    id: '01JNE4ZHTDNN6E9B4Y1S7U3P0C',
+    name: 'Enterprise Data Governance Rollout',
+    status: 'planning',
+    clientId: 'client-004',
+    clientName: 'Globex Holdings',
+    startDate: '2024-07-01',
+    endDate: '2025-01-31',
+  },
 ];
 
 export function getSeedProjects(): SeedProject[] {

--- a/apps/atomy-q/WEB/src/hooks/use-approvals.ts
+++ b/apps/atomy-q/WEB/src/hooks/use-approvals.ts
@@ -2,7 +2,6 @@
 
 import { useQuery } from '@tanstack/react-query';
 import { fetchLiveOrFail } from '@/lib/api-live';
-import { api } from '@/lib/api';
 
 export interface ApprovalsListMeta {
   current_page: number;

--- a/apps/atomy-q/WEB/src/hooks/use-approvals.ts
+++ b/apps/atomy-q/WEB/src/hooks/use-approvals.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { useQuery } from '@tanstack/react-query';
+import { fetchLiveOrFail } from '@/lib/api-live';
 import { api } from '@/lib/api';
 
 export interface ApprovalsListMeta {
@@ -117,8 +118,6 @@ export interface UseApprovalsParams {
 }
 
 export function useApprovalsList(params: UseApprovalsParams) {
-  const useMocks = process.env.NEXT_PUBLIC_USE_MOCKS === 'true';
-
   return useQuery({
     queryKey: ['approvals', 'list', {
       rfq_id: params.rfq_id ?? null,
@@ -128,56 +127,57 @@ export function useApprovalsList(params: UseApprovalsParams) {
     }],
     queryFn: async (): Promise<ApprovalsListResult> => {
       const page = Math.max(1, params.page ?? 1);
-      if (!useMocks) {
-        const { data } = await api.get('/approvals', {
-          params: {
-            rfq_id: params.rfq_id || undefined,
-            status: params.status || undefined,
-            type: params.type || undefined,
-            page,
-          },
-        });
-        const items = normalizeApprovalRows(data);
-        const meta = parseApprovalsMeta(data);
-        if (meta === null) {
-          throw new Error('Invalid approvals list response: pagination meta');
+      const data = await fetchLiveOrFail<{ data: ApprovalListRow[] }>('/approvals', {
+        params: {
+          rfq_id: params.rfq_id || undefined,
+          status: params.status || undefined,
+          type: params.type || undefined,
+          page,
+        },
+      });
+
+      if (data === undefined) {
+        const { getSeedPendingApprovals } = await import('@/data/seed');
+        const seed = getSeedPendingApprovals();
+        let rows: ApprovalListRow[] = seed.map((a) => ({
+          id: a.id,
+          rfq_id: a.rfqId,
+          rfq_title: a.summary,
+          type: a.type,
+          type_label: a.type,
+          status: 'pending',
+          priority: a.priority,
+          summary: a.summary,
+          sla: a.sla,
+          sla_variant: a.slaVariant,
+          assignee: a.assignee,
+          requested_at: null,
+        }));
+        if (params.rfq_id) {
+          rows = rows.filter((r) => r.rfq_id === params.rfq_id);
         }
-        return { items, meta };
+        if (params.type) {
+          rows = rows.filter((r) => r.type === params.type);
+        }
+        if (params.status && params.status !== 'pending') {
+          rows = [];
+        }
+        const perPage = 20;
+        const total = rows.length;
+        const totalPages = Math.max(1, Math.ceil(total / perPage));
+        const start = (page - 1) * perPage;
+        return {
+          items: rows.slice(start, start + perPage),
+          meta: { current_page: page, per_page: perPage, total, total_pages: totalPages },
+        };
       }
 
-      const { getSeedPendingApprovals } = await import('@/data/seed');
-      const seed = getSeedPendingApprovals();
-      let rows: ApprovalListRow[] = seed.map((a) => ({
-        id: a.id,
-        rfq_id: a.rfqId,
-        rfq_title: a.summary,
-        type: a.type,
-        type_label: a.type,
-        status: 'pending',
-        priority: a.priority,
-        summary: a.summary,
-        sla: a.sla,
-        sla_variant: a.slaVariant,
-        assignee: a.assignee,
-        requested_at: null,
-      }));
-      if (params.rfq_id) {
-        rows = rows.filter((r) => r.rfq_id === params.rfq_id);
+      const items = normalizeApprovalRows(data);
+      const meta = parseApprovalsMeta(data);
+      if (meta === null) {
+        throw new Error('Invalid approvals list response: pagination meta');
       }
-      if (params.type) {
-        rows = rows.filter((r) => r.type === params.type);
-      }
-      if (params.status && params.status !== 'pending') {
-        rows = [];
-      }
-      const perPage = 20;
-      const total = rows.length;
-      const totalPages = Math.max(1, Math.ceil(total / perPage));
-      const start = (page - 1) * perPage;
-      return {
-        items: rows.slice(start, start + perPage),
-        meta: { current_page: page, per_page: perPage, total, total_pages: totalPages },
-      };
+      return { items, meta };
     },
   });
 }
@@ -195,13 +195,14 @@ export interface ApprovalDetail extends ApprovalListRow {
 }
 
 export function useApprovalDetail(id: string | undefined) {
-  const useMocks = process.env.NEXT_PUBLIC_USE_MOCKS === 'true';
-
   return useQuery({
     queryKey: ['approvals', 'detail', id],
     queryFn: async (): Promise<ApprovalDetail> => {
       if (!id) throw new Error('Approval id required');
-      if (useMocks) {
+
+      const data = await fetchLiveOrFail<{ data: ApprovalDetail }>(`/approvals/${encodeURIComponent(id)}`);
+
+      if (data === undefined) {
         const { getSeedPendingApprovals } = await import('@/data/seed');
         const row = getSeedPendingApprovals().find((a) => a.id === id);
         if (!row) throw new Error('Not found');
@@ -220,7 +221,7 @@ export function useApprovalDetail(id: string | undefined) {
           comparison_run: null,
         };
       }
-      const { data } = await api.get<{ data?: Record<string, unknown> }>(`/approvals/${encodeURIComponent(id)}`);
+
       const r = data?.data;
       if (!r || typeof r !== 'object') throw new Error('Not found');
       const rec = r as Record<string, unknown>;
@@ -252,21 +253,23 @@ export function useApprovalDetail(id: string | undefined) {
 }
 
 export function useRfqPendingApprovalCount(rfqId: string | undefined) {
-  const useMocks = process.env.NEXT_PUBLIC_USE_MOCKS === 'true';
-
   return useQuery({
     queryKey: ['approvals', 'pending-count', rfqId],
     queryFn: async (): Promise<number> => {
-      const { data } = await api.get('/approvals', {
+      const data = await fetchLiveOrFail<{ data: ApprovalListRow[] }>('/approvals', {
         params: { status: 'pending', rfq_id: rfqId, per_page: 1, page: 1 },
       });
+
+      if (data === undefined) {
+        return 2;
+      }
+
       const meta = parseApprovalsMeta(data);
       if (meta === null) {
         throw new Error('Invalid approvals pending-count response: pagination meta');
       }
       return meta.total;
     },
-    enabled: Boolean(rfqId) && !useMocks,
-    initialData: useMocks && rfqId ? 2 : undefined,
+    enabled: Boolean(rfqId),
   });
 }

--- a/apps/atomy-q/WEB/src/hooks/use-approvals.ts
+++ b/apps/atomy-q/WEB/src/hooks/use-approvals.ts
@@ -224,7 +224,7 @@ export function useApprovalDetail(id: string | undefined) {
 
       const r = data?.data;
       if (!r || typeof r !== 'object') throw new Error('Not found');
-      const rec = r as Record<string, unknown>;
+      const rec = r as unknown as Record<string, unknown>;
       const base = normalizeApprovalRows({ data: [rec] })[0];
       return {
         ...base,

--- a/apps/atomy-q/WEB/src/hooks/use-approvals.ts
+++ b/apps/atomy-q/WEB/src/hooks/use-approvals.ts
@@ -125,17 +125,9 @@ export function useApprovalsList(params: UseApprovalsParams) {
       page: params.page ?? 1,
     }],
     queryFn: async (): Promise<ApprovalsListResult> => {
+      const isMock = process.env.NEXT_PUBLIC_USE_MOCKS === 'true';
       const page = Math.max(1, params.page ?? 1);
-      const data = await fetchLiveOrFail<{ data: ApprovalListRow[] }>('/approvals', {
-        params: {
-          rfq_id: params.rfq_id || undefined,
-          status: params.status || undefined,
-          type: params.type || undefined,
-          page,
-        },
-      });
-
-      if (data === undefined) {
+      if (isMock) {
         const { getSeedPendingApprovals } = await import('@/data/seed');
         const seed = getSeedPendingApprovals();
         let rows: ApprovalListRow[] = seed.map((a) => ({
@@ -171,6 +163,18 @@ export function useApprovalsList(params: UseApprovalsParams) {
         };
       }
 
+      const data = await fetchLiveOrFail<{ data: ApprovalListRow[] }>('/approvals', {
+        params: {
+          rfq_id: params.rfq_id || undefined,
+          status: params.status || undefined,
+          type: params.type || undefined,
+          page,
+        },
+      });
+      if (data === undefined) {
+        throw new Error('Approvals list unavailable');
+      }
+
       const items = normalizeApprovalRows(data);
       const meta = parseApprovalsMeta(data);
       if (meta === null) {
@@ -199,9 +203,7 @@ export function useApprovalDetail(id: string | undefined) {
     queryFn: async (): Promise<ApprovalDetail> => {
       if (!id) throw new Error('Approval id required');
 
-      const data = await fetchLiveOrFail<{ data: ApprovalDetail }>(`/approvals/${encodeURIComponent(id)}`);
-
-      if (data === undefined) {
+      if (process.env.NEXT_PUBLIC_USE_MOCKS === 'true') {
         const { getSeedPendingApprovals } = await import('@/data/seed');
         const row = getSeedPendingApprovals().find((a) => a.id === id);
         if (!row) throw new Error('Not found');
@@ -219,6 +221,11 @@ export function useApprovalDetail(id: string | undefined) {
           requested_at: null,
           comparison_run: null,
         };
+      }
+
+      const data = await fetchLiveOrFail<{ data: ApprovalDetail }>(`/approvals/${encodeURIComponent(id)}`);
+      if (data === undefined) {
+        throw new Error('Approval detail unavailable');
       }
 
       const r = data?.data;
@@ -254,13 +261,17 @@ export function useApprovalDetail(id: string | undefined) {
 export function useRfqPendingApprovalCount(rfqId: string | undefined) {
   return useQuery({
     queryKey: ['approvals', 'pending-count', rfqId],
-    queryFn: async (): Promise<number> => {
+    queryFn: async (): Promise<number | undefined> => {
+      if (process.env.NEXT_PUBLIC_USE_MOCKS === 'true') {
+        return undefined;
+      }
+
       const data = await fetchLiveOrFail<{ data: ApprovalListRow[] }>('/approvals', {
         params: { status: 'pending', rfq_id: rfqId, per_page: 1, page: 1 },
       });
 
       if (data === undefined) {
-        return 2;
+        return undefined;
       }
 
       const meta = parseApprovalsMeta(data);

--- a/apps/atomy-q/WEB/src/hooks/use-award.ts
+++ b/apps/atomy-q/WEB/src/hooks/use-award.ts
@@ -127,7 +127,6 @@ export function useAward(rfqId: string) {
         ];
       }
 
-      const data = await fetchLiveOrFail<AwardRecord[]>(`/awards?rfq_id=${encodeURIComponent(rfqId)}`);
       return normalizeAwardRows(data);
     },
     enabled: Boolean(rfqId),

--- a/apps/atomy-q/WEB/src/hooks/use-award.ts
+++ b/apps/atomy-q/WEB/src/hooks/use-award.ts
@@ -3,7 +3,6 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { fetchLiveOrFail } from '@/lib/api-live';
 import { api } from '@/lib/api';
-import { fetchLiveOrFail } from '@/lib/api-live';
 import { getSeedAwardByRfqId } from '@/data/seed';
 
 export interface AwardRecord {

--- a/apps/atomy-q/WEB/src/hooks/use-award.ts
+++ b/apps/atomy-q/WEB/src/hooks/use-award.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { api } from '@/lib/api';
 import { fetchLiveOrFail } from '@/lib/api-live';
 import { getSeedAwardByRfqId } from '@/data/seed';
 

--- a/apps/atomy-q/WEB/src/hooks/use-award.ts
+++ b/apps/atomy-q/WEB/src/hooks/use-award.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { api } from '@/lib/api';
+import { fetchLiveOrFail } from '@/lib/api-live';
 import { getSeedAwardByRfqId } from '@/data/seed';
 
 export interface AwardRecord {
@@ -89,13 +89,14 @@ function normalizeAwardRows(payload: unknown): AwardRecord[] {
 }
 
 export function useAward(rfqId: string) {
-  const useMocks = process.env.NEXT_PUBLIC_USE_MOCKS === 'true';
   const qc = useQueryClient();
 
   const query = useQuery({
     queryKey: ['awards', rfqId],
     queryFn: async (): Promise<AwardRecord[]> => {
-      if (useMocks) {
+      const data = await fetchLiveOrFail<{ data: AwardRecord[] }>('/awards', { params: { rfq_id: rfqId } });
+
+      if (data === undefined) {
         const seed = getSeedAwardByRfqId(rfqId);
         if (!seed) return [];
         return [
@@ -124,7 +125,6 @@ export function useAward(rfqId: string) {
         ];
       }
 
-      const { data } = await api.get('/awards', { params: { rfq_id: rfqId } });
       return normalizeAwardRows(data);
     },
     enabled: Boolean(rfqId),

--- a/apps/atomy-q/WEB/src/hooks/use-comparison-run-matrix.test.ts
+++ b/apps/atomy-q/WEB/src/hooks/use-comparison-run-matrix.test.ts
@@ -60,7 +60,8 @@ describe('useComparisonRunMatrix', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(mockGet).toHaveBeenCalledWith('/comparison-runs/run-42/matrix');
+    expect(mockGet).toHaveBeenCalledTimes(1);
+expect(mockGet.mock.calls[0][0]).toBe('/comparison-runs/run-42/matrix');
     expect(result.current.data).toEqual({
       id: 'run-42',
       clusters: [

--- a/apps/atomy-q/WEB/src/hooks/use-comparison-run-matrix.test.ts
+++ b/apps/atomy-q/WEB/src/hooks/use-comparison-run-matrix.test.ts
@@ -61,7 +61,7 @@ describe('useComparisonRunMatrix', () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
     expect(mockGet).toHaveBeenCalledTimes(1);
-expect(mockGet.mock.calls[0][0]).toBe('/comparison-runs/run-42/matrix');
+    expect(mockGet.mock.calls[0][0]).toBe('/comparison-runs/run-42/matrix');
     expect(result.current.data).toEqual({
       id: 'run-42',
       clusters: [

--- a/apps/atomy-q/WEB/src/hooks/use-comparison-run-matrix.ts
+++ b/apps/atomy-q/WEB/src/hooks/use-comparison-run-matrix.ts
@@ -166,12 +166,11 @@ export function useComparisonRunMatrix(runId: string, options?: { rfqId?: string
       const data = await fetchLiveOrFail<{ data: ComparisonRunMatrix }>(`/comparison-runs/${encodeURIComponent(runId)}/matrix`);
 
       if (data === undefined) {
-        return buildMockMatrix(runId, options?.rfqId);
-      }
-
-      const data = await fetchLiveOrFail(`/comparison-runs/${encodeURIComponent(runId)}/matrix`);
-      if (data === undefined) {
-        return buildMockMatrix(runId, options?.rfqId);
+        const rawData = await fetchLiveOrFail(`/comparison-runs/${encodeURIComponent(runId)}/matrix`);
+        if (rawData === undefined) {
+          return buildMockMatrix(runId, options?.rfqId);
+        }
+        return normalizeComparisonRunMatrix(rawData);
       }
 
       return normalizeComparisonRunMatrix(data);

--- a/apps/atomy-q/WEB/src/hooks/use-comparison-run-matrix.ts
+++ b/apps/atomy-q/WEB/src/hooks/use-comparison-run-matrix.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { useQuery } from '@tanstack/react-query';
-import { api } from '@/lib/api';
+import { fetchLiveOrFail } from '@/lib/api-live';
 import { getSeedComparisonRunsByRfqId } from '@/data/seed';
 import { isObject, toText, unwrapResponse } from '@/hooks/normalize-utils';
 
@@ -159,16 +159,15 @@ function buildMockMatrix(runId: string, rfqId?: string): ComparisonRunMatrix {
 }
 
 export function useComparisonRunMatrix(runId: string, options?: { rfqId?: string }) {
-  const useMocks = process.env.NEXT_PUBLIC_USE_MOCKS === 'true';
-
   return useQuery({
     queryKey: ['comparison-run-matrix', options?.rfqId ?? runId, runId],
     queryFn: async (): Promise<ComparisonRunMatrix> => {
-      if (useMocks) {
+      const data = await fetchLiveOrFail<{ data: ComparisonRunMatrix }>(`/comparison-runs/${encodeURIComponent(runId)}/matrix`);
+
+      if (data === undefined) {
         return buildMockMatrix(runId, options?.rfqId);
       }
 
-      const { data } = await api.get(`/comparison-runs/${encodeURIComponent(runId)}/matrix`);
       return normalizeComparisonRunMatrix(data);
     },
     enabled: Boolean(runId),

--- a/apps/atomy-q/WEB/src/hooks/use-comparison-run-readiness.test.ts
+++ b/apps/atomy-q/WEB/src/hooks/use-comparison-run-readiness.test.ts
@@ -41,7 +41,8 @@ describe('useComparisonRunReadiness', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(mockGet).toHaveBeenCalledWith('/comparison-runs/run-42/readiness');
+    expect(mockGet).toHaveBeenCalledTimes(1);
+expect(mockGet.mock.calls[0][0]).toBe('/comparison-runs/run-42/readiness');
     expect(result.current.data).toEqual({
       id: 'run-42',
       isReady: false,

--- a/apps/atomy-q/WEB/src/hooks/use-comparison-run-readiness.test.ts
+++ b/apps/atomy-q/WEB/src/hooks/use-comparison-run-readiness.test.ts
@@ -42,7 +42,7 @@ describe('useComparisonRunReadiness', () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
     expect(mockGet).toHaveBeenCalledTimes(1);
-expect(mockGet.mock.calls[0][0]).toBe('/comparison-runs/run-42/readiness');
+    expect(mockGet.mock.calls[0][0]).toBe('/comparison-runs/run-42/readiness');
     expect(result.current.data).toEqual({
       id: 'run-42',
       isReady: false,
@@ -71,5 +71,17 @@ expect(mockGet.mock.calls[0][0]).toBe('/comparison-runs/run-42/readiness');
     await waitFor(() => expect(result.current.isError).toBe(true));
 
     expect(result.current.error?.message).toMatch(/message/i);
+  });
+
+  it('stays idle in mock mode', async () => {
+    process.env.NEXT_PUBLIC_USE_MOCKS = 'true';
+
+    const { Wrapper } = createTestWrapper();
+    const { result } = renderHook(() => useComparisonRunReadiness('run-42'), { wrapper: Wrapper });
+
+    await waitFor(() => expect(result.current.fetchStatus).toBe('idle'));
+
+    expect(result.current.status).toBe('pending');
+    expect(mockGet).not.toHaveBeenCalled();
   });
 });

--- a/apps/atomy-q/WEB/src/hooks/use-comparison-run-readiness.ts
+++ b/apps/atomy-q/WEB/src/hooks/use-comparison-run-readiness.ts
@@ -92,12 +92,11 @@ export function useComparisonRunReadiness(runId: string, options?: { rfqId?: str
       const data = await fetchLiveOrFail<{ data: ComparisonRunReadiness }>(`/comparison-runs/${encodeURIComponent(runId)}/readiness`);
 
       if (data === undefined) {
-        return buildMockReadiness(runId, options?.rfqId);
-      }
-
-      const data = await fetchLiveOrFail(`/comparison-runs/${encodeURIComponent(runId)}/readiness`);
-      if (data === undefined) {
-        return buildMockReadiness(runId, options?.rfqId);
+        const rawData = await fetchLiveOrFail(`/comparison-runs/${encodeURIComponent(runId)}/readiness`);
+        if (rawData === undefined) {
+          return buildMockReadiness(runId, options?.rfqId);
+        }
+        return normalizeComparisonRunReadiness(rawData);
       }
 
       return normalizeComparisonRunReadiness(data);

--- a/apps/atomy-q/WEB/src/hooks/use-comparison-run-readiness.ts
+++ b/apps/atomy-q/WEB/src/hooks/use-comparison-run-readiness.ts
@@ -1,9 +1,7 @@
 'use client';
 
 import { useQuery } from '@tanstack/react-query';
-import { api } from '@/lib/api';
 import { fetchLiveOrFail } from '@/lib/api-live';
-import { getSeedComparisonRunsByRfqId } from '@/data/seed';
 import { isObject, toText, unwrapResponse } from '@/hooks/normalize-utils';
 
 export interface ComparisonRunReadinessEntry {
@@ -74,17 +72,6 @@ function normalizeComparisonRunReadiness(payload: unknown): ComparisonRunReadine
   };
 }
 
-function buildMockReadiness(runId: string, rfqId?: string): ComparisonRunReadiness {
-  const run = rfqId ? getSeedComparisonRunsByRfqId(rfqId).find((item) => item.id === runId || item.runId === runId) : null;
-  return {
-    id: run?.id ?? runId,
-    isReady: true,
-    isPreviewOnly: run?.type !== 'final',
-    blockers: [],
-    warnings: [],
-  };
-}
-
 export function useComparisonRunReadiness(runId: string, options?: { rfqId?: string }) {
   return useQuery({
     queryKey: ['comparison-run-readiness', options?.rfqId ?? runId, runId],
@@ -92,11 +79,7 @@ export function useComparisonRunReadiness(runId: string, options?: { rfqId?: str
       const data = await fetchLiveOrFail<{ data: ComparisonRunReadiness }>(`/comparison-runs/${encodeURIComponent(runId)}/readiness`);
 
       if (data === undefined) {
-        const rawData = await fetchLiveOrFail(`/comparison-runs/${encodeURIComponent(runId)}/readiness`);
-        if (rawData === undefined) {
-          return buildMockReadiness(runId, options?.rfqId);
-        }
-        return normalizeComparisonRunReadiness(rawData);
+        throw new Error(`Comparison readiness unavailable for run "${runId}".`);
       }
 
       return normalizeComparisonRunReadiness(data);

--- a/apps/atomy-q/WEB/src/hooks/use-comparison-run-readiness.ts
+++ b/apps/atomy-q/WEB/src/hooks/use-comparison-run-readiness.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { useQuery } from '@tanstack/react-query';
-import { api } from '@/lib/api';
+import { fetchLiveOrFail } from '@/lib/api-live';
 import { getSeedComparisonRunsByRfqId } from '@/data/seed';
 import { isObject, toText, unwrapResponse } from '@/hooks/normalize-utils';
 
@@ -85,16 +85,15 @@ function buildMockReadiness(runId: string, rfqId?: string): ComparisonRunReadine
 }
 
 export function useComparisonRunReadiness(runId: string, options?: { rfqId?: string }) {
-  const useMocks = process.env.NEXT_PUBLIC_USE_MOCKS === 'true';
-
   return useQuery({
     queryKey: ['comparison-run-readiness', options?.rfqId ?? runId, runId],
     queryFn: async (): Promise<ComparisonRunReadiness> => {
-      if (useMocks) {
+      const data = await fetchLiveOrFail<{ data: ComparisonRunReadiness }>(`/comparison-runs/${encodeURIComponent(runId)}/readiness`);
+
+      if (data === undefined) {
         return buildMockReadiness(runId, options?.rfqId);
       }
 
-      const { data } = await api.get(`/comparison-runs/${encodeURIComponent(runId)}/readiness`);
       return normalizeComparisonRunReadiness(data);
     },
     enabled: Boolean(runId),

--- a/apps/atomy-q/WEB/src/hooks/use-comparison-run-readiness.ts
+++ b/apps/atomy-q/WEB/src/hooks/use-comparison-run-readiness.ts
@@ -73,6 +73,8 @@ function normalizeComparisonRunReadiness(payload: unknown): ComparisonRunReadine
 }
 
 export function useComparisonRunReadiness(runId: string, options?: { rfqId?: string }) {
+  const isMock = process.env.NEXT_PUBLIC_USE_MOCKS === 'true';
+
   return useQuery({
     queryKey: ['comparison-run-readiness', options?.rfqId ?? runId, runId],
     queryFn: async (): Promise<ComparisonRunReadiness> => {
@@ -84,7 +86,7 @@ export function useComparisonRunReadiness(runId: string, options?: { rfqId?: str
 
       return normalizeComparisonRunReadiness(data);
     },
-    enabled: Boolean(runId),
+    enabled: Boolean(runId) && !isMock,
   });
 }
 

--- a/apps/atomy-q/WEB/src/hooks/use-comparison-run.test.ts
+++ b/apps/atomy-q/WEB/src/hooks/use-comparison-run.test.ts
@@ -56,7 +56,8 @@ describe('useComparisonRun', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(mockGet).toHaveBeenCalledWith('/comparison-runs/run-42');
+    expect(mockGet).toHaveBeenCalledTimes(1);
+expect(mockGet.mock.calls[0][0]).toBe('/comparison-runs/run-42');
     expect(result.current.data).toEqual({
       id: 'run-42',
       rfqId: 'rfq-9',

--- a/apps/atomy-q/WEB/src/hooks/use-comparison-run.test.ts
+++ b/apps/atomy-q/WEB/src/hooks/use-comparison-run.test.ts
@@ -57,7 +57,7 @@ describe('useComparisonRun', () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
     expect(mockGet).toHaveBeenCalledTimes(1);
-expect(mockGet.mock.calls[0][0]).toBe('/comparison-runs/run-42');
+    expect(mockGet.mock.calls[0][0]).toBe('/comparison-runs/run-42');
     expect(result.current.data).toEqual({
       id: 'run-42',
       rfqId: 'rfq-9',

--- a/apps/atomy-q/WEB/src/hooks/use-comparison-run.ts
+++ b/apps/atomy-q/WEB/src/hooks/use-comparison-run.ts
@@ -1,7 +1,6 @@
 'use client';
 
 import { useQuery } from '@tanstack/react-query';
-import { api } from '@/lib/api';
 import { fetchLiveOrFail } from '@/lib/api-live';
 import { getSeedComparisonRunsByRfqId } from '@/data/seed';
 import { isObject, toText, unwrapResponse } from '@/hooks/normalize-utils';
@@ -223,11 +222,7 @@ export function useComparisonRun(runId: string, options?: { rfqId?: string }) {
       const data = await fetchLiveOrFail<{ data: ComparisonRunDetail }>(`/comparison-runs/${encodeURIComponent(runId)}`);
 
       if (data === undefined) {
-        const rawData = await fetchLiveOrFail(`/comparison-runs/${encodeURIComponent(runId)}`);
-        if (rawData === undefined) {
-          return buildMockComparisonRun(runId, options?.rfqId);
-        }
-        return normalizeAndValidateComparisonRun(rawData, options?.rfqId);
+        return buildMockComparisonRun(runId, options?.rfqId);
       }
 
       return normalizeAndValidateComparisonRun(data, options?.rfqId);

--- a/apps/atomy-q/WEB/src/hooks/use-comparison-run.ts
+++ b/apps/atomy-q/WEB/src/hooks/use-comparison-run.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { useQuery } from '@tanstack/react-query';
-import { api } from '@/lib/api';
+import { fetchLiveOrFail } from '@/lib/api-live';
 import { getSeedComparisonRunsByRfqId } from '@/data/seed';
 import { isObject, toText, unwrapResponse } from '@/hooks/normalize-utils';
 
@@ -216,16 +216,15 @@ function buildMockComparisonRun(runId: string, rfqId?: string): ComparisonRunDet
 }
 
 export function useComparisonRun(runId: string, options?: { rfqId?: string }) {
-  const useMocks = process.env.NEXT_PUBLIC_USE_MOCKS === 'true';
-
   return useQuery({
     queryKey: ['comparison-run', options?.rfqId ?? runId, runId],
     queryFn: async (): Promise<ComparisonRunDetail> => {
-      if (useMocks) {
+      const data = await fetchLiveOrFail<{ data: ComparisonRunDetail }>(`/comparison-runs/${encodeURIComponent(runId)}`);
+
+      if (data === undefined) {
         return buildMockComparisonRun(runId, options?.rfqId);
       }
 
-      const { data } = await api.get(`/comparison-runs/${encodeURIComponent(runId)}`);
       const normalizedRun = normalizeComparisonRun(data);
 
       if (options?.rfqId !== undefined && normalizedRun.rfqId !== options.rfqId) {

--- a/apps/atomy-q/WEB/src/hooks/use-comparison-run.ts
+++ b/apps/atomy-q/WEB/src/hooks/use-comparison-run.ts
@@ -223,24 +223,25 @@ export function useComparisonRun(runId: string, options?: { rfqId?: string }) {
       const data = await fetchLiveOrFail<{ data: ComparisonRunDetail }>(`/comparison-runs/${encodeURIComponent(runId)}`);
 
       if (data === undefined) {
-        return buildMockComparisonRun(runId, options?.rfqId);
+        const rawData = await fetchLiveOrFail(`/comparison-runs/${encodeURIComponent(runId)}`);
+        if (rawData === undefined) {
+          return buildMockComparisonRun(runId, options?.rfqId);
+        }
+        return normalizeAndValidateComparisonRun(rawData, options?.rfqId);
       }
 
-      const data = await fetchLiveOrFail(`/comparison-runs/${encodeURIComponent(runId)}`);
-      if (data === undefined) {
-        return buildMockComparisonRun(runId, options?.rfqId);
-      }
-
-      const normalizedRun = normalizeComparisonRun(data);
-
-      if (options?.rfqId !== undefined && normalizedRun.rfqId !== options.rfqId) {
-        throw new Error(`Comparison run "${normalizedRun.id}" does not belong to RFQ "${options.rfqId}".`);
-      }
-
-      return normalizedRun;
+      return normalizeAndValidateComparisonRun(data, options?.rfqId);
     },
     enabled: Boolean(runId),
   });
+}
+
+function normalizeAndValidateComparisonRun(data: unknown, rfqId?: string): ComparisonRunDetail {
+  const normalizedRun = normalizeComparisonRun(data);
+  if (rfqId !== undefined && normalizedRun.rfqId !== rfqId) {
+    throw new Error(`Comparison run "${normalizedRun.id}" does not belong to RFQ "${rfqId}".`);
+  }
+  return normalizedRun;
 }
 
 export { normalizeComparisonRun, normalizeSnapshot };

--- a/apps/atomy-q/WEB/src/hooks/use-comparison-runs.ts
+++ b/apps/atomy-q/WEB/src/hooks/use-comparison-runs.ts
@@ -46,7 +46,7 @@ export function useComparisonRuns(rfqId: string) {
     queryKey: ['comparison-runs', rfqId],
     queryFn: async (): Promise<ComparisonRunRow[]> => {
       const data = await fetchLiveOrFail<{ data: ComparisonRunRow[] }>(
-        `/comparison-runs?rfq_id=${rfqId}`
+        `/comparison-runs?rfq_id=${encodeURIComponent(rfqId)}`
       );
 
       if (data === undefined) {

--- a/apps/atomy-q/WEB/src/hooks/use-comparison-runs.ts
+++ b/apps/atomy-q/WEB/src/hooks/use-comparison-runs.ts
@@ -45,9 +45,9 @@ export function useComparisonRuns(rfqId: string) {
   return useQuery({
     queryKey: ['comparison-runs', rfqId],
     queryFn: async (): Promise<ComparisonRunRow[]> => {
-      const data = await fetchLiveOrFail<{ data: ComparisonRunRow[] }>(
-        `/comparison-runs?rfq_id=${encodeURIComponent(rfqId)}`
-      );
+      const data = await fetchLiveOrFail<{ data: ComparisonRunRow[] }>('/comparison-runs', {
+        params: { rfq_id: rfqId },
+      });
 
       if (data === undefined) {
         return getSeedComparisonRunsByRfqId(rfqId).map((r) => ({

--- a/apps/atomy-q/WEB/src/hooks/use-comparison-runs.ts
+++ b/apps/atomy-q/WEB/src/hooks/use-comparison-runs.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { useQuery } from '@tanstack/react-query';
-import { api } from '@/lib/api';
+import { fetchLiveOrFail } from '@/lib/api-live';
 import { getSeedComparisonRunsByRfqId } from '@/data/seed';
 
 export interface ComparisonRunRow {
@@ -42,12 +42,14 @@ function normalizeComparisonRuns(payload: unknown): ComparisonRunRow[] {
 }
 
 export function useComparisonRuns(rfqId: string) {
-  const useMocks = process.env.NEXT_PUBLIC_USE_MOCKS === 'true';
-
   return useQuery({
     queryKey: ['comparison-runs', rfqId],
     queryFn: async (): Promise<ComparisonRunRow[]> => {
-      if (useMocks) {
+      const data = await fetchLiveOrFail<{ data: ComparisonRunRow[] }>(
+        `/comparison-runs?rfq_id=${rfqId}`
+      );
+
+      if (data === undefined) {
         return getSeedComparisonRunsByRfqId(rfqId).map((r) => ({
           id: r.id,
           rfq_id: r.rfqId,
@@ -58,10 +60,6 @@ export function useComparisonRuns(rfqId: string) {
           created_at: null,
         }));
       }
-
-      const { data } = await api.get('/comparison-runs', {
-        params: { rfq_id: rfqId },
-      });
 
       return normalizeComparisonRuns(data);
     },

--- a/apps/atomy-q/WEB/src/hooks/use-normalization-review.ts
+++ b/apps/atomy-q/WEB/src/hooks/use-normalization-review.ts
@@ -3,7 +3,6 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { fetchLiveOrFail } from '@/lib/api-live';
 import { api } from '@/lib/api';
-import { fetchLiveOrFail } from '@/lib/api-live';
 
 export type NormalizationConflictRow = {
   id: string;
@@ -68,11 +67,19 @@ export function useNormalizationReview(rfqId: string, options?: { enabled?: bool
   });
 
   const meta = query.data?.meta;
+  const rawBlocking = meta?.blocking_issue_count;
+  let blockingIssueCount = 0;
+  if (rawBlocking !== null && rawBlocking !== undefined) {
+    const n = Number(rawBlocking);
+    if (Number.isFinite(n)) {
+      blockingIssueCount = Math.round(n);
+    }
+  }
   return {
     ...query,
     conflicts: query.data?.data ?? [],
     hasBlockingIssues: Boolean(meta?.has_blocking_issues),
-    blockingIssueCount: Number(meta?.blocking_issue_count ?? 0),
+    blockingIssueCount,
     resolveConflict,
   };
 }

--- a/apps/atomy-q/WEB/src/hooks/use-normalization-review.ts
+++ b/apps/atomy-q/WEB/src/hooks/use-normalization-review.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { fetchLiveOrFail } from '@/lib/api-live';
 import { api } from '@/lib/api';
 
 export type NormalizationConflictRow = {
@@ -30,15 +31,17 @@ export function conflictTypeLabel(conflictType: string): string {
 
 export function useNormalizationReview(rfqId: string, options?: { enabled?: boolean }) {
   const qc = useQueryClient();
-  const useMocks = process.env.NEXT_PUBLIC_USE_MOCKS === 'true';
-  const enabled = (options?.enabled ?? true) && Boolean(rfqId) && !useMocks;
+  const enabled = (options?.enabled ?? true) && Boolean(rfqId);
 
   const query = useQuery({
     queryKey: ['normalization-conflicts', rfqId],
     queryFn: async (): Promise<ConflictsResponse> => {
-      const { data } = await api.get<ConflictsResponse>(
-        `/normalization/${encodeURIComponent(rfqId)}/conflicts`,
-      );
+      const data = await fetchLiveOrFail<ConflictsResponse>(`/normalization/${encodeURIComponent(rfqId)}/conflicts`);
+
+      if (data === undefined) {
+        return { data: [], meta: {} };
+      }
+
       return data;
     },
     enabled,

--- a/apps/atomy-q/WEB/src/hooks/use-normalization-source-lines.ts
+++ b/apps/atomy-q/WEB/src/hooks/use-normalization-source-lines.ts
@@ -92,14 +92,6 @@ export function useNormalizationSourceLines(rfqId: string, options?: { enabled?:
         return [];
       }
 
-      const data = await fetchLiveOrFail<{ data: NormalizationSourceLineRow[] }>(
-        `/normalization/${encodeURIComponent(rfqId)}/source-lines`
-      );
-
-      if (data === undefined) {
-        return [];
-      }
-
       return normalizeSourceLines(data);
     },
     enabled,

--- a/apps/atomy-q/WEB/src/hooks/use-normalization-source-lines.ts
+++ b/apps/atomy-q/WEB/src/hooks/use-normalization-source-lines.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { useQuery } from '@tanstack/react-query';
-import { api } from '@/lib/api';
+import { fetchLiveOrFail } from '@/lib/api-live';
 
 export interface NormalizationSourceLineRow {
   id: string;
@@ -80,17 +80,17 @@ function parseOptionalNumber(value: unknown): number | null {
 }
 
 export function useNormalizationSourceLines(rfqId: string, options?: { enabled?: boolean }) {
-  const useMocks = process.env.NEXT_PUBLIC_USE_MOCKS === 'true';
-  const enabled = (options?.enabled ?? true) && Boolean(rfqId) && !useMocks;
+  const enabled = (options?.enabled ?? true) && Boolean(rfqId);
 
   return useQuery({
     queryKey: ['normalization-source-lines', rfqId],
     queryFn: async (): Promise<NormalizationSourceLineRow[]> => {
-      if (useMocks) {
+      const data = await fetchLiveOrFail<{ data: NormalizationSourceLineRow[] }>('/normalization/' + encodeURIComponent(rfqId) + '/source-lines');
+
+      if (data === undefined) {
         return [];
       }
 
-      const { data } = await api.get('/normalization/' + encodeURIComponent(rfqId) + '/source-lines');
       return normalizeSourceLines(data);
     },
     enabled,

--- a/apps/atomy-q/WEB/src/hooks/use-normalization-source-lines.ts
+++ b/apps/atomy-q/WEB/src/hooks/use-normalization-source-lines.ts
@@ -81,6 +81,7 @@ function parseOptionalNumber(value: unknown): number | null {
 
 export function useNormalizationSourceLines(rfqId: string, options?: { enabled?: boolean }) {
   const enabled = (options?.enabled ?? true) && Boolean(rfqId);
+  const isMock = process.env.NEXT_PUBLIC_USE_MOCKS === 'true';
 
   return useQuery({
     queryKey: ['normalization-source-lines', rfqId],
@@ -88,7 +89,10 @@ export function useNormalizationSourceLines(rfqId: string, options?: { enabled?:
       const data = await fetchLiveOrFail<{ data: NormalizationSourceLineRow[] }>('/normalization/' + encodeURIComponent(rfqId) + '/source-lines');
 
       if (data === undefined) {
-        return [];
+        if (isMock) {
+          return [];
+        }
+        throw new Error(`Normalization source lines unavailable for RFQ "${rfqId}".`);
       }
 
       return normalizeSourceLines(data);

--- a/apps/atomy-q/WEB/src/hooks/use-normalization-source-lines.ts
+++ b/apps/atomy-q/WEB/src/hooks/use-normalization-source-lines.ts
@@ -1,7 +1,6 @@
 'use client';
 
 import { useQuery } from '@tanstack/react-query';
-import { api } from '@/lib/api';
 import { fetchLiveOrFail } from '@/lib/api-live';
 
 export interface NormalizationSourceLineRow {

--- a/apps/atomy-q/WEB/src/hooks/use-projects.ts
+++ b/apps/atomy-q/WEB/src/hooks/use-projects.ts
@@ -2,6 +2,7 @@
 
 import { useQuery } from '@tanstack/react-query';
 import { fetchLiveOrFail } from '@/lib/api-live';
+import { getSeedProjects } from '@/data/seed';
 
 export interface ProjectListItem {
   id: string;
@@ -49,7 +50,7 @@ export function useProjects(options?: { enabled?: boolean }) {
       const data = await fetchLiveOrFail<{ data: ProjectListItem[] }>('/projects');
 
       if (data === undefined) {
-        return [];
+        return normalizeProjectsPayload(getSeedProjects());
       }
 
       return normalizeProjectsPayload(data);

--- a/apps/atomy-q/WEB/src/hooks/use-projects.ts
+++ b/apps/atomy-q/WEB/src/hooks/use-projects.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { useQuery } from '@tanstack/react-query';
-import { api } from '@/lib/api';
+import { fetchLiveOrFail } from '@/lib/api-live';
 
 export interface ProjectListItem {
   id: string;
@@ -42,12 +42,16 @@ function normalizeProjectsPayload(payload: unknown): ProjectListItem[] {
 }
 
 export function useProjects(options?: { enabled?: boolean }) {
-  const useMocks = process.env.NEXT_PUBLIC_USE_MOCKS === 'true';
-  const enabled = (options?.enabled ?? true) && !useMocks;
+  const enabled = options?.enabled ?? true;
   return useQuery({
     queryKey: ['projects'],
     queryFn: async (): Promise<ProjectListItem[]> => {
-      const { data } = await api.get('/projects');
+      const data = await fetchLiveOrFail<{ data: ProjectListItem[] }>('/projects');
+
+      if (data === undefined) {
+        return [];
+      }
+
       return normalizeProjectsPayload(data);
     },
     enabled,

--- a/apps/atomy-q/WEB/src/hooks/use-quote-submission.ts
+++ b/apps/atomy-q/WEB/src/hooks/use-quote-submission.ts
@@ -94,17 +94,6 @@ export function useQuoteSubmission(quoteId: string, options?: { enabled?: boolea
           vendor_name: 'Vendor',
         };
       }
-      const data = await fetchLiveOrFail<{ data: QuoteSubmissionSummary }>(
-        `/quote-submissions/${encodeURIComponent(quoteId)}`
-      );
-      if (data === undefined) {
-        return {
-          id: quoteId,
-          status: 'ready',
-          blocking_issue_count: 0,
-          vendor_name: 'Vendor',
-        };
-      }
       return normalizeQuoteSubmission(data);
     },
     enabled,

--- a/apps/atomy-q/WEB/src/hooks/use-quote-submission.ts
+++ b/apps/atomy-q/WEB/src/hooks/use-quote-submission.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { useQuery } from '@tanstack/react-query';
-import { api } from '@/lib/api';
+import { fetchLiveOrFail } from '@/lib/api-live';
 
 export interface QuoteSubmissionSummary {
   id: string;
@@ -78,13 +78,14 @@ function normalizeNullableNumber(value: unknown, field: string): number | null |
 }
 
 export function useQuoteSubmission(quoteId: string, options?: { enabled?: boolean }) {
-  const useMocks = process.env.NEXT_PUBLIC_USE_MOCKS === 'true';
   const enabled = (options?.enabled ?? true) && Boolean(quoteId);
 
   return useQuery({
     queryKey: ['quote-submissions', quoteId],
     queryFn: async (): Promise<QuoteSubmissionSummary> => {
-      if (useMocks) {
+      const data = await fetchLiveOrFail<{ data: QuoteSubmissionSummary }>(`/quote-submissions/${encodeURIComponent(quoteId)}`);
+
+      if (data === undefined) {
         return {
           id: quoteId,
           status: 'ready',
@@ -92,9 +93,8 @@ export function useQuoteSubmission(quoteId: string, options?: { enabled?: boolea
           vendor_name: 'Vendor',
         };
       }
-      const { data } = await api.get(`/quote-submissions/${encodeURIComponent(quoteId)}`);
       return normalizeQuoteSubmission(data);
     },
-    enabled: enabled && (useMocks || Boolean(quoteId)),
+    enabled,
   });
 }

--- a/apps/atomy-q/WEB/src/hooks/use-quote-submissions.ts
+++ b/apps/atomy-q/WEB/src/hooks/use-quote-submissions.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { useQuery } from '@tanstack/react-query';
-import { api } from '@/lib/api';
+import { fetchLiveOrFail } from '@/lib/api-live';
 import { getSeedQuotesByRfqId } from '@/data/seed';
 
 export interface QuoteSubmissionRow {
@@ -95,12 +95,14 @@ function normalizeRequiredString(value: unknown, field: string, index: number): 
 }
 
 export function useQuoteSubmissions(rfqId: string) {
-  const useMocks = process.env.NEXT_PUBLIC_USE_MOCKS === 'true';
-
   return useQuery({
     queryKey: ['quote-submissions', 'list', rfqId],
     queryFn: async (): Promise<QuoteSubmissionRow[]> => {
-      if (useMocks) {
+      const data = await fetchLiveOrFail<{ data: QuoteSubmissionRow[] }>('/quote-submissions', {
+        params: { rfq_id: rfqId },
+      });
+
+      if (data === undefined) {
         return getSeedQuotesByRfqId(rfqId).map((q) => ({
           id: q.id,
           rfq_id: q.rfqId,
@@ -114,10 +116,6 @@ export function useQuoteSubmissions(rfqId: string) {
           original_filename: q.fileName,
         }));
       }
-
-      const { data } = await api.get('/quote-submissions', {
-        params: { rfq_id: rfqId },
-      });
 
       return normalizeQuoteSubmissionRows(data);
     },

--- a/apps/atomy-q/WEB/src/hooks/use-quote-submissions.ts
+++ b/apps/atomy-q/WEB/src/hooks/use-quote-submissions.ts
@@ -1,7 +1,6 @@
 'use client';
 
 import { useQuery } from '@tanstack/react-query';
-import { api } from '@/lib/api';
 import { fetchLiveOrFail } from '@/lib/api-live';
 import { getSeedQuotesByRfqId } from '@/data/seed';
 
@@ -102,6 +101,22 @@ export function useQuoteSubmissions(rfqId: string) {
       const data = await fetchLiveOrFail<{ data: QuoteSubmissionRow[] }>('/quote-submissions', {
         params: { rfq_id: rfqId },
       });
+
+      if (data === undefined) {
+        const seedRows = getSeedQuotesByRfqId(rfqId).map((row) => ({
+          id: row.id,
+          rfq_id: row.rfqId,
+          vendor_id: row.vendorId,
+          vendor_name: row.vendorName,
+          file_name: row.fileName,
+          status: row.status,
+          confidence: row.confidence,
+          submitted_at: row.uploadedAt,
+          blocking_issue_count: 0,
+          original_filename: row.fileName,
+        }));
+        return normalizeQuoteSubmissionRows({ data: seedRows });
+      }
 
       return normalizeQuoteSubmissionRows(data);
     },

--- a/apps/atomy-q/WEB/src/hooks/use-quote-submissions.ts
+++ b/apps/atomy-q/WEB/src/hooks/use-quote-submissions.ts
@@ -103,40 +103,6 @@ export function useQuoteSubmissions(rfqId: string) {
         params: { rfq_id: rfqId },
       });
 
-      if (data === undefined) {
-        return getSeedQuotesByRfqId(rfqId).map((q) => ({
-          id: q.id,
-          rfq_id: q.rfqId,
-          vendor_id: q.vendorId,
-          vendor_name: q.vendorName,
-          file_name: q.fileName,
-          status: q.status,
-          confidence: q.confidence,
-          uploaded_at: q.uploadedAt,
-          blocking_issue_count: q.status === 'error' ? 1 : 0,
-          original_filename: q.fileName,
-        }));
-      }
-
-      const data = await fetchLiveOrFail<{ data: QuoteSubmissionRow[] }>(
-        `/quote-submissions?rfq_id=${encodeURIComponent(rfqId)}`
-      );
-
-      if (data === undefined) {
-        return getSeedQuotesByRfqId(rfqId).map((q) => ({
-          id: q.id,
-          rfq_id: q.rfqId,
-          vendor_id: q.vendorId,
-          vendor_name: q.vendorName,
-          file_name: q.fileName,
-          status: q.status,
-          confidence: q.confidence,
-          uploaded_at: q.uploadedAt,
-          blocking_issue_count: q.status === 'error' ? 1 : 0,
-          original_filename: q.fileName,
-        }));
-      }
-
       return normalizeQuoteSubmissionRows(data);
     },
     enabled: Boolean(rfqId),

--- a/apps/atomy-q/WEB/src/hooks/use-rfq-counts.ts
+++ b/apps/atomy-q/WEB/src/hooks/use-rfq-counts.ts
@@ -62,16 +62,7 @@ export function useRfqNavCounts() {
       const data = await fetchLiveOrFail<{ data?: Partial<RfqNavCounts> }>('/rfqs/counts');
 
       if (data === undefined) {
-        return {
-          draft: 0,
-          published: 0,
-          closed: 0,
-          awarded: 0,
-          cancelled: 0,
-          active: 0,
-          pending: 0,
-          archived: 0,
-        };
+        return { ...emptyCounts };
       }
 
       const d = data?.data;

--- a/apps/atomy-q/WEB/src/hooks/use-rfq-counts.ts
+++ b/apps/atomy-q/WEB/src/hooks/use-rfq-counts.ts
@@ -55,24 +55,22 @@ function parseCount(raw: unknown): number | undefined {
 }
 
 export function useRfqNavCounts() {
-  const emptyCounts: RfqNavCounts = {
-    draft: 0,
-    published: 0,
-    closed: 0,
-    awarded: 0,
-    cancelled: 0,
-    active: 0,
-    pending: 0,
-    archived: 0,
-  };
-
   return useQuery({
     queryKey: ['rfqs', 'counts'],
     queryFn: async (): Promise<RfqNavCounts> => {
       const data = await fetchLiveOrFail<{ data?: Partial<RfqNavCounts> }>('/rfqs/counts');
 
       if (data === undefined) {
-        return emptyCounts;
+        return {
+          draft: 0,
+          published: 0,
+          closed: 0,
+          awarded: 0,
+          cancelled: 0,
+          active: 0,
+          pending: 0,
+          archived: 0,
+        };
       }
 
       const d = data?.data;

--- a/apps/atomy-q/WEB/src/hooks/use-rfq-counts.ts
+++ b/apps/atomy-q/WEB/src/hooks/use-rfq-counts.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { useQuery } from '@tanstack/react-query';
-import { api } from '@/lib/api';
+import { fetchLiveOrFail } from '@/lib/api-live';
 
 export interface RfqNavCounts {
   draft: number;
@@ -55,12 +55,26 @@ function parseCount(raw: unknown): number | undefined {
 }
 
 export function useRfqNavCounts() {
-  const useMocks = process.env.NEXT_PUBLIC_USE_MOCKS === 'true';
+  const emptyCounts: RfqNavCounts = {
+    draft: 0,
+    published: 0,
+    closed: 0,
+    awarded: 0,
+    cancelled: 0,
+    active: 0,
+    pending: 0,
+    archived: 0,
+  };
 
   return useQuery({
     queryKey: ['rfqs', 'counts'],
     queryFn: async (): Promise<RfqNavCounts> => {
-      const { data } = await api.get<{ data?: Partial<RfqNavCounts> }>('/rfqs/counts');
+      const data = await fetchLiveOrFail<{ data?: Partial<RfqNavCounts> }>('/rfqs/counts');
+
+      if (data === undefined) {
+        return emptyCounts;
+      }
+
       const d = data?.data;
       const published = parseCount(d?.published) ?? 0;
       const cancelled = parseCount(d?.cancelled) ?? 0;
@@ -75,7 +89,5 @@ export function useRfqNavCounts() {
         archived: parseCount(d?.archived) ?? cancelled,
       };
     },
-    enabled: !useMocks,
-    initialData: useMocks ? emptyCounts : undefined,
   });
 }

--- a/apps/atomy-q/WEB/src/hooks/use-rfq-overview.ts
+++ b/apps/atomy-q/WEB/src/hooks/use-rfq-overview.ts
@@ -247,7 +247,7 @@ export function useRfqOverview(rfqId: string) {
       const normalized = normalizeOverviewPayload(data);
       const activityRes = await fetchLiveOrFail<{ data: unknown[] }>(`/rfqs/${encodeURIComponent(rfqId)}/activity`, { params: { limit: 50 } });
       if (activityRes?.data && typeof activityRes.data === 'object') {
-        const body = activityRes.data as Record<string, unknown>;
+        const body = activityRes.data as unknown as Record<string, unknown>;
         const fromEndpoint = normalizeActivityList(body.data);
         if (fromEndpoint.length > 0) {
           return { ...normalized, activity: fromEndpoint };

--- a/apps/atomy-q/WEB/src/hooks/use-rfq-overview.ts
+++ b/apps/atomy-q/WEB/src/hooks/use-rfq-overview.ts
@@ -1,7 +1,6 @@
 'use client';
 
 import { useQuery } from '@tanstack/react-query';
-import { api } from '@/lib/api';
 import { fetchLiveOrFail } from '@/lib/api-live';
 import type { RfqStatus } from '@/hooks/use-rfqs';
 
@@ -188,61 +187,7 @@ export function useRfqOverview(rfqId: string) {
       const data = await fetchLiveOrFail<RfqOverviewData>(`/rfqs/${encodeURIComponent(rfqId)}/overview`);
 
       if (data === undefined) {
-        const { getSeedRfqDetail } = await import('@/data/seed');
-        const detail = getSeedRfqDetail(rfqId);
-        const vendorsCount = detail?.vendorsCount ?? 0;
-        const quotesCount = detail?.quotesCount ?? 0;
-        const accepted = Math.round(quotesCount * 0.75);
-        return {
-          rfq: {
-            id: detail?.id ?? rfqId,
-            rfq_number: detail?.id ?? rfqId,
-            title: detail?.title ?? 'Requisition',
-            description: detail?.description ?? null,
-            status: (detail?.status as RfqStatus) ?? 'active',
-            owner: null,
-            submission_deadline: new Date(Date.now() + 86400000 * 5).toISOString(),
-            closing_date: new Date(Date.now() + 86400000 * 12).toISOString(),
-            expected_award_at: new Date(Date.now() + 86400000 * 45).toISOString(),
-            technical_review_due_at: new Date(Date.now() + 86400000 * 18).toISOString(),
-            financial_review_due_at: new Date(Date.now() + 86400000 * 28).toISOString(),
-            category: null,
-            estimated_value: detail?.estValue,
-            estValue: detail?.estValue,
-            savings: detail?.savings ?? null,
-            vendors_count: vendorsCount,
-            quotes_count: quotesCount,
-          },
-          expected_quotes: vendorsCount,
-          normalization: {
-            accepted_count: accepted,
-            total_quotes: quotesCount,
-            progress_pct: quotesCount > 0 ? Math.round((accepted / quotesCount) * 100) : 0,
-            uploaded_count: Math.max(0, quotesCount - accepted),
-            needs_review_count: 0,
-            ready_count: accepted,
-          },
-          comparison: {
-            id: 'run-1',
-            name: 'Run #004',
-            status: 'preview',
-            is_preview: true,
-            created_at: new Date().toISOString(),
-          },
-          approvals: {
-            pending_count: 0,
-            approved_count: 0,
-            rejected_count: 0,
-            overall: 'none',
-          },
-          activity: [
-            { id: '1', type: 'quote', actor: 'Dell Technologies', action: 'Quote submitted (accepted)', timestamp: new Date(Date.now() - 7200000).toISOString() },
-            { id: '2', type: 'invitation', actor: 'System', action: 'Invitation sent to HP Enterprise', timestamp: new Date(Date.now() - 14400000).toISOString() },
-            { id: '3', type: 'comparison', actor: 'System', action: 'Comparison run: Run #004 (preview)', timestamp: new Date(Date.now() - 86400000).toISOString() },
-            { id: '4', type: 'system', actor: 'System', action: 'RFQ published and vendors notified', timestamp: new Date(Date.now() - 259200000).toISOString() },
-            { id: '5', type: 'creation', actor: 'User', action: `Created ${rfqId}`, timestamp: new Date(Date.now() - 518400000).toISOString() },
-          ],
-        };
+        throw new Error(`RFQ overview unavailable for "${rfqId}".`);
       }
 
       const normalized = normalizeOverviewPayload(data);

--- a/apps/atomy-q/WEB/src/hooks/use-rfq-overview.ts
+++ b/apps/atomy-q/WEB/src/hooks/use-rfq-overview.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { useQuery } from '@tanstack/react-query';
-import { api } from '@/lib/api';
+import { fetchLiveOrFail } from '@/lib/api-live';
 import type { RfqStatus } from '@/hooks/use-rfqs';
 
 export interface RfqOverviewRfq {
@@ -181,12 +181,12 @@ function normalizeOverviewPayload(payload: unknown): RfqOverviewData {
 }
 
 export function useRfqOverview(rfqId: string) {
-  const useMocks = process.env.NEXT_PUBLIC_USE_MOCKS === 'true';
-
   return useQuery({
     queryKey: ['rfqs', rfqId, 'overview'],
     queryFn: async (): Promise<RfqOverviewData> => {
-      if (useMocks) {
+      const data = await fetchLiveOrFail<RfqOverviewData>(`/rfqs/${encodeURIComponent(rfqId)}/overview`);
+
+      if (data === undefined) {
         const { getSeedRfqDetail } = await import('@/data/seed');
         const detail = getSeedRfqDetail(rfqId);
         const vendorsCount = detail?.vendorsCount ?? 0;
@@ -244,21 +244,16 @@ export function useRfqOverview(rfqId: string) {
         };
       }
 
-      const [overviewRes, activityRes] = await Promise.all([
-        api.get(`/rfqs/${encodeURIComponent(rfqId)}/overview`),
-        api
-          .get(`/rfqs/${encodeURIComponent(rfqId)}/activity`, { params: { limit: 50 } })
-          .catch(() => null),
-      ]);
-      const base = normalizeOverviewPayload(overviewRes.data);
+      const normalized = normalizeOverviewPayload(data);
+      const activityRes = await fetchLiveOrFail<{ data: unknown[] }>(`/rfqs/${encodeURIComponent(rfqId)}/activity`, { params: { limit: 50 } });
       if (activityRes?.data && typeof activityRes.data === 'object') {
         const body = activityRes.data as Record<string, unknown>;
         const fromEndpoint = normalizeActivityList(body.data);
         if (fromEndpoint.length > 0) {
-          return { ...base, activity: fromEndpoint };
+          return { ...normalized, activity: fromEndpoint };
         }
       }
-      return base;
+      return normalized;
     },
     enabled: Boolean(rfqId),
   });

--- a/apps/atomy-q/WEB/src/hooks/use-rfq-overview.ts
+++ b/apps/atomy-q/WEB/src/hooks/use-rfq-overview.ts
@@ -247,9 +247,9 @@ export function useRfqOverview(rfqId: string) {
 
       const normalized = normalizeOverviewPayload(data);
       const activityRes = await fetchLiveOrFail<{ data: unknown[] }>(`/rfqs/${encodeURIComponent(rfqId)}/activity`, { params: { limit: 50 } });
-      if (activityRes?.data && typeof activityRes.data === 'object') {
-        const body = activityRes.data as unknown as Record<string, unknown>;
-        const fromEndpoint = normalizeActivityList(body.data);
+      const activityData = activityRes?.data;
+      if (Array.isArray(activityData)) {
+        const fromEndpoint = normalizeActivityList(activityData);
         if (fromEndpoint.length > 0) {
           return { ...normalized, activity: fromEndpoint };
         }

--- a/apps/atomy-q/WEB/src/hooks/use-rfq-vendors.ts
+++ b/apps/atomy-q/WEB/src/hooks/use-rfq-vendors.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { useQuery } from '@tanstack/react-query';
-import { api } from '@/lib/api';
+import { fetchLiveOrFail } from '@/lib/api-live';
 import { getSeedVendorsByRfqId } from '@/data/seed';
 
 export interface RfqVendorRow {
@@ -11,8 +11,6 @@ export interface RfqVendorRow {
   status: 'invited' | 'responded';
   contact: string;
 }
-
-const useMocks = process.env.NEXT_PUBLIC_USE_MOCKS === 'true';
 
 function normalizeInvitationPayload(payload: unknown): RfqVendorRow[] {
   const raw = payload as { data?: unknown[] };
@@ -36,7 +34,9 @@ export function useRfqVendors(rfqId: string) {
   return useQuery({
     queryKey: ['rfqs', rfqId, 'vendors'],
     queryFn: async (): Promise<RfqVendorRow[]> => {
-      if (useMocks) {
+      const data = await fetchLiveOrFail<{ data: RfqVendorRow[] }>(`/rfqs/${encodeURIComponent(rfqId)}/invitations`);
+
+      if (data === undefined) {
         return getSeedVendorsByRfqId(rfqId).map((v) => ({
           id: v.id,
           vendor_id: v.id,
@@ -45,7 +45,6 @@ export function useRfqVendors(rfqId: string) {
           contact: v.email,
         }));
       }
-      const { data } = await api.get(`/rfqs/${encodeURIComponent(rfqId)}/invitations`);
       return normalizeInvitationPayload(data);
     },
     enabled: Boolean(rfqId),

--- a/apps/atomy-q/WEB/src/hooks/use-rfq-vendors.ts
+++ b/apps/atomy-q/WEB/src/hooks/use-rfq-vendors.ts
@@ -36,16 +36,6 @@ export function useRfqVendors(rfqId: string) {
     queryFn: async (): Promise<RfqVendorRow[]> => {
       const data = await fetchLiveOrFail<{ data: RfqVendorRow[] }>(`/rfqs/${encodeURIComponent(rfqId)}/invitations`);
 
-      if (data === undefined) {
-        return getSeedVendorsByRfqId(rfqId).map((v) => ({
-          id: v.id,
-          vendor_id: v.id,
-          name: v.name,
-          status: v.status,
-          contact: v.email,
-        }));
-      }
-      const data = await fetchLiveOrFail<RfqVendorRow[]>(`/rfqs/${encodeURIComponent(rfqId)}/invitations`);
       return normalizeInvitationPayload(data);
     },
     enabled: Boolean(rfqId),

--- a/apps/atomy-q/WEB/src/hooks/use-rfq-vendors.ts
+++ b/apps/atomy-q/WEB/src/hooks/use-rfq-vendors.ts
@@ -36,6 +36,19 @@ export function useRfqVendors(rfqId: string) {
     queryFn: async (): Promise<RfqVendorRow[]> => {
       const data = await fetchLiveOrFail<{ data: RfqVendorRow[] }>(`/rfqs/${encodeURIComponent(rfqId)}/invitations`);
 
+      if (data === undefined) {
+        const seededPayload = {
+          data: getSeedVendorsByRfqId(rfqId).map((vendor) => ({
+            id: vendor.id,
+            vendor_id: vendor.id,
+            vendor_name: vendor.name,
+            status: vendor.status,
+            vendor_email: vendor.email,
+          })),
+        };
+        return normalizeInvitationPayload(seededPayload);
+      }
+
       return normalizeInvitationPayload(data);
     },
     enabled: Boolean(rfqId),

--- a/apps/atomy-q/WEB/src/hooks/use-rfq.ts
+++ b/apps/atomy-q/WEB/src/hooks/use-rfq.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { api } from '@/lib/api';
 import { fetchLiveOrFail } from '@/lib/api-live';
 import { type RfqStatus, isValidRfqStatus, RFQ_STATUSES } from '@/hooks/use-rfqs';
 

--- a/apps/atomy-q/WEB/src/hooks/use-rfq.ts
+++ b/apps/atomy-q/WEB/src/hooks/use-rfq.ts
@@ -37,6 +37,14 @@ export interface RfqUpdateBody {
   financial_review_due_at?: string | null;
 }
 
+function parseMaybeNumber(value: unknown): number | undefined {
+  if (value === null || value === undefined) return undefined;
+  if (typeof value === 'string' && value.trim() === '') return undefined;
+  const n = Number(value);
+  if (!Number.isFinite(n)) return undefined;
+  return n;
+}
+
 function normalizeRfq(payload: unknown): RfqDetail {
   let raw = payload as Record<string, unknown> | null | undefined;
   while (raw?.data) {
@@ -57,8 +65,8 @@ function normalizeRfq(payload: unknown): RfqDetail {
           })(),
     status,
     rfq_number: raw?.rfq_number != null ? String(raw.rfq_number) : undefined,
-    vendorsCount: (raw?.vendorsCount ?? raw?.vendors_count) as number | undefined,
-    quotesCount: (raw?.quotesCount ?? raw?.quotes_count) as number | undefined,
+    vendorsCount: parseMaybeNumber(raw?.vendorsCount ?? raw?.vendors_count),
+    quotesCount: parseMaybeNumber(raw?.quotesCount ?? raw?.quotes_count),
     estValue: est !== null && est !== undefined ? String(est) : undefined,
     savings: raw?.savings != null ? String(raw.savings) : undefined,
     projectId: (raw?.project_id ?? raw?.projectId) as string | null | undefined,
@@ -85,7 +93,6 @@ export function useRfq(rfqId: string) {
         return normalizeRfq(detail);
       }
 
-      const data = await fetchLiveOrFail<unknown>(`/rfqs/${encodeURIComponent(rfqId)}`);
       return normalizeRfq(data);
     },
   });

--- a/apps/atomy-q/WEB/src/hooks/use-rfq.ts
+++ b/apps/atomy-q/WEB/src/hooks/use-rfq.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { api } from '@/lib/api';
+import { fetchLiveOrFail } from '@/lib/api-live';
 import { type RfqStatus, isValidRfqStatus, RFQ_STATUSES } from '@/hooks/use-rfqs';
 
 export interface RfqDetail {
@@ -72,19 +72,18 @@ function normalizeRfq(payload: unknown): RfqDetail {
 }
 
 export function useRfq(rfqId: string) {
-  const useMocks = process.env.NEXT_PUBLIC_USE_MOCKS === 'true';
-
   return useQuery({
     queryKey: ['rfqs', rfqId],
     queryFn: async () => {
-      if (useMocks) {
+      const data = await fetchLiveOrFail<{ data: RfqDetail }>(`/rfqs/${encodeURIComponent(rfqId)}`);
+
+      if (data === undefined) {
         const { getSeedRfqDetail } = await import('@/data/seed');
         const detail = getSeedRfqDetail(rfqId);
         if (!detail) throw new Error('RFQ not found');
         return normalizeRfq(detail);
       }
 
-      const { data } = await api.get(`/rfqs/${encodeURIComponent(rfqId)}`);
       return normalizeRfq(data);
     },
   });

--- a/apps/atomy-q/WEB/src/lib/api-live.ts
+++ b/apps/atomy-q/WEB/src/lib/api-live.ts
@@ -1,0 +1,33 @@
+// src/lib/api-live.ts
+'use client';
+
+import { api } from '@/lib/api';
+
+export interface FetchLiveOrFailOptions {
+  signal?: AbortSignal;
+  headers?: Record<string, string>;
+  params?: Record<string, string | number | undefined>;
+}
+
+/**
+ * Fetches from API in live mode, throwing a descriptive error on failure.
+ * In mock mode, returns undefined to signal the caller should use seed data.
+ */
+export async function fetchLiveOrFail<T>(
+  endpoint: string,
+  options?: FetchLiveOrFailOptions
+): Promise<T | undefined> {
+  const useMocks = process.env.NEXT_PUBLIC_USE_MOCKS === 'true';
+
+  if (useMocks) {
+    return undefined;
+  }
+
+  try {
+    const { data } = await api.get(endpoint, options);
+    return data as T;
+  } catch (e) {
+    const message = e instanceof Error ? e.message : 'Unknown error';
+    throw new Error(`Failed to load ${endpoint}: ${message}`);
+  }
+}

--- a/apps/atomy-q/WEB/src/lib/api-live.ts
+++ b/apps/atomy-q/WEB/src/lib/api-live.ts
@@ -3,10 +3,13 @@
 
 import { api } from '@/lib/api';
 
+export type FetchResponseType = 'json' | 'text' | 'blob' | 'arrayBuffer';
+
 export interface FetchLiveOrFailOptions {
   signal?: AbortSignal;
   headers?: Record<string, string>;
   params?: Record<string, string | number | undefined>;
+  responseType?: FetchResponseType;
 }
 
 /**
@@ -28,6 +31,17 @@ export async function fetchLiveOrFail<T>(
     return data as T;
   } catch (e) {
     const message = e instanceof Error ? e.message : 'Unknown error';
-    throw new Error(`Failed to load ${endpoint}: ${message}`);
+    const err = new Error(`Failed to load ${endpoint}: ${message}`);
+    if (e instanceof Error) {
+      err.cause = e;
+    }
+    const axiosErr = e as { response?: { status?: number; data?: unknown }; status?: number };
+    if (axiosErr.response) {
+      (err as Record<string, unknown>).status = axiosErr.response.status;
+      (err as Record<string, unknown>).response = axiosErr.response.data;
+    } else if (axiosErr.status) {
+      (err as Record<string, unknown>).status = axiosErr.status;
+    }
+    throw err;
   }
 }

--- a/apps/atomy-q/WEB/src/lib/api-live.ts
+++ b/apps/atomy-q/WEB/src/lib/api-live.ts
@@ -3,7 +3,7 @@
 
 import { api } from '@/lib/api';
 
-export type FetchResponseType = 'json' | 'text' | 'blob' | 'arrayBuffer';
+export type FetchResponseType = 'json' | 'text' | 'blob' | 'arraybuffer';
 
 export interface FetchLiveOrFailOptions {
   signal?: AbortSignal;


### PR DESCRIPTION
## Summary
- Implements Gap 9 (Mock Fallback Elimination) from alpha mitigation plan
- Creates `fetchLiveOrFail` utility in `src/lib/api-live.ts` that throws descriptive errors in live mode
- Updates all hooks and pages to fail loudly when API calls fail instead of silently falling back to seed data

### Changes
- Add `fetchLiveOrFail` utility with proper types
- Update comparison hooks: use-comparison-runs.ts, use-comparison-run.ts, etc.
- Update quote intake hooks: use-quote-submissions.ts, use-quote-submission.ts
- Update RFQ hooks: use-rfq.ts, use-rfq-overview.ts, use-rfq-counts.ts
- Update other hooks: use-award.ts, use-rfq-vendors.ts, use-projects.ts, use-approvals.ts
- Update pages: auth pages and dashboard

## Test Plan
- [x] `npm run build` passes
- [x] `npm run lint` passes (warnings only)
- [x] `npm run test:unit` passes (69 tests)