### PR TITLE
[codex] Rectify alpha task 1 release gates

### DIFF
--- a/apps/atomy-q/API/IMPLEMENTATION_SUMMARY.md
+++ b/apps/atomy-q/API/IMPLEMENTATION_SUMMARY.md
@@ -49,6 +49,7 @@
 - `AtomyUserQuery` now exposes real role and permission data through `user_roles`, `role_permissions`, and `user_permissions` pivots, with legacy single-role fallback for seeded alpha users.
 - `AtomyUserAuthenticator` now increments failed-login counters and locks accounts after five failures, and the new identity tests verify both lockout and wildcard RBAC through the real middleware path.
 - `AuthTest::test_sso_*` exercise OIDC init + mock callback (`mock_authorization_code` + `SSO_MOCK_DISCOVERY_DOCUMENT`) end-to-end against these bindings.
+- MFA verification now resolves tenant context from the persisted challenge record. `tenant_id` is optional on `POST /api/v1/auth/mfa/verify`; when supplied and mismatched, the endpoint returns the generic invalid-challenge response without exposing cross-tenant state.
 
 ### Environment
 
@@ -79,6 +80,13 @@
 - Draft saves now preserve explicit nulls for nullable fields that are actually present in the request instead of falling back through `??` to old values.
 - Duplicate RFQs now create `rfq_number` and insert inside a single transaction with retry on unique-key conflicts, closing the atomicity gap between number generation and persistence.
 - Bulk-action execution now rejects preloaded record sets that do not exactly match the requested RFQ ids, preventing writes against unvalidated identifiers.
+
+## Alpha Task 1 rectification (2026-04-15)
+
+- Quote upload happy-path tests now include a valid RFQ line-item fixture, proving the mock processor can mark uploads `ready`; no-line upload coverage proves missing RFQ line context does not masquerade as ready.
+- `Award::creator()` is available as a relation mapped to the current `signed_off_by` schema while preserving `signedOffByUser()`.
+- Sourcing adapter tests mirror the production RFQ schema for project/schedule fields, and duplicate RFQ number exhaustion maps SQLite unique violations to `DuplicateRfqNumberException`.
+- Verification: API alpha matrix passes with 93 tests / 522 assertions; full API suite passes with 425 tests / 1131 assertions.
 
 ## Endpoint Coverage
 

--- a/apps/atomy-q/API/app/Contracts/MfaChallengeStoreInterface.php
+++ b/apps/atomy-q/API/app/Contracts/MfaChallengeStoreInterface.php
@@ -10,6 +10,12 @@ interface MfaChallengeStoreInterface
 {
     public function create(string $userId, string $tenantId, string $method): string;
 
+    /**
+     * Privileged lookup for MFA verification requests that do not carry tenant context.
+     * Callers must validate challenge state and use the stored tenant for all writes.
+     */
+    public function findByChallengeId(string $challengeId): ?MfaChallenge;
+
     public function find(string $challengeId, string $tenantId): ?MfaChallenge;
 
     public function consume(string $challengeId, string $tenantId): void;

--- a/apps/atomy-q/API/app/Http/Controllers/Api/V1/AuthController.php
+++ b/apps/atomy-q/API/app/Http/Controllers/Api/V1/AuthController.php
@@ -236,7 +236,7 @@ final class AuthController extends Controller
     {
         $validator = Validator::make($request->all(), [
             'challenge_id' => ['required', 'string'],
-            'tenant_id' => ['required', 'string'],
+            'tenant_id' => ['sometimes', 'string'],
             'otp' => ['required', 'string'],
         ]);
 
@@ -245,10 +245,15 @@ final class AuthController extends Controller
         }
 
         $challengeId = (string) $request->input('challenge_id');
-        $tenantId = (string) $request->input('tenant_id');
         $otp = trim((string) $request->input('otp'));
+        $suppliedTenantId = $request->input('tenant_id');
+        $suppliedTenantId = is_string($suppliedTenantId) ? trim($suppliedTenantId) : '';
 
-        $challenge = $this->mfaChallenges->find($challengeId, $tenantId);
+        $challenge = $suppliedTenantId !== ''
+            ? $this->mfaChallenges->find($challengeId, $suppliedTenantId)
+            : $this->mfaChallenges->findByChallengeId($challengeId);
+        $tenantId = $challenge !== null ? (string) $challenge->tenant_id : '';
+
         if (
             $challenge === null
             || $challenge->consumed_at !== null

--- a/apps/atomy-q/API/app/Models/Award.php
+++ b/apps/atomy-q/API/app/Models/Award.php
@@ -62,7 +62,15 @@ class Award extends Model
      */
     public function signedOffByUser(): BelongsTo
     {
-        return $this->belongsTo(User::class, 'signed_off_by');
+        return $this->signedOffByRelation('signedOffByUser');
+    }
+
+    /**
+     * @return BelongsTo<User, $this>
+     */
+    public function creator(): BelongsTo
+    {
+        return $this->signedOffByRelation('creator');
     }
 
     /**
@@ -71,5 +79,13 @@ class Award extends Model
     public function handoffs(): HasMany
     {
         return $this->hasMany(Handoff::class, 'award_id');
+    }
+
+    /**
+     * @return BelongsTo<User, $this>
+     */
+    private function signedOffByRelation(string $relation): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'signed_off_by', 'id', $relation);
     }
 }

--- a/apps/atomy-q/API/app/Services/Identity/AtomyMfaChallengeStore.php
+++ b/apps/atomy-q/API/app/Services/Identity/AtomyMfaChallengeStore.php
@@ -39,6 +39,13 @@ final readonly class AtomyMfaChallengeStore implements MfaChallengeStoreInterfac
             ->first();
     }
 
+    public function findByChallengeId(string $challengeId): ?MfaChallenge
+    {
+        return MfaChallenge::query()
+            ->whereKey($challengeId)
+            ->first();
+    }
+
     public function consume(string $challengeId, string $tenantId): void
     {
         MfaChallenge::query()

--- a/apps/atomy-q/API/app/Services/SourcingOperations/AtomyRfqLifecyclePersist.php
+++ b/apps/atomy-q/API/app/Services/SourcingOperations/AtomyRfqLifecyclePersist.php
@@ -173,7 +173,7 @@ final readonly class AtomyRfqLifecyclePersist implements RfqLifecyclePersistPort
         $message = strtolower($exception->getMessage());
 
         // Only return true for unique-index violations on the RFQ number constraint
-        $isUniqueViolation = $errorCode === '23505' || $driverCode === '1062';
+        $isUniqueViolation = $errorCode === '23505' || $errorCode === '23000' || $driverCode === '1062' || $driverCode === '19';
         $isRfqNumberConstraint = str_contains($message, 'rfqs_tenant_id_rfq_number_unique')
             || str_contains($message, 'rfqs.tenant_id, rfqs.rfq_number');
 

--- a/apps/atomy-q/API/tests/Feature/Api/AuthTest.php
+++ b/apps/atomy-q/API/tests/Feature/Api/AuthTest.php
@@ -303,6 +303,26 @@ final class AuthTest extends TestCase
         $verify->assertJsonPath('user.tenantId', $user['tenant_id']);
     }
 
+    public function test_mfa_verify_rejects_mismatched_optional_tenant_id(): void
+    {
+        $user = $this->createTestUser(['mfa_enabled' => true]);
+
+        $challengeResponse = $this->postJson('/api/v1/auth/login', [
+            'email' => $user['email'],
+            'password' => $user['password'],
+        ]);
+
+        $challengeResponse->assertStatus(401);
+        $challengeId = (string) $challengeResponse->json('challenge_id');
+
+        $this->postJson('/api/v1/auth/mfa/verify', [
+            'challenge_id' => $challengeId,
+            'tenant_id' => (string) \Illuminate\Support\Str::ulid(),
+            'otp' => '123456',
+        ])->assertStatus(401)
+            ->assertJsonPath('message', 'Invalid or expired MFA challenge');
+    }
+
     public function test_forgot_password_requires_email(): void
     {
         $this->postJson('/api/v1/auth/forgot-password', [])

--- a/apps/atomy-q/API/tests/Feature/QuoteSubmissionWorkflowTest.php
+++ b/apps/atomy-q/API/tests/Feature/QuoteSubmissionWorkflowTest.php
@@ -6,6 +6,7 @@ namespace Tests\Feature;
 
 use App\Models\QuoteSubmission;
 use App\Models\Rfq;
+use App\Models\RfqLineItem;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\UploadedFile;
@@ -227,6 +228,16 @@ final class QuoteSubmissionWorkflowTest extends ApiTestCase
             'submission_deadline' => now()->addDays(14),
             'status' => 'draft',
         ]);
+        RfqLineItem::query()->create([
+            'tenant_id' => $user->tenant_id,
+            'rfq_id' => $rfq->id,
+            'description' => 'Pump seal kit',
+            'quantity' => 2,
+            'uom' => 'EA',
+            'unit_price' => 100,
+            'currency' => 'USD',
+            'sort_order' => 1,
+        ]);
 
         $response = $this->withHeaders($this->authHeaders((string) $user->tenant_id, (string) $user->id))
             ->post('/api/v1/quote-submissions/upload', [
@@ -251,6 +262,40 @@ final class QuoteSubmissionWorkflowTest extends ApiTestCase
         ]);
     }
 
+    public function test_quote_submission_upload_without_rfq_lines_does_not_become_ready(): void
+    {
+        Storage::fake('local');
+
+        $user = $this->createUser();
+        $rfq = Rfq::query()->create([
+            'tenant_id' => $user->tenant_id,
+            'rfq_number' => 'RFQ-2002',
+            'title' => 'Upload RFQ Without Lines',
+            'owner_id' => $user->id,
+            'submission_deadline' => now()->addDays(14),
+            'status' => 'draft',
+        ]);
+
+        $response = $this->withHeaders($this->authHeaders((string) $user->tenant_id, (string) $user->id))
+            ->post('/api/v1/quote-submissions/upload', [
+                'rfq_id' => $rfq->id,
+                'vendor_id' => (string) Str::ulid(),
+                'vendor_name' => 'Upload Vendor',
+                'file' => UploadedFile::fake()->create('quote.txt', 12, 'text/plain'),
+            ]);
+
+        $response->assertCreated();
+        $response->assertJsonPath('data.status', 'failed');
+
+        $quoteId = (string) $response->json('data.id');
+        $this->assertDatabaseHas('quote_submissions', [
+            'id' => $quoteId,
+            'tenant_id' => $user->tenant_id,
+            'rfq_id' => $rfq->id,
+            'status' => 'failed',
+        ]);
+    }
+
     public function test_quote_submission_show_returns_404_for_other_tenant(): void
     {
         $owner = $this->createUser();
@@ -258,7 +303,7 @@ final class QuoteSubmissionWorkflowTest extends ApiTestCase
 
         $rfq = Rfq::query()->create([
             'tenant_id' => $owner->tenant_id,
-            'rfq_number' => 'RFQ-2002',
+            'rfq_number' => 'RFQ-2003',
             'title' => 'Tenant scoped RFQ',
             'owner_id' => $owner->id,
             'submission_deadline' => now()->addDays(14),
@@ -295,7 +340,7 @@ final class QuoteSubmissionWorkflowTest extends ApiTestCase
 
         $rfqA = Rfq::query()->create([
             'tenant_id' => $user->tenant_id,
-            'rfq_number' => 'RFQ-2003',
+            'rfq_number' => 'RFQ-2004',
             'title' => 'List RFQ A',
             'owner_id' => $user->id,
             'submission_deadline' => now()->addDays(14),
@@ -304,7 +349,7 @@ final class QuoteSubmissionWorkflowTest extends ApiTestCase
 
         $rfqB = Rfq::query()->create([
             'tenant_id' => $user->tenant_id,
-            'rfq_number' => 'RFQ-2004',
+            'rfq_number' => 'RFQ-2005',
             'title' => 'List RFQ B',
             'owner_id' => $user->id,
             'submission_deadline' => now()->addDays(14),

--- a/apps/atomy-q/API/tests/Unit/Services/SourcingOperationsAdaptersTest.php
+++ b/apps/atomy-q/API/tests/Unit/Services/SourcingOperationsAdaptersTest.php
@@ -40,6 +40,7 @@ final class SourcingOperationsAdaptersTest extends TestCase
         Schema::create('rfqs', static function ($table): void {
             $table->ulid('id')->primary();
             $table->ulid('tenant_id')->index();
+            $table->ulid('project_id')->nullable()->index();
             $table->string('rfq_number');
             $table->string('title');
             $table->text('description')->nullable();
@@ -51,6 +52,9 @@ final class SourcingOperationsAdaptersTest extends TestCase
             $table->decimal('savings_percentage', 5, 2)->default(0);
             $table->timestamp('submission_deadline')->nullable();
             $table->timestamp('closing_date')->nullable();
+            $table->timestamp('expected_award_at')->nullable();
+            $table->timestamp('technical_review_due_at')->nullable();
+            $table->timestamp('financial_review_due_at')->nullable();
             $table->string('payment_terms')->nullable();
             $table->string('evaluation_method')->nullable();
             $table->timestamps();

--- a/apps/atomy-q/WEB/IMPLEMENTATION_SUMMARY.md
+++ b/apps/atomy-q/WEB/IMPLEMENTATION_SUMMARY.md
@@ -48,3 +48,10 @@
 - Added seeded fallbacks for mock mode in quote submissions and RFQ invitations so normalizers always receive valid payloads.
 - Corrected `FetchResponseType` to use Axios-compatible `'arraybuffer'`.
 - Cleaned unused imports and fixed assertion indentation consistency in comparison run test files.
+
+## 2026-04-15 Alpha Task 1 Rectification
+
+- `fetchLiveOrFail` now decorates live API failures through a typed `LiveApiError` shape, preserving status/response metadata without unsafe `Error` casts.
+- The RFQ award page now exposes a live create-award path when no award exists and a final comparison run is available, using real comparison-run and RFQ-vendor hook data. Mock mode still disables the mutation.
+- `useAward` now returns a `store` mutation for `POST /awards` and invalidates the RFQ award query after creation.
+- Verification: `npm run lint` exits 0 with the documented existing warnings; `npm run build` and `npm run test:unit` pass.

--- a/apps/atomy-q/WEB/src/app/(dashboard)/rfqs/[rfqId]/award/page.test.tsx
+++ b/apps/atomy-q/WEB/src/app/(dashboard)/rfqs/[rfqId]/award/page.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { beforeAll, describe, expect, it, vi, beforeEach } from 'vitest';
-import { fireEvent, screen } from '@testing-library/react';
+import { act, fireEvent, screen } from '@testing-library/react';
 import { renderWithProviders } from '@/test/utils';
 
 import { useAward } from '@/hooks/use-award';
@@ -97,12 +97,13 @@ describe('RfqAwardPage', () => {
   });
 
   it('shows award creation UI when no award exists', async () => {
+    const storeMutate = vi.fn();
     vi.mocked(useAward).mockReturnValue({
       award: null,
       awards: [],
       signoff: { mutate: vi.fn(), isPending: false, isError: false },
       debrief: { mutate: vi.fn(), isPending: false, isError: false },
-      store: { mutate: vi.fn(), isPending: false, isError: false },
+      store: { mutate: storeMutate, isPending: false, isError: false },
     } as unknown as UseAwardReturn);
     
     vi.mocked(useComparisonRuns).mockReturnValue({
@@ -112,6 +113,25 @@ describe('RfqAwardPage', () => {
     renderWithProviders(<RfqAwardPageContent rfqId="rfq-1" />);
 
     expect(await screen.findByText(/Select a vendor to award the contract based on the final comparison run/i)).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /create award/i })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /create award/i }));
+
+    expect(storeMutate).toHaveBeenCalledWith(
+      { rfqId: 'rfq-1', comparisonRunId: 'run-1', vendorId: 'vendor-1' },
+      expect.objectContaining({
+        onError: expect.any(Function),
+        onSuccess: expect.any(Function),
+      }),
+    );
+    const callbacks = storeMutate.mock.calls[0]?.[1] as { onError: (error: Error) => void; onSuccess: () => void };
+
+    act(() => {
+      callbacks.onError(new Error('Award creation rejected'));
+    });
+    expect(screen.getByText('Award creation rejected')).toBeInTheDocument();
+
+    act(() => {
+      callbacks.onSuccess();
+    });
+    expect(screen.queryByText('Award creation rejected')).not.toBeInTheDocument();
   });
 });

--- a/apps/atomy-q/WEB/src/app/(dashboard)/rfqs/[rfqId]/award/page.tsx
+++ b/apps/atomy-q/WEB/src/app/(dashboard)/rfqs/[rfqId]/award/page.tsx
@@ -9,7 +9,9 @@ import { StatusBadge } from '@/components/ds/Badge';
 import { PageHeader } from '@/components/ds/FilterBar';
 import { WorkspaceBreadcrumbs } from '@/components/workspace/workspace-breadcrumbs';
 import { useAward } from '@/hooks/use-award';
+import { useComparisonRuns } from '@/hooks/use-comparison-runs';
 import { useRfq } from '@/hooks/use-rfq';
+import { useRfqVendors } from '@/hooks/use-rfq-vendors';
 
 const useMocks = process.env.NEXT_PUBLIC_USE_MOCKS === 'true';
 
@@ -36,15 +38,35 @@ function awardBadge(status: string | null | undefined): { status: 'pending' | 'a
 export function RfqAwardPageContent({ rfqId }: { rfqId: string }) {
   const router = useRouter();
   const { data: rfq } = useRfq(rfqId);
-  const { award, debrief, signoff } = useAward(rfqId);
+  const { award, debrief, signoff, store } = useAward(rfqId);
+  const { data: comparisonRuns = [] } = useComparisonRuns(rfqId);
+  const { data: vendors = [] } = useRfqVendors(rfqId);
   const [debriefMessage, setDebriefMessage] = React.useState('');
+  const [selectedVendorId, setSelectedVendorId] = React.useState('');
+  const [awardError, setAwardError] = React.useState('');
+  const awardVendorSelectId = React.useId();
   const displayAward = award ?? null;
   const awardStatus = awardBadge(displayAward?.status);
   const isFinalized = awardStatus.status === 'approved';
+  const finalRun = comparisonRuns.find((run) => run.type === 'final' && ['frozen', 'final', 'completed'].includes(run.status));
+  const awardCandidates = React.useMemo(
+    () => vendors.filter((vendor) => vendor.vendor_id !== null && vendor.vendor_id.trim() !== ''),
+    [vendors],
+  );
   const nonWinners = displayAward?.comparison?.vendors?.length
     ? displayAward.comparison.vendors.filter((vendor) => vendor.vendor_id !== '' && vendor.vendor_id !== displayAward.vendor_id)
     : [];
   const awardAmount = formatAmount(displayAward?.amount ?? null, displayAward?.currency ?? null);
+
+  React.useEffect(() => {
+    if (selectedVendorId === '' && awardCandidates[0]?.vendor_id) {
+      setSelectedVendorId(awardCandidates[0].vendor_id);
+    }
+  }, [awardCandidates, selectedVendorId]);
+
+  React.useEffect(() => {
+    setAwardError('');
+  }, [selectedVendorId]);
 
   const breadcrumbItems = [
     { label: 'RFQs', href: '/rfqs' },
@@ -84,11 +106,65 @@ export function RfqAwardPageContent({ rfqId }: { rfqId: string }) {
               <p className="text-xs text-slate-600">
                 {displayAward
                   ? `${isFinalized ? 'Amount' : 'Proposed amount'}: ${awardAmount}`
-                  : 'Freeze a comparison run to create an award record.'}
+                  : finalRun
+                    ? 'Create an award from the final comparison run.'
+                    : 'Freeze a comparison run to create an award record.'}
               </p>
               <StatusBadge status={awardStatus.status} label={displayAward ? (isFinalized ? awardStatus.label : 'Recommended') : 'Recommended'} />
             </div>
           </SectionCard>
+          {!displayAward && finalRun ? (
+            <SectionCard title="Create award">
+              <div className="space-y-3">
+                <p className="text-sm text-slate-600">
+                  Select a vendor to award the contract based on the final comparison run.
+                </p>
+                {awardCandidates.length > 0 ? (
+                  <label htmlFor={awardVendorSelectId} className="block space-y-1">
+                    <span className="text-xs font-medium text-slate-600">Award vendor</span>
+                    <select
+                      id={awardVendorSelectId}
+                      className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-800 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                      value={selectedVendorId}
+                      onChange={(event) => setSelectedVendorId(event.target.value)}
+                    >
+                      {awardCandidates.map((vendor) => (
+                        <option key={vendor.id} value={vendor.vendor_id ?? ''}>
+                          {vendor.name}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                ) : (
+                  <p className="text-sm text-slate-500">No vendors available for award selection.</p>
+                )}
+                <Button
+                  size="sm"
+                  variant="primary"
+                  disabled={selectedVendorId === '' || store.isPending || useMocks}
+                  onClick={() => {
+                    if (selectedVendorId !== '') {
+                      setAwardError('');
+                      store.mutate(
+                        { rfqId, comparisonRunId: finalRun.id, vendorId: selectedVendorId },
+                        {
+                          onError: (error) => {
+                            setAwardError(error instanceof Error ? error.message : 'Award creation failed.');
+                          },
+                          onSuccess: () => {
+                            setAwardError('');
+                          },
+                        },
+                      );
+                    }
+                  }}
+                >
+                  Create Award
+                </Button>
+                {awardError !== '' ? <p className="text-xs text-red-600">{awardError}</p> : null}
+              </div>
+            </SectionCard>
+          ) : null}
           <SectionCard title="Sign-off">
             <div className="space-y-3">
               <Button

--- a/apps/atomy-q/WEB/src/hooks/use-award.ts
+++ b/apps/atomy-q/WEB/src/hooks/use-award.ts
@@ -151,6 +151,20 @@ export function useAward(rfqId: string) {
     },
   });
 
+  const store = useMutation({
+    mutationFn: async (input: { rfqId: string; comparisonRunId: string; vendorId: string }) => {
+      const { data } = await api.post('/awards', {
+        rfq_id: input.rfqId,
+        comparison_run_id: input.comparisonRunId,
+        vendor_id: input.vendorId,
+      });
+      return data;
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['awards', rfqId] });
+    },
+  });
+
   const awards = query.data ?? [];
   return {
     ...query,
@@ -158,5 +172,6 @@ export function useAward(rfqId: string) {
     award: awards[0] ?? null,
     signoff,
     debrief,
+    store,
   };
 }

--- a/apps/atomy-q/WEB/src/lib/api-live.ts
+++ b/apps/atomy-q/WEB/src/lib/api-live.ts
@@ -12,6 +12,11 @@ export interface FetchLiveOrFailOptions {
   responseType?: FetchResponseType;
 }
 
+type LiveApiError = Error & {
+  status?: number;
+  response?: unknown;
+};
+
 /**
  * Fetches from API in live mode, throwing a descriptive error on failure.
  * In mock mode, returns undefined to signal the caller should use seed data.
@@ -31,16 +36,16 @@ export async function fetchLiveOrFail<T>(
     return data as T;
   } catch (e) {
     const message = e instanceof Error ? e.message : 'Unknown error';
-    const err = new Error(`Failed to load ${endpoint}: ${message}`);
+    const err: LiveApiError = new Error(`Failed to load ${endpoint}: ${message}`);
     if (e instanceof Error) {
       err.cause = e;
     }
     const axiosErr = e as { response?: { status?: number; data?: unknown }; status?: number };
     if (axiosErr.response) {
-      (err as Record<string, unknown>).status = axiosErr.response.status;
-      (err as Record<string, unknown>).response = axiosErr.response.data;
+      err.status = axiosErr.response.status;
+      err.response = axiosErr.response.data;
     } else if (axiosErr.status) {
-      (err as Record<string, unknown>).status = axiosErr.status;
+      err.status = axiosErr.status;
     }
     throw err;
   }

--- a/apps/atomy-q/docs/ALPHA_RELEASE_CHECKLIST.md
+++ b/apps/atomy-q/docs/ALPHA_RELEASE_CHECKLIST.md
@@ -7,9 +7,22 @@
 
 ## Executive Status
 
-Alpha is **not release-ready** on this baseline. The current blockers are concentrated in WEB build/unit health and API alpha-matrix failures rather than missing infrastructure startup.
+Task 1 rectification is **green locally as of 2026-04-15**. The WEB lint/build/unit gates, API alpha matrix, and API full suite now pass after the rectification pass documented below.
 
-The strongest signal is that many alpha-critical backend flows pass independently: company registration, RFQ lifecycle, invitations, comparison, awards, vendor workflow, identity gap tests, normalization review, quote ingestion pipeline, and operational approvals all have passing coverage in the alpha matrix. The release gate is still blocked by specific regressions that must be fixed before staging smoke can be meaningful.
+The original baseline captured in this document was **not release-ready**. Those failure details are retained as historical context underneath the current evidence.
+
+The strongest rectification signal is that the alpha-critical backend flows pass together in the matrix: company registration, RFQ lifecycle, invitations, comparison, awards, vendor workflow, identity gap tests, normalization review, quote ingestion pipeline, and operational approvals. Remaining non-Task-1 alpha work should continue from the broader release plan before staging smoke.
+
+## Latest Rectification Evidence - 2026-04-15
+
+- `cd apps/atomy-q/WEB && npm run lint`: PASS. Exit 0 with 7 existing warnings:
+  `negotiations/page.tsx` unused `SectionCard`, `overview/page.tsx` missing `comparison` dependency in `useMemo`, `rfqs/page.tsx` unused `_ids`, `settings/page.tsx` unused `Settings`, and unused `api` imports in `use-comparison-run-matrix.ts`, `use-quote-submission.ts`, and `use-rfq-counts.ts`.
+- `cd apps/atomy-q/WEB && npm run build`: PASS.
+- `cd apps/atomy-q/WEB && npm run test:unit`: PASS. 33 files, 87 tests.
+- `cd apps/atomy-q/API && php artisan test --filter "RegisterCompanyTest|AuthTest|RfqLifecycleMutationTest|RfqInvitationReminderTest|QuoteSubmissionWorkflowTest|QuoteIngestionPipelineTest|QuoteIngestionIntelligenceTest|NormalizationReviewWorkflowTest|ComparisonRunWorkflowTest|ComparisonSnapshotWorkflowTest|AwardWorkflowTest|VendorWorkflowTest|IdentityGap7Test|OperationalApprovalApiTest|ProjectAclTest"`: PASS. 93 tests, 522 assertions.
+- `cd apps/atomy-q/API && php artisan test`: PASS. 425 tests, 1131 assertions.
+
+## Historical Baseline Evidence
 
 ## Gate Summary
 

--- a/apps/atomy-q/docs/ALPHA_RELEASE_PLAN_2026-04-15.md
+++ b/apps/atomy-q/docs/ALPHA_RELEASE_PLAN_2026-04-15.md
@@ -133,6 +133,8 @@ After this task, stakeholders should have a simple release checklist showing whi
 **Files:**
 - Modify: `apps/atomy-q/docs/ALPHA_RELEASE_PLAN_2026-04-15.md`
 - Create: `apps/atomy-q/docs/ALPHA_RELEASE_CHECKLIST.md`
+- Follow-up spec: [`ALPHA_TASK1_RECTIFICATION_SPEC_2026-04-15.md`](./ALPHA_TASK1_RECTIFICATION_SPEC_2026-04-15.md)
+- Follow-up plan: [`ALPHA_TASK1_RECTIFICATION_IMPLEMENTATION_PLAN_2026-04-15.md`](./ALPHA_TASK1_RECTIFICATION_IMPLEMENTATION_PLAN_2026-04-15.md)
 
 - [x] Run WEB gates: `cd apps/atomy-q/WEB && npm run lint && npm run build && npm run test:unit`.
 - [x] Run API gates: `cd apps/atomy-q/API && php artisan test`.

--- a/apps/atomy-q/docs/ALPHA_TASK1_RECTIFICATION_IMPLEMENTATION_PLAN_2026-04-15.md
+++ b/apps/atomy-q/docs/ALPHA_TASK1_RECTIFICATION_IMPLEMENTATION_PLAN_2026-04-15.md
@@ -1,0 +1,519 @@
+# Alpha Task 1 Rectification Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the Task 1 baseline failures so Atomy-Q has green WEB and API alpha release evidence before proceeding to Task 2.
+
+**Architecture:** This is a narrow rectification pass. WEB fixes stay in hooks/page components and preserve live-mode fail-loud behavior. API fixes stay in Laravel adapters/controllers/models/tests and preserve tenant-scoped behavior, with no Layer 1 or Layer 2 framework coupling changes.
+
+**Tech Stack:** Laravel API, PHPUnit, Next.js App Router, TypeScript, TanStack Query, Vitest.
+
+---
+
+## File Structure
+
+- Modify `apps/atomy-q/WEB/src/lib/api-live.ts`: make live error metadata assignment type-safe.
+- Modify `apps/atomy-q/WEB/src/hooks/use-award.ts`: expose award creation mutation if it is not already present on the current branch.
+- Modify `apps/atomy-q/WEB/src/app/(dashboard)/rfqs/[rfqId]/award/page.tsx`: render no-award creation UI using final frozen comparison runs and vendors.
+- Modify `apps/atomy-q/WEB/src/app/(dashboard)/rfqs/[rfqId]/award/page.test.tsx`: keep the no-award creation assertion and add click/mutation coverage if missing.
+- Modify `apps/atomy-q/API/app/Contracts/MfaChallengeStoreInterface.php`: add a challenge lookup method that does not require client-supplied tenant ID.
+- Modify `apps/atomy-q/API/app/Services/Identity/AtomyMfaChallengeStore.php`: implement the lookup method with an ID-only query.
+- Modify `apps/atomy-q/API/app/Http/Controllers/Api/V1/AuthController.php`: make `tenant_id` optional for MFA verify and use stored challenge tenant for all downstream operations.
+- Modify `apps/atomy-q/API/tests/Feature/Api/AuthTest.php`: assert MFA verify works without `tenant_id` and rejects a mismatched optional `tenant_id` generically.
+- Modify `apps/atomy-q/API/tests/Feature/QuoteSubmissionWorkflowTest.php`: add RFQ line-item fixture data to the upload happy path and keep failure behavior explicit.
+- Modify `apps/atomy-q/API/app/Models/Award.php`: add the expected `creator()` relation mapped to the current schema.
+- Modify `apps/atomy-q/API/tests/Unit/Services/SourcingOperationsAdaptersTest.php`: add nullable `project_id` to the in-memory RFQ schema.
+- Modify `apps/atomy-q/docs/ALPHA_RELEASE_CHECKLIST.md`: replace Task 1 failure evidence after verification.
+- Modify package/app `IMPLEMENTATION_SUMMARY.md` files only where code behavior changes need documentation.
+
+## Task 1: Fix WEB Build Error Metadata Typing
+
+**Files:**
+- Modify: `apps/atomy-q/WEB/src/lib/api-live.ts`
+
+- [ ] **Step 1: Run the failing build gate**
+
+Run:
+```bash
+cd apps/atomy-q/WEB && npm run build
+```
+
+Expected before the fix: TypeScript fails at `src/lib/api-live.ts` because `Error` is cast directly to `Record<string, unknown>`.
+
+- [ ] **Step 2: Replace unsafe error metadata casts**
+
+In `apps/atomy-q/WEB/src/lib/api-live.ts`, use a local decorated error type around the existing error object:
+
+```ts
+type LiveApiError = Error & {
+  status?: number;
+  response?: unknown;
+};
+
+const err: LiveApiError = new Error(`Failed to load ${endpoint}: ${message}`);
+if (e instanceof Error) {
+  err.cause = e;
+}
+const axiosErr = e as { response?: { status?: number; data?: unknown }; status?: number };
+if (axiosErr.response) {
+  err.status = axiosErr.response.status;
+  err.response = axiosErr.response.data;
+} else if (axiosErr.status) {
+  err.status = axiosErr.status;
+}
+throw err;
+```
+
+Keep the existing endpoint/message behavior unchanged.
+
+- [ ] **Step 3: Verify the build gate moves past this failure**
+
+Run:
+```bash
+cd apps/atomy-q/WEB && npm run build
+```
+
+Expected after this task: the previous `api-live.ts` type error is gone. If the build exposes a later unrelated error, record it in the checklist and continue with the remaining rectification tasks.
+
+## Task 2: Restore Award Creation Empty State
+
+**Files:**
+- Modify: `apps/atomy-q/WEB/src/hooks/use-award.ts`
+- Modify: `apps/atomy-q/WEB/src/app/(dashboard)/rfqs/[rfqId]/award/page.tsx`
+- Modify: `apps/atomy-q/WEB/src/app/(dashboard)/rfqs/[rfqId]/award/page.test.tsx`
+
+- [ ] **Step 1: Run the focused failing unit test**
+
+Run:
+```bash
+cd apps/atomy-q/WEB && npx vitest run 'src/app/(dashboard)/rfqs/[rfqId]/award/page.test.tsx'
+```
+
+Expected before the fix: `shows award creation UI when no award exists` fails because the page renders passive empty-state text instead of `Select a vendor...` and `Create Award`.
+
+- [ ] **Step 2: Ensure `useAward` exposes a create mutation**
+
+If `useAward` does not already return `store`, add it in `apps/atomy-q/WEB/src/hooks/use-award.ts`:
+
+```ts
+const store = useMutation({
+  mutationFn: async (input: { rfqId: string; comparisonRunId: string; vendorId: string }) => {
+    const { data } = await api.post('/awards', {
+      rfq_id: input.rfqId,
+      comparison_run_id: input.comparisonRunId,
+      vendor_id: input.vendorId,
+    });
+    return data;
+  },
+  onSuccess: () => {
+    qc.invalidateQueries({ queryKey: ['awards', rfqId] });
+  },
+});
+```
+
+Return `store` with `award`, `awards`, `signoff`, and `debrief`.
+
+- [ ] **Step 3: Use comparison runs and vendors in the award page**
+
+In `apps/atomy-q/WEB/src/app/(dashboard)/rfqs/[rfqId]/award/page.tsx`, import the hooks:
+
+```ts
+import { useComparisonRuns } from '@/hooks/use-comparison-runs';
+import { useRfqVendors } from '@/hooks/use-rfq-vendors';
+```
+
+Inside `RfqAwardPageContent`, derive the creation state:
+
+```ts
+const { award, debrief, signoff, store } = useAward(rfqId);
+const { data: comparisonRuns = [] } = useComparisonRuns(rfqId);
+const { data: vendors = [] } = useRfqVendors(rfqId);
+const finalRun = comparisonRuns.find((run) => run.type === 'final' && ['frozen', 'final', 'completed'].includes(run.status));
+const awardCandidates = vendors.filter((vendor) => vendor.vendor_id !== null && vendor.vendor_id.trim() !== '');
+const [selectedVendorId, setSelectedVendorId] = React.useState('');
+
+React.useEffect(() => {
+  if (selectedVendorId === '' && awardCandidates[0]?.vendor_id) {
+    setSelectedVendorId(awardCandidates[0].vendor_id);
+  }
+}, [awardCandidates, selectedVendorId]);
+```
+
+- [ ] **Step 4: Render the no-award creation panel**
+
+When `displayAward` is null and `finalRun` exists, render concise guidance and a create action near the recommended winner card:
+
+```tsx
+{!displayAward && finalRun ? (
+  <SectionCard title="Create award">
+    <div className="space-y-3">
+      <p className="text-sm text-slate-600">
+        Select a vendor to award the contract based on the final comparison run.
+      </p>
+      <label className="block space-y-1">
+        <span className="text-xs font-medium text-slate-600">Award vendor</span>
+        <select
+          className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-800 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+          value={selectedVendorId}
+          onChange={(event) => setSelectedVendorId(event.target.value)}
+        >
+          {awardCandidates.map((vendor) => (
+            <option key={vendor.id} value={vendor.vendor_id ?? ''}>
+              {vendor.name}
+            </option>
+          ))}
+        </select>
+      </label>
+      <Button
+        size="sm"
+        variant="primary"
+        disabled={selectedVendorId === '' || store.isPending || useMocks}
+        onClick={() => {
+          if (finalRun && selectedVendorId !== '') {
+            store.mutate({ rfqId, comparisonRunId: finalRun.id, vendorId: selectedVendorId });
+          }
+        }}
+      >
+        Create Award
+      </Button>
+    </div>
+  </SectionCard>
+) : null}
+```
+
+If no final run exists, keep the current `Freeze a comparison run to create an award record.` guidance.
+
+- [ ] **Step 5: Add mutation assertion to the page test**
+
+In `page.test.tsx`, store the mocked mutation in a variable and assert the click payload:
+
+```ts
+const storeMutate = vi.fn();
+vi.mocked(useAward).mockReturnValue({
+  award: null,
+  awards: [],
+  signoff: { mutate: vi.fn(), isPending: false, isError: false },
+  debrief: { mutate: vi.fn(), isPending: false, isError: false },
+  store: { mutate: storeMutate, isPending: false, isError: false },
+} as unknown as UseAwardReturn);
+
+renderWithProviders(<RfqAwardPageContent rfqId="rfq-1" />);
+
+fireEvent.click(await screen.findByRole('button', { name: /create award/i }));
+expect(storeMutate).toHaveBeenCalledWith({ rfqId: 'rfq-1', comparisonRunId: 'run-1', vendorId: 'vendor-1' });
+```
+
+- [ ] **Step 6: Verify WEB unit tests**
+
+Run:
+```bash
+cd apps/atomy-q/WEB && npm run test:unit
+```
+
+Expected: all Vitest tests pass.
+
+## Task 3: Fix MFA Verify Tenant Contract
+
+**Files:**
+- Modify: `apps/atomy-q/API/app/Contracts/MfaChallengeStoreInterface.php`
+- Modify: `apps/atomy-q/API/app/Services/Identity/AtomyMfaChallengeStore.php`
+- Modify: `apps/atomy-q/API/app/Http/Controllers/Api/V1/AuthController.php`
+- Modify: `apps/atomy-q/API/tests/Feature/Api/AuthTest.php`
+
+- [ ] **Step 1: Run the focused failing test**
+
+Run:
+```bash
+cd apps/atomy-q/API && php artisan test --filter AuthTest::test_mfa_verify_endpoint_returns_message_and_verified
+```
+
+Expected before the fix: response status is 422 because `tenant_id` is required.
+
+- [ ] **Step 2: Add ID-only challenge lookup to the interface**
+
+Add to `MfaChallengeStoreInterface`:
+
+```php
+public function findByChallengeId(string $challengeId): ?MfaChallenge;
+```
+
+- [ ] **Step 3: Implement the lookup in `AtomyMfaChallengeStore`**
+
+Add:
+
+```php
+public function findByChallengeId(string $challengeId): ?MfaChallenge
+{
+    return MfaChallenge::query()
+        ->whereKey($challengeId)
+        ->first();
+}
+```
+
+Do not remove the existing tenant-scoped `find`, `consume`, or `incrementAttempts` methods.
+
+- [ ] **Step 4: Make `tenant_id` optional in controller validation**
+
+In `AuthController::mfaVerify`, change validation to:
+
+```php
+$validator = Validator::make($request->all(), [
+    'challenge_id' => ['required', 'string'],
+    'tenant_id' => ['sometimes', 'string'],
+    'otp' => ['required', 'string'],
+]);
+```
+
+Load the challenge before choosing tenant context:
+
+```php
+$challengeId = (string) $request->input('challenge_id');
+$otp = trim((string) $request->input('otp'));
+$suppliedTenantId = $request->input('tenant_id');
+
+$challenge = $this->mfaChallenges->findByChallengeId($challengeId);
+$tenantId = $challenge !== null ? (string) $challenge->tenant_id : '';
+
+if (is_string($suppliedTenantId) && trim($suppliedTenantId) !== '' && $tenantId !== '' && trim($suppliedTenantId) !== $tenantId) {
+    $challenge = null;
+}
+```
+
+Keep the existing invalid/expired challenge response. All later calls to `incrementAttempts`, `consume`, audit context, and `completeMfaLogin` must use `$tenantId` derived from the stored challenge.
+
+- [ ] **Step 5: Add mismatch coverage**
+
+In `AuthTest`, add a test that submits a valid challenge with a different `tenant_id` and expects a generic failure:
+
+```php
+public function test_mfa_verify_rejects_mismatched_optional_tenant_id(): void
+{
+    $user = $this->createTestUser(['mfa_enabled' => true]);
+
+    $challengeResponse = $this->postJson('/api/v1/auth/login', [
+        'email' => $user['email'],
+        'password' => $user['password'],
+    ]);
+
+    $challengeResponse->assertStatus(401);
+    $challengeId = (string) $challengeResponse->json('challenge_id');
+
+    $this->postJson('/api/v1/auth/mfa/verify', [
+        'challenge_id' => $challengeId,
+        'tenant_id' => 'wrong-tenant',
+        'otp' => '123456',
+    ])->assertStatus(401)
+        ->assertJsonPath('message', 'Invalid or expired MFA challenge');
+}
+```
+
+- [ ] **Step 6: Verify focused and matrix tests**
+
+Run:
+```bash
+cd apps/atomy-q/API && php artisan test --filter AuthTest
+```
+
+Expected: Auth feature tests pass.
+
+## Task 4: Fix Quote Upload Happy-Path Fixture
+
+**Files:**
+- Modify: `apps/atomy-q/API/tests/Feature/QuoteSubmissionWorkflowTest.php`
+
+- [ ] **Step 1: Run the focused failing test**
+
+Run:
+```bash
+cd apps/atomy-q/API && php artisan test --filter QuoteSubmissionWorkflowTest::test_quote_submission_upload_persists_uploaded_state_and_tenant_id
+```
+
+Expected before the fix: response status is created, but `data.status` is `failed` instead of `ready`.
+
+- [ ] **Step 2: Add at least one RFQ line item to the test fixture**
+
+After creating the RFQ in `test_quote_submission_upload_persists_uploaded_state_and_tenant_id`, create a matching line item:
+
+```php
+RfqLineItem::query()->create([
+    'tenant_id' => $user->tenant_id,
+    'rfq_id' => $rfq->id,
+    'line_number' => 1,
+    'description' => 'Pump seal kit',
+    'quantity' => 2,
+    'uom' => 'EA',
+    'estimated_unit_price' => 100,
+    'currency' => 'USD',
+    'sort_order' => 1,
+]);
+```
+
+Add `use App\Models\RfqLineItem;` if it is not already imported.
+
+- [ ] **Step 3: Keep the ready assertions**
+
+Do not weaken these assertions:
+
+```php
+$response->assertCreated();
+$response->assertJsonPath('data.status', 'ready');
+$response->assertJsonPath('data.blocking_issue_count', 0);
+```
+
+The fixture should now satisfy the mock processor and prove the alpha upload happy path.
+
+- [ ] **Step 4: Verify quote workflow tests**
+
+Run:
+```bash
+cd apps/atomy-q/API && php artisan test --filter QuoteSubmissionWorkflowTest
+```
+
+Expected: all quote submission workflow tests pass.
+
+## Task 5: Fix Award Relation Drift
+
+**Files:**
+- Modify: `apps/atomy-q/API/app/Models/Award.php`
+
+- [ ] **Step 1: Run the focused relation failure**
+
+Run:
+```bash
+cd apps/atomy-q/API && php artisan test --filter ModelRelationsTest
+```
+
+Expected before the fix: `Call to undefined method App\Models\Award::creator()`.
+
+- [ ] **Step 2: Add `creator()` relation to `Award`**
+
+In `Award.php`, add:
+
+```php
+/**
+ * @return BelongsTo<User, $this>
+ */
+public function creator(): BelongsTo
+{
+    return $this->belongsTo(User::class, 'signed_off_by');
+}
+```
+
+Keep `signedOffByUser()` unchanged for existing call sites.
+
+- [ ] **Step 3: Verify model relations**
+
+Run:
+```bash
+cd apps/atomy-q/API && php artisan test --filter ModelRelationsTest
+```
+
+Expected: model relation tests pass.
+
+## Task 6: Fix Sourcing Adapter Test Schema Drift
+
+**Files:**
+- Modify: `apps/atomy-q/API/tests/Unit/Services/SourcingOperationsAdaptersTest.php`
+
+- [ ] **Step 1: Run the focused adapter tests**
+
+Run:
+```bash
+cd apps/atomy-q/API && php artisan test --filter SourcingOperationsAdaptersTest
+```
+
+Expected before the fix: duplicate RFQ tests fail with SQLite missing `rfqs.project_id`.
+
+- [ ] **Step 2: Add `project_id` to the in-memory schema**
+
+Inside the `Schema::create('rfqs', ...)` callback, add this after `tenant_id`:
+
+```php
+$table->ulid('project_id')->nullable()->index();
+```
+
+This mirrors the production RFQ schema and lets `AtomyRfqLifecyclePersist::createDuplicate()` copy source project context.
+
+- [ ] **Step 3: Verify adapter tests**
+
+Run:
+```bash
+cd apps/atomy-q/API && php artisan test --filter SourcingOperationsAdaptersTest
+```
+
+Expected: adapter tests pass, including numeric suffix and duplicate exception behavior.
+
+## Task 7: Run Release Gates And Update Evidence
+
+**Files:**
+- Modify: `apps/atomy-q/docs/ALPHA_RELEASE_CHECKLIST.md`
+- Modify: relevant `IMPLEMENTATION_SUMMARY.md` files only if behavior changed and the package/app already tracks that behavior.
+
+- [ ] **Step 1: Run WEB lint**
+
+Run:
+```bash
+cd apps/atomy-q/WEB && npm run lint
+```
+
+Expected: exit 0. Existing warnings may remain only if they are non-blocking and documented.
+
+- [ ] **Step 2: Run WEB build**
+
+Run:
+```bash
+cd apps/atomy-q/WEB && npm run build
+```
+
+Expected: exit 0.
+
+- [ ] **Step 3: Run WEB unit tests**
+
+Run:
+```bash
+cd apps/atomy-q/WEB && npm run test:unit
+```
+
+Expected: exit 0.
+
+- [ ] **Step 4: Run API alpha matrix**
+
+Run:
+```bash
+cd apps/atomy-q/API && php artisan test --filter "RegisterCompanyTest|AuthTest|RfqLifecycleMutationTest|RfqInvitationReminderTest|QuoteSubmissionWorkflowTest|QuoteIngestionPipelineTest|QuoteIngestionIntelligenceTest|NormalizationReviewWorkflowTest|ComparisonRunWorkflowTest|ComparisonSnapshotWorkflowTest|AwardWorkflowTest|VendorWorkflowTest|IdentityGap7Test|OperationalApprovalApiTest|ProjectAclTest"
+```
+
+Expected: exit 0.
+
+- [ ] **Step 5: Run API full suite**
+
+Run:
+```bash
+cd apps/atomy-q/API && php artisan test
+```
+
+Expected: exit 0. If an unrelated failure appears, record exact class, test, status, and why it is unrelated before deciding whether Task 1 can remain closed.
+
+- [ ] **Step 6: Update checklist evidence**
+
+Update `apps/atomy-q/docs/ALPHA_RELEASE_CHECKLIST.md` with:
+
+```md
+### Latest Rectification Evidence - 2026-04-15
+
+- `cd apps/atomy-q/WEB && npm run lint`: PASS, with any remaining warnings listed.
+- `cd apps/atomy-q/WEB && npm run build`: PASS.
+- `cd apps/atomy-q/WEB && npm run test:unit`: PASS.
+- `cd apps/atomy-q/API && php artisan test --filter "...alpha matrix..."`: PASS.
+- `cd apps/atomy-q/API && php artisan test`: PASS or documented residual risk.
+```
+
+Do not delete the original baseline failure evidence; keep it as historical context and append the rectification evidence above or below it.
+
+## Self-Review Checklist
+
+- Every failure from `ALPHA_RELEASE_CHECKLIST.md` has a corresponding implementation task.
+- No task disables or weakens an alpha gate.
+- MFA tenant behavior resolves from stored challenge state and avoids cross-tenant existence leaks.
+- WEB award creation does not fabricate live-mode data.
+- Quote upload happy path uses a valid RFQ line-item fixture instead of treating no extracted lines as ready.

--- a/apps/atomy-q/docs/ALPHA_TASK1_RECTIFICATION_IMPLEMENTATION_PLAN_2026-04-15.md
+++ b/apps/atomy-q/docs/ALPHA_TASK1_RECTIFICATION_IMPLEMENTATION_PLAN_2026-04-15.md
@@ -24,7 +24,7 @@
 - Modify `apps/atomy-q/API/app/Models/Award.php`: add the expected `creator()` relation mapped to the current schema.
 - Modify `apps/atomy-q/API/tests/Unit/Services/SourcingOperationsAdaptersTest.php`: add nullable `project_id` to the in-memory RFQ schema.
 - Modify `apps/atomy-q/docs/ALPHA_RELEASE_CHECKLIST.md`: replace Task 1 failure evidence after verification.
-- Modify package/app `IMPLEMENTATION_SUMMARY.md` files only where code behavior changes need documentation.
+- Update the affected package/app `IMPLEMENTATION_SUMMARY.md` after every code change in that package/app.
 
 ## Task 1: Fix WEB Build Error Metadata Typing
 
@@ -34,6 +34,7 @@
 - [ ] **Step 1: Run the failing build gate**
 
 Run:
+
 ```bash
 cd apps/atomy-q/WEB && npm run build
 ```
@@ -69,6 +70,7 @@ Keep the existing endpoint/message behavior unchanged.
 - [ ] **Step 3: Verify the build gate moves past this failure**
 
 Run:
+
 ```bash
 cd apps/atomy-q/WEB && npm run build
 ```
@@ -85,6 +87,7 @@ Expected after this task: the previous `api-live.ts` type error is gone. If the 
 - [ ] **Step 1: Run the focused failing unit test**
 
 Run:
+
 ```bash
 cd apps/atomy-q/WEB && npx vitest run 'src/app/(dashboard)/rfqs/[rfqId]/award/page.test.tsx'
 ```
@@ -206,6 +209,7 @@ expect(storeMutate).toHaveBeenCalledWith({ rfqId: 'rfq-1', comparisonRunId: 'run
 - [ ] **Step 6: Verify WEB unit tests**
 
 Run:
+
 ```bash
 cd apps/atomy-q/WEB && npm run test:unit
 ```
@@ -223,6 +227,7 @@ Expected: all Vitest tests pass.
 - [ ] **Step 1: Run the focused failing test**
 
 Run:
+
 ```bash
 cd apps/atomy-q/API && php artisan test --filter AuthTest::test_mfa_verify_endpoint_returns_message_and_verified
 ```
@@ -310,6 +315,7 @@ public function test_mfa_verify_rejects_mismatched_optional_tenant_id(): void
 - [ ] **Step 6: Verify focused and matrix tests**
 
 Run:
+
 ```bash
 cd apps/atomy-q/API && php artisan test --filter AuthTest
 ```
@@ -324,6 +330,7 @@ Expected: Auth feature tests pass.
 - [ ] **Step 1: Run the focused failing test**
 
 Run:
+
 ```bash
 cd apps/atomy-q/API && php artisan test --filter QuoteSubmissionWorkflowTest::test_quote_submission_upload_persists_uploaded_state_and_tenant_id
 ```
@@ -365,6 +372,7 @@ The fixture should now satisfy the mock processor and prove the alpha upload hap
 - [ ] **Step 4: Verify quote workflow tests**
 
 Run:
+
 ```bash
 cd apps/atomy-q/API && php artisan test --filter QuoteSubmissionWorkflowTest
 ```
@@ -379,6 +387,7 @@ Expected: all quote submission workflow tests pass.
 - [ ] **Step 1: Run the focused relation failure**
 
 Run:
+
 ```bash
 cd apps/atomy-q/API && php artisan test --filter ModelRelationsTest
 ```
@@ -404,6 +413,7 @@ Keep `signedOffByUser()` unchanged for existing call sites.
 - [ ] **Step 3: Verify model relations**
 
 Run:
+
 ```bash
 cd apps/atomy-q/API && php artisan test --filter ModelRelationsTest
 ```
@@ -418,6 +428,7 @@ Expected: model relation tests pass.
 - [ ] **Step 1: Run the focused adapter tests**
 
 Run:
+
 ```bash
 cd apps/atomy-q/API && php artisan test --filter SourcingOperationsAdaptersTest
 ```
@@ -437,6 +448,7 @@ This mirrors the production RFQ schema and lets `AtomyRfqLifecyclePersist::creat
 - [ ] **Step 3: Verify adapter tests**
 
 Run:
+
 ```bash
 cd apps/atomy-q/API && php artisan test --filter SourcingOperationsAdaptersTest
 ```
@@ -452,6 +464,7 @@ Expected: adapter tests pass, including numeric suffix and duplicate exception b
 - [ ] **Step 1: Run WEB lint**
 
 Run:
+
 ```bash
 cd apps/atomy-q/WEB && npm run lint
 ```
@@ -461,6 +474,7 @@ Expected: exit 0. Existing warnings may remain only if they are non-blocking and
 - [ ] **Step 2: Run WEB build**
 
 Run:
+
 ```bash
 cd apps/atomy-q/WEB && npm run build
 ```
@@ -470,6 +484,7 @@ Expected: exit 0.
 - [ ] **Step 3: Run WEB unit tests**
 
 Run:
+
 ```bash
 cd apps/atomy-q/WEB && npm run test:unit
 ```
@@ -479,6 +494,7 @@ Expected: exit 0.
 - [ ] **Step 4: Run API alpha matrix**
 
 Run:
+
 ```bash
 cd apps/atomy-q/API && php artisan test --filter "RegisterCompanyTest|AuthTest|RfqLifecycleMutationTest|RfqInvitationReminderTest|QuoteSubmissionWorkflowTest|QuoteIngestionPipelineTest|QuoteIngestionIntelligenceTest|NormalizationReviewWorkflowTest|ComparisonRunWorkflowTest|ComparisonSnapshotWorkflowTest|AwardWorkflowTest|VendorWorkflowTest|IdentityGap7Test|OperationalApprovalApiTest|ProjectAclTest"
 ```
@@ -488,6 +504,7 @@ Expected: exit 0.
 - [ ] **Step 5: Run API full suite**
 
 Run:
+
 ```bash
 cd apps/atomy-q/API && php artisan test
 ```

--- a/apps/atomy-q/docs/ALPHA_TASK1_RECTIFICATION_SPEC_2026-04-15.md
+++ b/apps/atomy-q/docs/ALPHA_TASK1_RECTIFICATION_SPEC_2026-04-15.md
@@ -1,0 +1,88 @@
+# Alpha Task 1 Rectification Spec
+
+**Date:** 2026-04-15  
+**Source:** Task 1 release evidence baseline in `apps/atomy-q/docs/ALPHA_RELEASE_CHECKLIST.md`  
+**Status:** Ready for implementation planning
+
+## 1. Purpose
+
+Task 1 established the alpha release evidence baseline and exposed several gaps that must be rectified before Atomy-Q can move to downstream alpha tasks with reliable release evidence. This spec defines the intended behavior for those rectifications so the team fixes the release blockers rather than only adjusting tests.
+
+The goal is to make the baseline gates green while preserving the alpha scope: tenant registration/login, RFQ creation, quote upload and ingestion, normalization, comparison finalization, award creation/signoff, vendor follow-up, project ACL, operational approvals, and minimal identity operations.
+
+## 2. Current Gaps
+
+| Area | Gate | Observed failure | Required outcome |
+|---|---|---|---|
+| WEB live API helper | `npm run build` | TypeScript rejects direct conversion of `Error` to `Record<string, unknown>` in `src/lib/api-live.ts`. | Build passes with a type-safe error decoration pattern. |
+| WEB award page | `npm run test:unit` | Award empty-state test expects award creation UI, but the page only renders passive empty state text. | No-award state offers a clear Create Award path when a final frozen comparison run exists. |
+| API MFA verify | API alpha matrix and full suite | `POST /auth/mfa/verify` returns 422 unless the client submits `tenant_id`. | MFA verify resolves tenant context from the challenge and accepts the login response contract already used by the test/client. |
+| API quote upload | API alpha matrix and full suite | Upload test receives `failed` instead of `ready` because the test RFQ has no line items for the mock ingestion processor to extract. | A valid quote-upload fixture produces ready status with zero blocking issues; malformed/no-line RFQs remain a controlled failure path. |
+| API model relations | API full suite | `Award::creator()` is missing while relation coverage expects it. | Award exposes the expected creator relation without changing signoff semantics. |
+| API sourcing adapter tests | API full suite | In-memory `rfqs` schema omits `project_id`, so duplicate RFQ adapter tests fail before reaching the behavior under test. | Test schema mirrors current RFQ persistence columns needed by the adapter. |
+
+## 3. Rectification Strategy
+
+Use the smallest production-aligned fixes that restore release evidence. The rectification should not hide failures by weakening assertions, disabling tests, or adding mock-only branches that differ from live behavior.
+
+For WEB, the changes should make strict TypeScript and unit tests reflect intended user behavior. The live API helper should continue to throw rich errors in live mode. The award page should use the already-existing comparison-run and vendor hooks to present a creation action only when there is enough data to create an award.
+
+For API, fixes should respect tenant isolation and the current three-layer boundary expectations. The MFA verify endpoint should not require the browser to echo tenant context after login has already created a tenant-scoped challenge. Quote upload should use a valid ingestion fixture to prove the happy path, while preserving a deterministic failure path for invalid input. Full-suite failures caused by model/schema drift should be corrected in the model or test fixture rather than ignored.
+
+## 4. Intended Behavior
+
+### 4.1 WEB Live API Error Decoration
+
+`fetchLiveOrFail` must preserve response status and response payload on thrown errors without unsafe TypeScript casts. The implementation may introduce a narrow local type such as `Error & { status?: number; response?: unknown }` and assign through that type.
+
+Completion means `npm run build` no longer fails at `src/lib/api-live.ts`, and error consumers still have access to `status` and `response` when Axios provides them.
+
+### 4.2 WEB Award Creation Empty State
+
+When an RFQ has no award record and at least one final frozen comparison run exists, the award page must show concise creation guidance and a `Create Award` action. The guidance should explain that the user must select a vendor based on the final comparison run. The action should call the existing award creation mutation and should be disabled while pending or when mock mode is enabled.
+
+If no final frozen comparison run exists, the page should keep the current guidance that the user must freeze a comparison run before creating an award. The page must not fabricate award data in live mode.
+
+### 4.3 Award Creation Data Source
+
+The award creation UI should derive candidate vendors from the RFQ vendor roster first and may fall back to vendor IDs in the final comparison snapshot if the roster is unavailable. The payload sent to the API must include the RFQ ID, selected final comparison run ID, and selected vendor ID. The page should keep existing signoff and debrief behavior after an award exists.
+
+### 4.4 MFA Verification Contract
+
+`POST /api/v1/auth/mfa/verify` must accept `challenge_id` and `otp` as required fields. `tenant_id` may be accepted as optional compatibility input, but the server must resolve the authoritative tenant from the stored MFA challenge.
+
+If a supplied `tenant_id` does not match the stored challenge tenant, the endpoint must return the same generic invalid-challenge response used for invalid or expired challenges. It must not reveal whether the challenge exists in another tenant. All challenge consume/increment operations must continue to use the stored tenant ID.
+
+### 4.5 Quote Upload Ingestion Fixture
+
+The quote upload happy-path test must create an RFQ with at least one line item because the current mock content processor intentionally extracts lines from RFQ line items, not from arbitrary text file content. With a valid line-item fixture, synchronous testing-mode processing should produce normalized source lines, zero blocking issues, and final `ready` status.
+
+A separate negative assertion should remain or be added to show that an upload without extractable RFQ line context does not masquerade as ready. That protects the alpha flow from false readiness.
+
+### 4.6 Award Creator Relation
+
+`Award` should expose the relation expected by model relation coverage. Because the current awards table stores `signed_off_by` rather than `created_by`, `creator()` should map to the user who signed off the award unless the schema is later extended with a distinct creator column. This keeps the relation compatible with the current schema and does not alter the existing `signedOffByUser()` relation.
+
+If product later needs separate award creator versus signoff actor semantics, that belongs in a post-alpha schema change and OpenAPI/client update, not this rectification pass.
+
+### 4.7 Sourcing Adapter Test Schema Drift
+
+`SourcingOperationsAdaptersTest` must keep its in-memory RFQ schema aligned with the adapter fields it exercises. The schema must include nullable `project_id` because `AtomyRfqLifecyclePersist::createDuplicate()` copies that field from the source RFQ.
+
+The duplicate-number tests must then reach their intended assertions: highest numeric suffix selection and domain exception wrapping after persistent duplicate-number failures.
+
+## 5. Non-Goals
+
+- Do not broaden alpha scope beyond the Task 1 failures.
+- Do not replace the quote intelligence mock binding; that remains Task 2.
+- Do not regenerate the OpenAPI contract unless a rectification changes API shape beyond validation optionality.
+- Do not archive or move the active alpha plan or checklist.
+- Do not add synthetic live-mode fallbacks in WEB hooks.
+
+## 6. Acceptance Criteria
+
+- `cd apps/atomy-q/WEB && npm run build` passes.
+- `cd apps/atomy-q/WEB && npm run test:unit` passes.
+- `cd apps/atomy-q/API && php artisan test --filter "RegisterCompanyTest|AuthTest|RfqLifecycleMutationTest|RfqInvitationReminderTest|QuoteSubmissionWorkflowTest|QuoteIngestionPipelineTest|QuoteIngestionIntelligenceTest|NormalizationReviewWorkflowTest|ComparisonRunWorkflowTest|ComparisonSnapshotWorkflowTest|AwardWorkflowTest|VendorWorkflowTest|IdentityGap7Test|OperationalApprovalApiTest|ProjectAclTest"` passes.
+- `cd apps/atomy-q/API && php artisan test` passes or has only explicitly documented unrelated failures.
+- `apps/atomy-q/docs/ALPHA_RELEASE_CHECKLIST.md` is updated with new evidence after the rectification is implemented.

--- a/apps/atomy-q/docs/ALPHA_TASK1_RECTIFICATION_SPEC_2026-04-15.md
+++ b/apps/atomy-q/docs/ALPHA_TASK1_RECTIFICATION_SPEC_2026-04-15.md
@@ -84,5 +84,16 @@ The duplicate-number tests must then reach their intended assertions: highest nu
 - `cd apps/atomy-q/WEB && npm run build` passes.
 - `cd apps/atomy-q/WEB && npm run test:unit` passes.
 - `cd apps/atomy-q/API && php artisan test --filter "RegisterCompanyTest|AuthTest|RfqLifecycleMutationTest|RfqInvitationReminderTest|QuoteSubmissionWorkflowTest|QuoteIngestionPipelineTest|QuoteIngestionIntelligenceTest|NormalizationReviewWorkflowTest|ComparisonRunWorkflowTest|ComparisonSnapshotWorkflowTest|AwardWorkflowTest|VendorWorkflowTest|IdentityGap7Test|OperationalApprovalApiTest|ProjectAclTest"` passes.
-- `cd apps/atomy-q/API && php artisan test` passes or has only explicitly documented unrelated failures.
+- `cd apps/atomy-q/API && php artisan test` passes with zero failures.
 - `apps/atomy-q/docs/ALPHA_RELEASE_CHECKLIST.md` is updated with new evidence after the rectification is implemented.
+
+## 7. Risk Acceptance / Exceptions
+
+No tolerated exceptions are accepted for Task 1 rectification at spec time.
+
+If a future execution of `cd apps/atomy-q/API && php artisan test` encounters an unrelated failure that the release owner wants to tolerate, it must be documented here with:
+
+- exact failing command and test/class name
+- rationale for treating it as unrelated to Task 1 rectification
+- owner responsible for follow-up
+- mitigation plan and expected resolution timing


### PR DESCRIPTION
## Summary
- Fixes Task 1 WEB release blockers: type-safe live API error decoration and no-award creation UI wired to final comparison runs and RFQ vendors.
- Fixes Task 1 API release blockers: MFA verify tenant resolution, quote upload fixtures and no-line guard, Award creator relation, and sourcing adapter schema/duplicate exception drift.
- Updates alpha release evidence plus WEB/API implementation summaries with post-rectification verification counts.

## Root Cause
- The Task 1 baseline exposed drift between tests, UI behavior, and current API/model/test fixtures: unsafe TypeScript error decoration, passive award empty state, MFA verify requiring client-supplied tenant context, quote upload fixtures without RFQ lines, missing relation parity, and in-memory RFQ schema drift.

## CodeRabbit Review
- Ran `cr review --agent --type all` twice.
- Applied in-scope findings: explicit award select labelling, award mutation error display, redundant assertion cleanup, relation duplication cleanup with explicit relation names, scoped lookup when optional MFA tenant is supplied, ULID mismatch test input, award candidate memoization and empty state, and wording cleanup.
- Did not apply out-of-scope or incorrect suggestions that conflicted with the spec, such as adding `tenantId` to the award POST body; the API derives tenant scope from auth context.

## Test Plan
- [x] `cd apps/atomy-q/WEB && npm run lint` (PASS, exit 0 with 7 existing warnings documented)
- [x] `cd apps/atomy-q/WEB && npm run build` (PASS)
- [x] `cd apps/atomy-q/WEB && npm run test:unit` (PASS, 33 files / 87 tests)
- [x] `cd apps/atomy-q/API && php artisan test --filter "RegisterCompanyTest|AuthTest|RfqLifecycleMutationTest|RfqInvitationReminderTest|QuoteSubmissionWorkflowTest|QuoteIngestionPipelineTest|QuoteIngestionIntelligenceTest|NormalizationReviewWorkflowTest|ComparisonRunWorkflowTest|ComparisonSnapshotWorkflowTest|AwardWorkflowTest|VendorWorkflowTest|IdentityGap7Test|OperationalApprovalApiTest|ProjectAclTest"` (PASS, 93 tests / 522 assertions)
- [x] `cd apps/atomy-q/API && php artisan test` (PASS, 425 tests / 1131 assertions)
