### PR TITLE
Implement provider quote extraction e2e path

### DIFF
--- a/apps/atomy-q/API/.env.example
+++ b/apps/atomy-q/API/.env.example
@@ -126,6 +126,14 @@ AI_DOCUMENT_RETRY_ATTEMPTS=2
 AI_DOCUMENT_RETRY_BACKOFF_MS=500
 AI_DOCUMENT_MODEL_ID=
 AI_DOCUMENT_MODEL_REVISION=
+# Parser plugin for OpenRouter PDF/image document ingestion. Default `file-parser`.
+AI_DOCUMENT_PARSER_PLUGIN=file-parser
+# OCR engine for PDF parsing. Default `mistral-ocr`; update only when the provider supports another engine.
+AI_DOCUMENT_PDF_ENGINE=mistral-ocr
+# Max local document size loaded into provider payloads (bytes).
+AI_DOCUMENT_MAX_FILE_SIZE_BYTES=10485760
+# Optional JSON object for provider-specific currency aliases, e.g. {"RM":"MYR"}.
+AI_DOCUMENT_CURRENCY_MAPPINGS=
 
 # Normalization intelligence: mapping, taxonomy, UOM normalization, conflict hints.
 AI_NORMALIZATION_ENDPOINT=

--- a/apps/atomy-q/API/.env.example
+++ b/apps/atomy-q/API/.env.example
@@ -130,9 +130,15 @@ AI_DOCUMENT_MODEL_REVISION=
 AI_DOCUMENT_PARSER_PLUGIN=file-parser
 # OCR engine for PDF parsing. Default `mistral-ocr`; update only when the provider supports another engine.
 AI_DOCUMENT_PDF_ENGINE=mistral-ocr
-# Max local document size loaded into provider payloads (bytes).
+# Optional override for resolving the monorepo sample fixture root.
+AI_SAMPLE_PATH=
+# Max local document size loaded into provider payloads (bytes). This is intentionally lower than `ATOMY_MAX_UPLOAD_MB=50`
+# unless you raise it; uploads above this provider-side cap still store successfully but provider extraction will fail fast.
 AI_DOCUMENT_MAX_FILE_SIZE_BYTES=10485760
-# Optional JSON object for provider-specific currency aliases, e.g. {"RM":"MYR"}.
+# Optional JSON object for provider-specific currency aliases.
+# Example in `.env`: AI_DOCUMENT_CURRENCY_MAPPINGS='{"RM":"MYR","S$":"SGD"}'
+# POSIX shell example: export AI_DOCUMENT_CURRENCY_MAPPINGS='{"RM":"MYR","S$":"SGD"}'
+# Double-quoted shell example: export AI_DOCUMENT_CURRENCY_MAPPINGS="{\"RM\":\"MYR\",\"S$\":\"SGD\"}"
 AI_DOCUMENT_CURRENCY_MAPPINGS=
 
 # Normalization intelligence: mapping, taxonomy, UOM normalization, conflict hints.

--- a/apps/atomy-q/API/IMPLEMENTATION_SUMMARY.md
+++ b/apps/atomy-q/API/IMPLEMENTATION_SUMMARY.md
@@ -479,3 +479,12 @@ Quote intake persistence is now tenant-scoped for `upload`, `index`, and `show`:
 - Added shared provider adapter shell classes under `app/Adapters/Ai`: `ProviderAiTransport`, `ProviderDocumentIntelligenceClient`, and `ProviderNormalizationClient`. These centralize endpoint auth/timeout invocation without making network calls during feature tests.
 - Verification:
   - `cd apps/atomy-q/API && ./vendor/bin/phpunit tests/Feature/QuoteIngestionIntelligenceTest.php tests/Feature/QuoteIngestionPipelineTest.php tests/Feature/NormalizationReviewWorkflowTest.php` -> PASS (23 tests, 183 assertions).
+
+## 2026-04-25 Provider Quote Extraction Path
+
+- `AI_MODE=provider` now binds quote upload/reparse extraction through `ProviderQuoteContentProcessor` instead of allowing legacy `QUOTE_INTELLIGENCE_MODE` to override the alpha provider path.
+- Added `DocumentExtractionRequest`, `OpenRouterDocumentPayloadFactory`, and `OpenRouterDocumentExtractionMapper` so the document adapter can send stored quotation PDFs to OpenRouter chat completions with base64 `file_data`, `file-parser`, and `mistral-ocr`, then map JSON content back into the existing source-line contract.
+- The provider mapper now normalizes `RM` to `MYR` by default, and that currency alias table is configurable through `AI_DOCUMENT_CURRENCY_MAPPINGS` for other provider-specific abbreviations.
+- Quotation document storage-path resolution now uses the configured Laravel `local` disk root (`Storage::disk('local')->path(...)`) instead of assuming `storage/app`, which was breaking real PDF reads on the provider path. Existing files on the same `local` disk do not require re-upload or migration.
+- Added document parser and payload guard config/env surface: `AI_DOCUMENT_PARSER_PLUGIN`, `AI_DOCUMENT_PDF_ENGINE`, `AI_DOCUMENT_MAX_FILE_SIZE_BYTES`, and `AI_DOCUMENT_CURRENCY_MAPPINGS`.
+- Added provider extraction coverage in `ProviderQuoteExtractionTest` plus binding regression coverage in `QuoteIngestionPipelineTest`.

--- a/apps/atomy-q/API/IMPLEMENTATION_SUMMARY.md
+++ b/apps/atomy-q/API/IMPLEMENTATION_SUMMARY.md
@@ -488,3 +488,8 @@ Quote intake persistence is now tenant-scoped for `upload`, `index`, and `show`:
 - Quotation document storage-path resolution now uses the configured Laravel `local` disk root (`Storage::disk('local')->path(...)`) instead of assuming `storage/app`, which was breaking real PDF reads on the provider path. Existing files on the same `local` disk do not require re-upload or migration.
 - Added document parser and payload guard config/env surface: `AI_DOCUMENT_PARSER_PLUGIN`, `AI_DOCUMENT_PDF_ENGINE`, `AI_DOCUMENT_MAX_FILE_SIZE_BYTES`, and `AI_DOCUMENT_CURRENCY_MAPPINGS`.
 - Added provider extraction coverage in `ProviderQuoteExtractionTest` plus binding regression coverage in `QuoteIngestionPipelineTest`.
+
+## Verification
+
+- `cd apps/atomy-q/API && ./vendor/bin/phpunit tests/Feature/ProviderQuoteExtractionTest.php tests/Feature/QuoteIngestionPipelineTest.php`
+- `cd apps/atomy-q/API && ./vendor/bin/phpunit tests/Unit/Adapters/Ai/DocumentExtractionRequestTest.php tests/Unit/Adapters/Ai/OpenRouterDocumentPayloadFactoryTest.php tests/Unit/Adapters/Ai/OpenRouterDocumentExtractionMapperTest.php tests/Unit/Adapters/Ai/ProviderDocumentIntelligenceClientTest.php`

--- a/apps/atomy-q/API/app/Adapters/Ai/ConfiguredAiEndpointRegistry.php
+++ b/apps/atomy-q/API/app/Adapters/Ai/ConfiguredAiEndpointRegistry.php
@@ -121,6 +121,11 @@ final readonly class ConfiguredAiEndpointRegistry implements AiEndpointRegistryI
             return $healthUrl;
         }
 
+        $providerProbeUrl = $this->providerProbeUrl($endpointUri);
+        if ($providerProbeUrl !== null) {
+            return $providerProbeUrl;
+        }
+
         $healthPath = trim((string) ($endpoint['health_path'] ?? '/health'));
         if ($healthPath === '') {
             $healthPath = '/health';
@@ -138,9 +143,44 @@ final readonly class ConfiguredAiEndpointRegistry implements AiEndpointRegistryI
      */
     private function resolveProbeMethod(array $endpoint): string
     {
+        if (trim((string) ($endpoint['health_url'] ?? '')) === '') {
+            $providerProbeMethod = $this->providerProbeMethod();
+            if ($providerProbeMethod !== null) {
+                return $providerProbeMethod;
+            }
+        }
+
         $method = strtoupper(trim((string) ($endpoint['health_method'] ?? 'GET')));
 
         return $method === '' ? 'GET' : $method;
+    }
+
+    private function providerProbeUrl(string $endpointUri): ?string
+    {
+        if ($this->providerKey() !== 'openrouter') {
+            return null;
+        }
+
+        $parts = parse_url($endpointUri);
+        if (!is_array($parts)) {
+            return null;
+        }
+
+        $scheme = isset($parts['scheme']) && is_string($parts['scheme']) ? $parts['scheme'] : null;
+        $host = isset($parts['host']) && is_string($parts['host']) ? $parts['host'] : null;
+
+        if ($scheme === null || $host === null || $scheme === '' || $host === '') {
+            return null;
+        }
+
+        $port = isset($parts['port']) ? ':' . (int) $parts['port'] : '';
+
+        return sprintf('%s://%s%s/api/v1/models', $scheme, $host, $port);
+    }
+
+    private function providerProbeMethod(): ?string
+    {
+        return $this->providerKey() === 'openrouter' ? 'GET' : null;
     }
 
     private function nullableString(mixed $value): ?string

--- a/apps/atomy-q/API/app/Adapters/Ai/ConfiguredAiEndpointRegistry.php
+++ b/apps/atomy-q/API/app/Adapters/Ai/ConfiguredAiEndpointRegistry.php
@@ -121,21 +121,21 @@ final readonly class ConfiguredAiEndpointRegistry implements AiEndpointRegistryI
             return $healthUrl;
         }
 
+        $healthPath = trim((string) ($endpoint['health_path'] ?? ''));
+        if ($healthPath !== '') {
+            if ($healthPath[0] !== '/') {
+                $healthPath = '/' . $healthPath;
+            }
+
+            return rtrim($endpointUri, '/') . $healthPath;
+        }
+
         $providerProbeUrl = $this->providerProbeUrl($endpointUri);
         if ($providerProbeUrl !== null) {
             return $providerProbeUrl;
         }
 
-        $healthPath = trim((string) ($endpoint['health_path'] ?? '/health'));
-        if ($healthPath === '') {
-            $healthPath = '/health';
-        }
-
-        if ($healthPath[0] !== '/') {
-            $healthPath = '/' . $healthPath;
-        }
-
-        return rtrim($endpointUri, '/') . $healthPath;
+        return rtrim($endpointUri, '/') . '/health';
     }
 
     /**
@@ -143,6 +143,11 @@ final readonly class ConfiguredAiEndpointRegistry implements AiEndpointRegistryI
      */
     private function resolveProbeMethod(array $endpoint): string
     {
+        $method = strtoupper(trim((string) ($endpoint['health_method'] ?? '')));
+        if ($method !== '') {
+            return $method;
+        }
+
         if (trim((string) ($endpoint['health_url'] ?? '')) === '') {
             $providerProbeMethod = $this->providerProbeMethod();
             if ($providerProbeMethod !== null) {
@@ -150,9 +155,7 @@ final readonly class ConfiguredAiEndpointRegistry implements AiEndpointRegistryI
             }
         }
 
-        $method = strtoupper(trim((string) ($endpoint['health_method'] ?? 'GET')));
-
-        return $method === '' ? 'GET' : $method;
+        return 'GET';
     }
 
     private function providerProbeUrl(string $endpointUri): ?string

--- a/apps/atomy-q/API/app/Adapters/Ai/Contracts/DocumentExtractionMapperInterface.php
+++ b/apps/atomy-q/API/app/Adapters/Ai/Contracts/DocumentExtractionMapperInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Adapters\Ai\Contracts;
+
+interface DocumentExtractionMapperInterface
+{
+    /**
+     * @param array<string, mixed> $response
+     * @return array<string, mixed>
+     */
+    public function map(array $response): array;
+}

--- a/apps/atomy-q/API/app/Adapters/Ai/Contracts/DocumentPayloadFactoryInterface.php
+++ b/apps/atomy-q/API/app/Adapters/Ai/Contracts/DocumentPayloadFactoryInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Adapters\Ai\Contracts;
+
+use App\Adapters\Ai\DTOs\DocumentExtractionRequest;
+
+interface DocumentPayloadFactoryInterface
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function build(DocumentExtractionRequest $request): array;
+}

--- a/apps/atomy-q/API/app/Adapters/Ai/Contracts/ProviderDocumentIntelligenceClientInterface.php
+++ b/apps/atomy-q/API/app/Adapters/Ai/Contracts/ProviderDocumentIntelligenceClientInterface.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Adapters\Ai\Contracts;
 
+use App\Adapters\Ai\DTOs\DocumentExtractionRequest;
+
 interface ProviderDocumentIntelligenceClientInterface
 {
     /**
@@ -11,4 +13,9 @@ interface ProviderDocumentIntelligenceClientInterface
      * @return array<string, mixed>
      */
     public function extract(array $payload): array;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function extractDocument(DocumentExtractionRequest $request): array;
 }

--- a/apps/atomy-q/API/app/Adapters/Ai/DTOs/DocumentExtractionRequest.php
+++ b/apps/atomy-q/API/app/Adapters/Ai/DTOs/DocumentExtractionRequest.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Adapters\Ai\DTOs;
+
+use InvalidArgumentException;
+
+/**
+ * Immutable request envelope for provider-backed quotation document extraction.
+ *
+ * `tenantId`, `rfqId`, and `quoteSubmissionId` must be non-empty identifiers.
+ * `mimeType` must be one of the supported provider-upload document types.
+ * `absolutePath` must be an absolute path rooted under an allowed local workspace/storage base path.
+ */
+final readonly class DocumentExtractionRequest
+{
+    /**
+     * @param string $tenantId Tenant identifier for scoped provider telemetry.
+     * @param string $rfqId RFQ identifier associated with the quotation document.
+     * @param string $quoteSubmissionId Quote submission identifier for persistence callbacks.
+     * @param string $filename Original stored filename sent to the provider.
+     * @param string $mimeType Supported quotation MIME type such as `application/pdf` or `image/png`.
+     * @param string $absolutePath Absolute local filesystem path to the stored quotation document.
+     */
+    public function __construct(
+        public string $tenantId,
+        public string $rfqId,
+        public string $quoteSubmissionId,
+        public string $filename,
+        public string $mimeType,
+        public string $absolutePath,
+    ) {
+        foreach ([
+            'tenantId' => $this->tenantId,
+            'rfqId' => $this->rfqId,
+            'quoteSubmissionId' => $this->quoteSubmissionId,
+            'filename' => $this->filename,
+            'mimeType' => $this->mimeType,
+            'absolutePath' => $this->absolutePath,
+        ] as $field => $value) {
+            if (trim($value) === '') {
+                throw new InvalidArgumentException(sprintf('%s must not be empty.', $field));
+            }
+        }
+
+        if (!in_array($this->mimeType, self::supportedMimeTypes(), true)) {
+            throw new InvalidArgumentException(sprintf('Unsupported document MIME type [%s].', $this->mimeType));
+        }
+
+        if (!$this->isAbsolutePath($this->absolutePath)) {
+            throw new InvalidArgumentException('absolutePath must be an absolute filesystem path.');
+        }
+
+        $resolvedPath = realpath($this->absolutePath);
+        if ($resolvedPath === false) {
+            throw new InvalidArgumentException('absolutePath must resolve to an existing filesystem path.');
+        }
+
+        if (!$this->pathWithinAllowedBases($resolvedPath)) {
+            throw new InvalidArgumentException('absolutePath must resolve inside an allowed local storage path.');
+        }
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function supportedMimeTypes(): array
+    {
+        return [
+            'application/pdf',
+            'image/jpeg',
+            'image/png',
+            'image/webp',
+        ];
+    }
+
+    private function isAbsolutePath(string $path): bool
+    {
+        return str_starts_with($path, DIRECTORY_SEPARATOR)
+            || preg_match('/^[A-Za-z]:\\\\/', $path) === 1;
+    }
+
+    private function pathWithinAllowedBases(string $resolvedPath): bool
+    {
+        foreach ($this->allowedBasePaths() as $basePath) {
+            if ($basePath !== '' && str_starts_with($resolvedPath, $basePath)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function allowedBasePaths(): array
+    {
+        $candidatePaths = [
+            realpath(sys_get_temp_dir()) ?: '',
+            $this->resolveLaravelPath('storage_path', 'app'),
+            $this->resolveLaravelPath('storage_path', 'app/private'),
+            $this->resolveSamplePath(),
+        ];
+
+        return array_values(array_unique(array_filter($candidatePaths, static fn (string $path): bool => $path !== '')));
+    }
+
+    private function resolveLaravelPath(string $helper, string $suffix): string
+    {
+        if (!function_exists($helper) || !function_exists('app')) {
+            return '';
+        }
+
+        try {
+            $app = app();
+        } catch (\Throwable) {
+            return '';
+        }
+
+        if (!is_object($app)) {
+            return '';
+        }
+
+        $method = $helper === 'storage_path' ? 'storagePath' : 'basePath';
+        if (!method_exists($app, $method)) {
+            return '';
+        }
+
+        $resolved = $helper($suffix);
+
+        return is_string($resolved) ? (realpath($resolved) ?: '') : '';
+    }
+
+    private function resolveSamplePath(): string
+    {
+        if (!function_exists('base_path') || !function_exists('app')) {
+            return '';
+        }
+
+        try {
+            $app = app();
+        } catch (\Throwable) {
+            return '';
+        }
+
+        if (!is_object($app) || !method_exists($app, 'basePath')) {
+            return '';
+        }
+
+        return realpath(dirname(base_path(), 3) . '/sample') ?: '';
+    }
+}

--- a/apps/atomy-q/API/app/Adapters/Ai/DTOs/DocumentExtractionRequest.php
+++ b/apps/atomy-q/API/app/Adapters/Ai/DTOs/DocumentExtractionRequest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Adapters\Ai\DTOs;
 
 use InvalidArgumentException;
+use App\Adapters\Ai\Support\SamplePath;
 
 /**
  * Immutable request envelope for provider-backed quotation document extraction.
@@ -78,13 +79,21 @@ final readonly class DocumentExtractionRequest
     private function isAbsolutePath(string $path): bool
     {
         return str_starts_with($path, DIRECTORY_SEPARATOR)
-            || preg_match('/^[A-Za-z]:\\\\/', $path) === 1;
+            || preg_match('/^[A-Za-z]:[\\\\\\/]/', $path) === 1;
     }
 
     private function pathWithinAllowedBases(string $resolvedPath): bool
     {
         foreach ($this->allowedBasePaths() as $basePath) {
-            if ($basePath !== '' && str_starts_with($resolvedPath, $basePath)) {
+            $normalizedBasePath = rtrim($basePath, DIRECTORY_SEPARATOR);
+            $normalizedResolvedPath = rtrim($resolvedPath, DIRECTORY_SEPARATOR);
+            if (
+                $normalizedBasePath !== ''
+                && (
+                    $normalizedResolvedPath === $normalizedBasePath
+                    || str_starts_with($normalizedResolvedPath, $normalizedBasePath . DIRECTORY_SEPARATOR)
+                )
+            ) {
                 return true;
             }
         }
@@ -135,20 +144,6 @@ final readonly class DocumentExtractionRequest
 
     private function resolveSamplePath(): string
     {
-        if (!function_exists('base_path') || !function_exists('app')) {
-            return '';
-        }
-
-        try {
-            $app = app();
-        } catch (\Throwable) {
-            return '';
-        }
-
-        if (!is_object($app) || !method_exists($app, 'basePath')) {
-            return '';
-        }
-
-        return realpath(dirname(base_path(), 3) . '/sample') ?: '';
+        return SamplePath::root();
     }
 }

--- a/apps/atomy-q/API/app/Adapters/Ai/ProviderDocumentIntelligenceClient.php
+++ b/apps/atomy-q/API/app/Adapters/Ai/ProviderDocumentIntelligenceClient.php
@@ -4,15 +4,22 @@ declare(strict_types=1);
 
 namespace App\Adapters\Ai;
 
-use App\Adapters\Ai\Contracts\ProviderDocumentIntelligenceClientInterface;
-use App\Adapters\Ai\Contracts\ProviderAiTransportInterface;
 use Nexus\IntelligenceOperations\DTOs\AiStatusSchema;
+
+use App\Adapters\Ai\Contracts\ProviderAiTransportInterface;
+use App\Adapters\Ai\Contracts\ProviderDocumentIntelligenceClientInterface;
+use App\Adapters\Ai\DTOs\DocumentExtractionRequest;
+use App\Adapters\Ai\Support\OpenRouterDocumentExtractionMapper;
+use App\Adapters\Ai\Support\OpenRouterDocumentPayloadFactory;
 
 final readonly class ProviderDocumentIntelligenceClient implements ProviderDocumentIntelligenceClientInterface
 {
     public function __construct(
         private ProviderAiTransportInterface $transport,
-    ) {}
+        private OpenRouterDocumentPayloadFactory $payloadFactory,
+        private OpenRouterDocumentExtractionMapper $mapper,
+    ) {
+    }
 
     /**
      * @param array<string, mixed> $payload
@@ -21,5 +28,16 @@ final readonly class ProviderDocumentIntelligenceClient implements ProviderDocum
     public function extract(array $payload): array
     {
         return $this->transport->invoke(AiStatusSchema::ENDPOINT_GROUP_DOCUMENT, $payload);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function extractDocument(DocumentExtractionRequest $request): array
+    {
+        return $this->mapper->map($this->transport->invoke(
+            AiStatusSchema::ENDPOINT_GROUP_DOCUMENT,
+            $this->payloadFactory->build($request),
+        ));
     }
 }

--- a/apps/atomy-q/API/app/Adapters/Ai/ProviderDocumentIntelligenceClient.php
+++ b/apps/atomy-q/API/app/Adapters/Ai/ProviderDocumentIntelligenceClient.php
@@ -6,18 +6,18 @@ namespace App\Adapters\Ai;
 
 use Nexus\IntelligenceOperations\DTOs\AiStatusSchema;
 
+use App\Adapters\Ai\Contracts\DocumentExtractionMapperInterface;
+use App\Adapters\Ai\Contracts\DocumentPayloadFactoryInterface;
 use App\Adapters\Ai\Contracts\ProviderAiTransportInterface;
 use App\Adapters\Ai\Contracts\ProviderDocumentIntelligenceClientInterface;
 use App\Adapters\Ai\DTOs\DocumentExtractionRequest;
-use App\Adapters\Ai\Support\OpenRouterDocumentExtractionMapper;
-use App\Adapters\Ai\Support\OpenRouterDocumentPayloadFactory;
 
 final readonly class ProviderDocumentIntelligenceClient implements ProviderDocumentIntelligenceClientInterface
 {
     public function __construct(
         private ProviderAiTransportInterface $transport,
-        private OpenRouterDocumentPayloadFactory $payloadFactory,
-        private OpenRouterDocumentExtractionMapper $mapper,
+        private DocumentPayloadFactoryInterface $payloadFactory,
+        private DocumentExtractionMapperInterface $mapper,
     ) {
     }
 

--- a/apps/atomy-q/API/app/Adapters/Ai/Support/DocumentExtractionValueCoercer.php
+++ b/apps/atomy-q/API/app/Adapters/Ai/Support/DocumentExtractionValueCoercer.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Adapters\Ai\Support;
+
+final class DocumentExtractionValueCoercer
+{
+    public static function stringOrNull(mixed $value): ?string
+    {
+        if (!is_string($value)) {
+            return null;
+        }
+
+        $trimmed = trim($value);
+
+        return $trimmed === '' ? null : $trimmed;
+    }
+
+    public static function floatOrNull(mixed $value): ?float
+    {
+        if (is_int($value) || is_float($value)) {
+            return (float) $value;
+        }
+
+        if (!is_string($value)) {
+            return null;
+        }
+
+        $normalized = trim($value);
+        if ($normalized === '') {
+            return null;
+        }
+
+        $isParenthesizedNegative = false;
+        if (preg_match('/^\((.+)\)$/', $normalized, $matches) === 1) {
+            $isParenthesizedNegative = true;
+            $normalized = trim((string) ($matches[1] ?? ''));
+        }
+
+        $normalized = preg_replace('/\s+/u', '', $normalized) ?? $normalized;
+        $normalized = preg_replace('/^[^\d+\-.,]+/u', '', $normalized) ?? $normalized;
+        $normalized = preg_replace('/[^\d.,]+$/u', '', $normalized) ?? $normalized;
+        if ($normalized === '' || preg_match('/[^\d+\-.,]/u', $normalized) === 1) {
+            return null;
+        }
+
+        $sign = '';
+        $firstCharacter = $normalized[0] ?? '';
+        if ($firstCharacter === '+' || $firstCharacter === '-') {
+            $sign = $firstCharacter;
+            $normalized = substr($normalized, 1);
+        }
+
+        if ($normalized === '' || strpbrk($normalized, '+-') !== false) {
+            return null;
+        }
+
+        $numeric = self::normalizeNumericString($normalized);
+        if ($numeric === null) {
+            return null;
+        }
+
+        if ($sign === '-') {
+            $numeric = '-' . $numeric;
+        } elseif ($isParenthesizedNegative) {
+            $numeric = '-' . $numeric;
+        }
+
+        return is_numeric($numeric) ? (float) $numeric : null;
+    }
+
+    private static function normalizeNumericString(string $value): ?string
+    {
+        $hasComma = str_contains($value, ',');
+        $hasDot = str_contains($value, '.');
+
+        if ($hasComma && $hasDot) {
+            if (preg_match('/^\d{1,3}(,\d{3})+(\.\d+)?$/', $value) !== 1) {
+                return null;
+            }
+
+            return str_replace(',', '', $value);
+        }
+
+        if ($hasComma) {
+            if (preg_match('/^\d{1,3}(,\d{3})+$/', $value) === 1) {
+                return str_replace(',', '', $value);
+            }
+
+            if (preg_match('/^\d+,\d+$/', $value) === 1) {
+                $parts = explode(',', $value, 2);
+                $fractional = $parts[1] ?? '';
+                if (strlen($fractional) === 3) {
+                    return null;
+                }
+
+                return ($parts[0] ?? '') . '.' . $fractional;
+            }
+
+            return null;
+        }
+
+        if (preg_match('/^\d+(\.\d+)?$/', $value) === 1) {
+            return $value;
+        }
+
+        return null;
+    }
+}

--- a/apps/atomy-q/API/app/Adapters/Ai/Support/OpenRouterDocumentExtractionMapper.php
+++ b/apps/atomy-q/API/app/Adapters/Ai/Support/OpenRouterDocumentExtractionMapper.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 namespace App\Adapters\Ai\Support;
 
+use App\Adapters\Ai\Contracts\DocumentExtractionMapperInterface;
 use App\Adapters\Ai\Exceptions\AiTransportInvalidResponseException;
 
-final readonly class OpenRouterDocumentExtractionMapper
+final readonly class OpenRouterDocumentExtractionMapper implements DocumentExtractionMapperInterface
 {
     /**
      * @param array<string, string> $currencyMappings
@@ -76,12 +77,7 @@ final readonly class OpenRouterDocumentExtractionMapper
     private function stripMarkdownFence(string $content): string
     {
         $trimmed = trim($content);
-
-        if (str_starts_with($trimmed, '```json')) {
-            $trimmed = substr($trimmed, 7);
-        } elseif (str_starts_with($trimmed, '```')) {
-            $trimmed = substr($trimmed, 3);
-        }
+        $trimmed = preg_replace('/^```(?:[A-Za-z0-9_-]+)?\R?/i', '', $trimmed) ?? $trimmed;
 
         if (str_ends_with($trimmed, '```')) {
             $trimmed = substr($trimmed, 0, -3);
@@ -92,7 +88,7 @@ final readonly class OpenRouterDocumentExtractionMapper
 
     private function stringOrNull(mixed $value): ?string
     {
-        return is_string($value) && trim($value) !== '' ? trim($value) : null;
+        return DocumentExtractionValueCoercer::stringOrNull($value);
     }
 
     private function normalizeCurrencyCode(mixed $value): ?string
@@ -109,19 +105,7 @@ final readonly class OpenRouterDocumentExtractionMapper
 
     private function floatOrNull(mixed $value): ?float
     {
-        if (is_int($value) || is_float($value)) {
-            return (float) $value;
-        }
-
-        if (is_string($value)) {
-            $normalized = preg_replace('/[^0-9.\-]/', '', $value);
-
-            return is_string($normalized) && $normalized !== '' && is_numeric($normalized)
-                ? (float) $normalized
-                : null;
-        }
-
-        return null;
+        return DocumentExtractionValueCoercer::floatOrNull($value);
     }
 
     /**

--- a/apps/atomy-q/API/app/Adapters/Ai/Support/OpenRouterDocumentExtractionMapper.php
+++ b/apps/atomy-q/API/app/Adapters/Ai/Support/OpenRouterDocumentExtractionMapper.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Adapters\Ai\Support;
+
+use App\Adapters\Ai\Exceptions\AiTransportInvalidResponseException;
+
+final readonly class OpenRouterDocumentExtractionMapper
+{
+    /**
+     * @param array<string, string> $currencyMappings
+     */
+    public function __construct(
+        private array $currencyMappings = ['RM' => 'MYR'],
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $response
+     * @return array<string, mixed>
+     */
+    public function map(array $response): array
+    {
+        $content = $response['choices'][0]['message']['content'] ?? null;
+        if (is_array($content)) {
+            $content = implode("\n", array_values(array_filter($content, 'is_string')));
+        }
+
+        if (!is_string($content) || trim($content) === '') {
+            throw new AiTransportInvalidResponseException('Document provider response did not include message content.');
+        }
+
+        $decoded = json_decode($this->stripMarkdownFence($content), true);
+        if (!is_array($decoded)) {
+            throw new AiTransportInvalidResponseException('Document provider response content was not valid JSON.');
+        }
+
+        $lines = [];
+        foreach (($decoded['line_items'] ?? []) as $index => $item) {
+            if (!is_array($item)) {
+                continue;
+            }
+
+            $description = $this->stringOrNull($item['description'] ?? null);
+            if ($description === null) {
+                continue;
+            }
+
+            $lines[] = [
+                'description' => $description,
+                'quantity' => $this->floatOrNull($item['quantity'] ?? null) ?? 1.0,
+                'unit_price' => $this->floatOrNull($item['unit_price'] ?? null),
+                'line_total' => $this->floatOrNull($item['total'] ?? null),
+                'total' => $this->floatOrNull($item['total'] ?? null),
+                'unit' => $this->stringOrNull($item['uom'] ?? $item['unit'] ?? null) ?? 'EA',
+                'currency' => $this->normalizeCurrencyCode($item['currency'] ?? $decoded['currency'] ?? null),
+                'terms' => $this->stringOrNull($item['terms'] ?? $decoded['payment_terms'] ?? null),
+                'sort_order' => $index,
+            ];
+        }
+
+        return [
+            'vendor_name' => $this->stringOrNull($decoded['vendor_name'] ?? null),
+            'quote_number' => $this->stringOrNull($decoded['quote_number'] ?? null),
+            'currency' => $this->normalizeCurrencyCode($decoded['currency'] ?? null),
+            'total_amount' => $this->floatOrNull($decoded['total_amount'] ?? null),
+            'payment_terms' => $this->stringOrNull($decoded['payment_terms'] ?? null),
+            'delivery_terms' => $this->stringOrNull($decoded['delivery_terms'] ?? null),
+            'validity' => $this->stringOrNull($decoded['validity'] ?? null),
+            'notes' => $this->stringList($decoded['notes'] ?? []),
+            'lines' => $lines,
+        ];
+    }
+
+    private function stripMarkdownFence(string $content): string
+    {
+        $trimmed = trim($content);
+
+        if (str_starts_with($trimmed, '```json')) {
+            $trimmed = substr($trimmed, 7);
+        } elseif (str_starts_with($trimmed, '```')) {
+            $trimmed = substr($trimmed, 3);
+        }
+
+        if (str_ends_with($trimmed, '```')) {
+            $trimmed = substr($trimmed, 0, -3);
+        }
+
+        return trim($trimmed);
+    }
+
+    private function stringOrNull(mixed $value): ?string
+    {
+        return is_string($value) && trim($value) !== '' ? trim($value) : null;
+    }
+
+    private function normalizeCurrencyCode(mixed $value): ?string
+    {
+        $currency = $this->stringOrNull($value);
+        if ($currency === null) {
+            return null;
+        }
+
+        $upper = strtoupper($currency);
+
+        return $this->currencyMappings[$upper] ?? $upper;
+    }
+
+    private function floatOrNull(mixed $value): ?float
+    {
+        if (is_int($value) || is_float($value)) {
+            return (float) $value;
+        }
+
+        if (is_string($value)) {
+            $normalized = preg_replace('/[^0-9.\-]/', '', $value);
+
+            return is_string($normalized) && $normalized !== '' && is_numeric($normalized)
+                ? (float) $normalized
+                : null;
+        }
+
+        return null;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function stringList(mixed $value): array
+    {
+        if (!is_array($value)) {
+            return [];
+        }
+
+        return array_values(array_filter(array_map(
+            fn (mixed $item): ?string => $this->stringOrNull($item),
+            $value,
+        )));
+    }
+}

--- a/apps/atomy-q/API/app/Adapters/Ai/Support/OpenRouterDocumentPayloadFactory.php
+++ b/apps/atomy-q/API/app/Adapters/Ai/Support/OpenRouterDocumentPayloadFactory.php
@@ -6,8 +6,9 @@ namespace App\Adapters\Ai\Support;
 
 use InvalidArgumentException;
 use App\Adapters\Ai\DTOs\DocumentExtractionRequest;
+use App\Adapters\Ai\Contracts\DocumentPayloadFactoryInterface;
 
-final readonly class OpenRouterDocumentPayloadFactory
+final readonly class OpenRouterDocumentPayloadFactory implements DocumentPayloadFactoryInterface
 {
     public function __construct(
         private string $modelId,

--- a/apps/atomy-q/API/app/Adapters/Ai/Support/OpenRouterDocumentPayloadFactory.php
+++ b/apps/atomy-q/API/app/Adapters/Ai/Support/OpenRouterDocumentPayloadFactory.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Adapters\Ai\Support;
+
+use InvalidArgumentException;
+use App\Adapters\Ai\DTOs\DocumentExtractionRequest;
+
+final readonly class OpenRouterDocumentPayloadFactory
+{
+    public function __construct(
+        private string $modelId,
+        private string $parserPlugin,
+        private string $pdfEngine,
+        private int $maxFileSizeBytes = 10_485_760,
+    ) {
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function build(DocumentExtractionRequest $request): array
+    {
+        if (!is_file($request->absolutePath) || !is_readable($request->absolutePath)) {
+            throw new InvalidArgumentException('Quote document file is not readable.');
+        }
+
+        $fileSize = filesize($request->absolutePath);
+        if (!is_int($fileSize) || $fileSize < 1) {
+            throw new InvalidArgumentException('Quote document file size could not be determined.');
+        }
+
+        if ($fileSize > $this->maxFileSizeBytes) {
+            throw new InvalidArgumentException(sprintf(
+                'Quote document file exceeds the maximum supported size of %d bytes.',
+                $this->maxFileSizeBytes,
+            ));
+        }
+
+        $contents = file_get_contents($request->absolutePath);
+        if ($contents === false || $contents === '') {
+            throw new InvalidArgumentException('Quote document file is empty or unreadable.');
+        }
+
+        return [
+            'model' => $this->modelId,
+            'messages' => [[
+                'role' => 'user',
+                'content' => [
+                    [
+                        'type' => 'text',
+                        'text' => 'Extract this supplier quotation into concise JSON with vendor_name, quote_number, currency, total_amount, line_items (description, quantity, unit_price, total), payment_terms, delivery_terms, validity, and notes. Return JSON only.',
+                    ],
+                    [
+                        'type' => 'file',
+                        'file' => [
+                            'filename' => $request->filename,
+                            'file_data' => 'data:' . $request->mimeType . ';base64,' . base64_encode($contents),
+                        ],
+                    ],
+                ],
+            ]],
+            'plugins' => [[
+                'id' => $this->parserPlugin,
+                'pdf' => [
+                    'engine' => $this->pdfEngine,
+                ],
+            ]],
+            'stream' => false,
+        ];
+    }
+}

--- a/apps/atomy-q/API/app/Adapters/Ai/Support/SamplePath.php
+++ b/apps/atomy-q/API/app/Adapters/Ai/Support/SamplePath.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Adapters\Ai\Support;
+
+final class SamplePath
+{
+    public static function root(): string
+    {
+        $configured = self::configuredRoot();
+        if ($configured !== '') {
+            return $configured;
+        }
+
+        if (!function_exists('base_path') || !function_exists('app')) {
+            return '';
+        }
+
+        try {
+            $app = app();
+        } catch (\Throwable) {
+            return '';
+        }
+
+        if (!is_object($app) || !method_exists($app, 'basePath')) {
+            return '';
+        }
+
+        return realpath(dirname(base_path(), 3) . '/sample') ?: '';
+    }
+
+    private static function configuredRoot(): string
+    {
+        if (!function_exists('config')) {
+            return '';
+        }
+
+        try {
+            $configured = config('atomy.ai.sample_path');
+        } catch (\Throwable) {
+            return '';
+        }
+
+        if (!is_string($configured) || trim($configured) === '') {
+            return '';
+        }
+
+        return realpath(trim($configured)) ?: '';
+    }
+}

--- a/apps/atomy-q/API/app/Adapters/QuotationIntelligence/AtomyDecisionTrailWriter.php
+++ b/apps/atomy-q/API/app/Adapters/QuotationIntelligence/AtomyDecisionTrailWriter.php
@@ -53,26 +53,21 @@ final readonly class AtomyDecisionTrailWriter implements DecisionTrailWriterInte
 
             $results = [];
             $comparisonRunId = $this->resolveComparisonRunId($tenantId, $resolvedRfqId, $idempotencyKey);
+            $lastEntry = DecisionTrailEntry::query()
+                ->where('tenant_id', $tenantId)
+                ->where('comparison_run_id', $comparisonRunId)
+                ->orderByDesc('sequence')
+                ->lockForUpdate()
+                ->first();
 
             $currentPreviousHash = $previousHash;
             if ($currentPreviousHash === '') {
-                $last = DecisionTrailEntry::query()
-                    ->where('tenant_id', $tenantId)
-                    ->where('comparison_run_id', $comparisonRunId)
-                    ->orderByDesc('sequence')
-                    ->lockForUpdate()
-                    ->first();
-
-                $currentPreviousHash = $last?->entry_hash ?? str_repeat('0', 64);
+                $currentPreviousHash = $lastEntry?->entry_hash ?? str_repeat('0', 64);
             }
 
             $nextSequence = max(
                 $startingSequence,
-                ((int) DecisionTrailEntry::query()
-                    ->where('tenant_id', $tenantId)
-                    ->where('comparison_run_id', $comparisonRunId)
-                    ->lockForUpdate()
-                    ->max('sequence')) + 1
+                ((int) ($lastEntry?->sequence ?? 0)) + 1
             );
 
             $occurredAt = now();

--- a/apps/atomy-q/API/app/Adapters/QuotationIntelligence/Concerns/WrapsModels.php
+++ b/apps/atomy-q/API/app/Adapters/QuotationIntelligence/Concerns/WrapsModels.php
@@ -9,6 +9,7 @@ use App\Models\QuoteSubmission;
 use App\Models\Rfq;
 use App\Models\RfqLineItem;
 use App\Models\Tenant;
+use Illuminate\Support\Facades\Storage;
 use Nexus\QuotationIntelligence\Contracts\OrchestratorRequisitionInterface;
 use Nexus\QuotationIntelligence\Contracts\OrchestratorRequisitionLineInterface;
 use Nexus\QuotationIntelligence\Contracts\OrchestratorTenantInterface;
@@ -45,7 +46,7 @@ trait WrapsModels
                     'vendor_id' => $this->submission->vendor_id,
                 ]; 
             }
-            public function getStoragePath(): string { return storage_path('app/' . $this->submission->file_path); }
+            public function getStoragePath(): string { return Storage::disk('local')->path($this->submission->file_path); }
         };
     }
 

--- a/apps/atomy-q/API/app/Adapters/QuotationIntelligence/DeterministicContentProcessor.php
+++ b/apps/atomy-q/API/app/Adapters/QuotationIntelligence/DeterministicContentProcessor.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Adapters\QuotationIntelligence;
 
+use Illuminate\Support\Facades\Storage;
 use Nexus\QuotationIntelligence\Contracts\OrchestratorContentProcessorInterface;
 use Nexus\Tenant\Contracts\TenantContextInterface;
 use App\Models\QuoteSubmission;
@@ -73,7 +74,7 @@ final readonly class DeterministicContentProcessor implements OrchestratorConten
 
     private function resolveRelativePath(string $storagePath): string
     {
-        $prefix = storage_path('app') . DIRECTORY_SEPARATOR;
+        $prefix = rtrim(Storage::disk('local')->path(''), DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
         if (str_starts_with($storagePath, $prefix)) {
             return substr($storagePath, strlen($prefix));
         }

--- a/apps/atomy-q/API/app/Adapters/QuotationIntelligence/ProviderQuoteContentProcessor.php
+++ b/apps/atomy-q/API/app/Adapters/QuotationIntelligence/ProviderQuoteContentProcessor.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace App\Adapters\QuotationIntelligence;
 
+use RuntimeException;
 use App\Models\QuoteSubmission;
+use App\Models\RfqLineItem;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 use Nexus\Tenant\Contracts\TenantContextInterface;
 use App\Adapters\Ai\DTOs\DocumentExtractionRequest;
+use App\Adapters\Ai\Support\DocumentExtractionValueCoercer;
 use Nexus\QuotationIntelligence\Exceptions\QuotationIntelligenceException;
 use Nexus\QuotationIntelligence\Contracts\OrchestratorContentProcessorInterface;
 use App\Adapters\Ai\Contracts\ProviderDocumentIntelligenceClientInterface;
@@ -84,7 +87,11 @@ final readonly class ProviderQuoteContentProcessor implements OrchestratorConten
             return substr($storagePath, strlen($prefix));
         }
 
-        return basename($storagePath);
+        throw new RuntimeException(sprintf(
+            'QuoteSubmission.file_path could not be resolved because [%s] is outside the expected local storage prefix [%s].',
+            $storagePath,
+            $prefix,
+        ));
     }
 
     /**
@@ -99,7 +106,8 @@ final readonly class ProviderQuoteContentProcessor implements OrchestratorConten
         }
 
         $lines = [];
-        foreach (($result['lines'] ?? []) as $index => $line) {
+        $claimedRfqLineIds = [];
+        foreach (($result['lines'] ?? []) as $line) {
             if (!is_array($line)) {
                 continue;
             }
@@ -111,23 +119,31 @@ final readonly class ProviderQuoteContentProcessor implements OrchestratorConten
                 continue;
             }
 
-            $rfqLineItem = $this->matchRfqLineItem($rfqLineItems->all(), $description, (int) $index);
+            $rfqLineItem = $this->matchRfqLineItem($rfqLineItems->all(), $description, array_keys($claimedRfqLineIds));
             if ($rfqLineItem === null) {
                 continue;
             }
 
+            $claimedRfqLineIds[(string) $rfqLineItem->id] = true;
+
+            $quantity = DocumentExtractionValueCoercer::floatOrNull($line['quantity'] ?? null) ?? 1.0;
+            $unitPrice = DocumentExtractionValueCoercer::floatOrNull($line['unit_price'] ?? null) ?? 0.0;
+            $terms = DocumentExtractionValueCoercer::stringOrNull($line['terms'] ?? null)
+                ?? DocumentExtractionValueCoercer::stringOrNull($result['payment_terms'] ?? null)
+                ?? '';
+
             $lines[] = [
                 'rfq_line_id' => (string) $rfqLineItem->id,
                 'description' => $description,
-                'quantity' => isset($line['quantity']) ? (float) $line['quantity'] : 1.0,
-                'unit_price' => isset($line['unit_price']) ? (float) $line['unit_price'] : 0.0,
+                'quantity' => $quantity,
+                'unit_price' => $unitPrice,
                 'unit' => is_string($line['unit'] ?? null) && trim((string) $line['unit']) !== ''
                     ? (string) $line['unit']
                     : (string) ($rfqLineItem->uom ?? 'EA'),
                 'currency' => is_string($line['currency'] ?? null) && trim((string) $line['currency']) !== ''
                     ? (string) $line['currency']
                     : (string) ($rfqLineItem->currency ?? $result['currency'] ?? 'USD'),
-                'terms' => is_string($line['terms'] ?? null) ? (string) $line['terms'] : ($result['payment_terms'] ?? ''),
+                'terms' => $terms,
                 'bbox' => ['x' => 0, 'y' => 0, 'w' => 0, 'h' => 0],
             ];
         }
@@ -136,15 +152,20 @@ final readonly class ProviderQuoteContentProcessor implements OrchestratorConten
     }
 
     /**
-     * @param array<int, mixed> $rfqLineItems
+     * @param array<int, RfqLineItem> $rfqLineItems
+     * @param list<string> $excludedRfqLineIds
      */
-    private function matchRfqLineItem(array $rfqLineItems, string $description, int $index): mixed
+    private function matchRfqLineItem(array $rfqLineItems, string $description, array $excludedRfqLineIds = []): ?RfqLineItem
     {
         $normalizedDescription = Str::of($description)->lower()->toString();
         $bestItem = null;
         $bestScore = -1;
 
         foreach ($rfqLineItems as $candidate) {
+            if (in_array((string) $candidate->id, $excludedRfqLineIds, true)) {
+                continue;
+            }
+
             $candidateDescription = Str::of((string) ($candidate->description ?? ''))->lower()->toString();
             $score = 0;
 
@@ -168,6 +189,6 @@ final readonly class ProviderQuoteContentProcessor implements OrchestratorConten
             return $bestItem;
         }
 
-        return $rfqLineItems[$index] ?? $rfqLineItems[0] ?? null;
+        return null;
     }
 }

--- a/apps/atomy-q/API/app/Adapters/QuotationIntelligence/ProviderQuoteContentProcessor.php
+++ b/apps/atomy-q/API/app/Adapters/QuotationIntelligence/ProviderQuoteContentProcessor.php
@@ -1,0 +1,173 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Adapters\QuotationIntelligence;
+
+use App\Models\QuoteSubmission;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Nexus\Tenant\Contracts\TenantContextInterface;
+use App\Adapters\Ai\DTOs\DocumentExtractionRequest;
+use Nexus\QuotationIntelligence\Exceptions\QuotationIntelligenceException;
+use Nexus\QuotationIntelligence\Contracts\OrchestratorContentProcessorInterface;
+use App\Adapters\Ai\Contracts\ProviderDocumentIntelligenceClientInterface;
+
+final readonly class ProviderQuoteContentProcessor implements OrchestratorContentProcessorInterface
+{
+    public function __construct(
+        private ProviderDocumentIntelligenceClientInterface $documentClient,
+        private TenantContextInterface $tenantContext,
+    ) {
+    }
+
+    public function analyze(string $storagePath): object
+    {
+        $tenantId = $this->tenantContext->getCurrentTenantId();
+        if ($tenantId === null || $tenantId === '') {
+            throw new QuotationIntelligenceException('Quote extraction requires tenant context.');
+        }
+
+        $relativePath = $this->resolveRelativePath($storagePath);
+        $submission = QuoteSubmission::query()
+            ->where('tenant_id', $tenantId)
+            ->where('file_path', $relativePath)
+            ->whereHas('rfq', fn ($query) => $query->where('tenant_id', $tenantId))
+            ->with([
+                'rfq.lineItems' => fn ($query) => $query
+                    ->where('tenant_id', $tenantId)
+                    ->orderBy('sort_order'),
+            ])
+            ->first();
+
+        if (!$submission instanceof QuoteSubmission || $submission->rfq === null) {
+            throw new QuotationIntelligenceException('Quote submission source document was not found.');
+        }
+
+        $result = $this->documentClient->extractDocument(new DocumentExtractionRequest(
+            tenantId: $tenantId,
+            rfqId: (string) $submission->rfq_id,
+            quoteSubmissionId: (string) $submission->id,
+            filename: (string) $submission->original_filename,
+            mimeType: (string) $submission->file_type,
+            absolutePath: $storagePath,
+        ));
+
+        $lines = $this->lines($submission, $result);
+
+        return new class($lines, $result) {
+            /**
+             * @param list<array<string, mixed>> $lines
+             * @param array<string, mixed> $result
+             */
+            public function __construct(
+                private array $lines,
+                private array $result,
+            ) {
+            }
+
+            public function getExtractedField(string $field, mixed $default = null): mixed
+            {
+                return match ($field) {
+                    'lines' => $this->lines,
+                    'provider_result' => $this->result,
+                    default => $this->result[$field] ?? $default,
+                };
+            }
+        };
+    }
+
+    private function resolveRelativePath(string $storagePath): string
+    {
+        $prefix = rtrim(Storage::disk('local')->path(''), DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+        if (str_starts_with($storagePath, $prefix)) {
+            return substr($storagePath, strlen($prefix));
+        }
+
+        return basename($storagePath);
+    }
+
+    /**
+     * @param array<string, mixed> $result
+     * @return list<array<string, mixed>>
+     */
+    private function lines(QuoteSubmission $submission, array $result): array
+    {
+        $rfqLineItems = $submission->rfq?->lineItems?->values();
+        if ($rfqLineItems === null || $rfqLineItems->isEmpty()) {
+            return [];
+        }
+
+        $lines = [];
+        foreach (($result['lines'] ?? []) as $index => $line) {
+            if (!is_array($line)) {
+                continue;
+            }
+
+            $description = isset($line['description']) && is_string($line['description'])
+                ? trim($line['description'])
+                : '';
+            if ($description === '') {
+                continue;
+            }
+
+            $rfqLineItem = $this->matchRfqLineItem($rfqLineItems->all(), $description, (int) $index);
+            if ($rfqLineItem === null) {
+                continue;
+            }
+
+            $lines[] = [
+                'rfq_line_id' => (string) $rfqLineItem->id,
+                'description' => $description,
+                'quantity' => isset($line['quantity']) ? (float) $line['quantity'] : 1.0,
+                'unit_price' => isset($line['unit_price']) ? (float) $line['unit_price'] : 0.0,
+                'unit' => is_string($line['unit'] ?? null) && trim((string) $line['unit']) !== ''
+                    ? (string) $line['unit']
+                    : (string) ($rfqLineItem->uom ?? 'EA'),
+                'currency' => is_string($line['currency'] ?? null) && trim((string) $line['currency']) !== ''
+                    ? (string) $line['currency']
+                    : (string) ($rfqLineItem->currency ?? $result['currency'] ?? 'USD'),
+                'terms' => is_string($line['terms'] ?? null) ? (string) $line['terms'] : ($result['payment_terms'] ?? ''),
+                'bbox' => ['x' => 0, 'y' => 0, 'w' => 0, 'h' => 0],
+            ];
+        }
+
+        return $lines;
+    }
+
+    /**
+     * @param array<int, mixed> $rfqLineItems
+     */
+    private function matchRfqLineItem(array $rfqLineItems, string $description, int $index): mixed
+    {
+        $normalizedDescription = Str::of($description)->lower()->toString();
+        $bestItem = null;
+        $bestScore = -1;
+
+        foreach ($rfqLineItems as $candidate) {
+            $candidateDescription = Str::of((string) ($candidate->description ?? ''))->lower()->toString();
+            $score = 0;
+
+            if ($candidateDescription !== '' && str_contains($normalizedDescription, $candidateDescription)) {
+                $score += 10;
+            }
+
+            foreach (preg_split('/\s+/', preg_replace('/[^a-z0-9 ]/i', ' ', $candidateDescription) ?? '') ?: [] as $token) {
+                if ($token !== '' && str_contains($normalizedDescription, $token)) {
+                    $score++;
+                }
+            }
+
+            if ($score > $bestScore) {
+                $bestScore = $score;
+                $bestItem = $candidate;
+            }
+        }
+
+        if ($bestItem !== null && $bestScore > 0) {
+            return $bestItem;
+        }
+
+        return $rfqLineItems[$index] ?? $rfqLineItems[0] ?? null;
+    }
+}

--- a/apps/atomy-q/API/app/Providers/AppServiceProvider.php
+++ b/apps/atomy-q/API/app/Providers/AppServiceProvider.php
@@ -20,6 +20,8 @@ use App\Adapters\Ai\Contracts\ProviderSourcingRecommendationClientInterface;
 use App\Adapters\Ai\ProviderAiTransport;
 use App\Adapters\Ai\ProviderComparisonAwardClient;
 use App\Adapters\Ai\ProviderDocumentIntelligenceClient;
+use App\Adapters\Ai\Support\OpenRouterDocumentExtractionMapper;
+use App\Adapters\Ai\Support\OpenRouterDocumentPayloadFactory;
 use App\Adapters\Ai\ProviderGovernanceClient;
 use App\Adapters\Ai\ProviderInsightClient;
 use App\Adapters\Ai\ProviderNormalizationClient;
@@ -164,6 +166,7 @@ use App\Adapters\QuotationIntelligence\DeterministicContentProcessor;
 use App\Adapters\QuotationIntelligence\DeterministicSemanticMapper;
 use App\Adapters\QuotationIntelligence\DormantLlmContentProcessor;
 use App\Adapters\QuotationIntelligence\DormantLlmSemanticMapper;
+use App\Adapters\QuotationIntelligence\ProviderQuoteContentProcessor;
 use App\Adapters\QuotationIntelligence\Support\InMemoryUomRepository;
 use App\Adapters\QuotationIntelligence\Support\StaticExchangeRateProvider;
 use App\Adapters\QuoteIngestion\EloquentQuoteSubmissionQuery;
@@ -181,6 +184,7 @@ use Nexus\QuotationIntelligence\Services\ComparisonReadinessValidator;
 use Nexus\QuotationIntelligence\Services\QuoteComparisonMatrixService;
 use Nexus\QuotationIntelligence\Services\WeightedVendorScoringService;
 use Nexus\QuotationIntelligence\Services\HighRiskApprovalGateService;
+use Nexus\IntelligenceOperations\DTOs\AiStatusSchema;
 use Nexus\ApprovalOperations\Contracts\ApprovalCommentPersistInterface;
 use Nexus\ApprovalOperations\Contracts\ApprovalInstancePersistInterface;
 use Nexus\ApprovalOperations\Contracts\ApprovalInstanceQueryInterface;
@@ -233,6 +237,20 @@ class AppServiceProvider extends ServiceProvider
             VendorScorerInterface::class,
             static fn ($app): VendorScorerInterface => new DeterministicVendorScorer($app->make(ClockInterface::class)),
         );
+        $this->app->singleton(OpenRouterDocumentPayloadFactory::class, function (): OpenRouterDocumentPayloadFactory {
+            return new OpenRouterDocumentPayloadFactory(
+                modelId: (string) config('atomy.ai.endpoints.document.model_id', ''),
+                parserPlugin: (string) config('atomy.ai.endpoints.document.parser_plugin', 'file-parser'),
+                pdfEngine: (string) config('atomy.ai.endpoints.document.pdf_engine', 'mistral-ocr'),
+                maxFileSizeBytes: (int) config('atomy.ai.endpoints.document.max_file_size_bytes', 10_485_760),
+            );
+        });
+        $this->app->singleton(OpenRouterDocumentExtractionMapper::class, function (): OpenRouterDocumentExtractionMapper {
+            /** @var array<string, string> $currencyMappings */
+            $currencyMappings = (array) config('atomy.ai.endpoints.document.currency_mappings', ['RM' => 'MYR']);
+
+            return new OpenRouterDocumentExtractionMapper($currencyMappings);
+        });
         $this->app->singleton(ProviderDocumentIntelligenceClient::class);
         $this->app->singleton(
             ProviderDocumentIntelligenceClientInterface::class,
@@ -339,6 +357,14 @@ class AppServiceProvider extends ServiceProvider
         $this->app->singleton(OrchestratorProcurementManagerInterface::class, OrchestratorProcurementManager::class);
         $this->app->singleton(DecisionTrailWriterInterface::class, AtomyDecisionTrailWriter::class);
         $this->app->bind(OrchestratorContentProcessorInterface::class, function (): OrchestratorContentProcessorInterface {
+            $aiMode = (string) config('atomy.ai.mode', AiStatusSchema::MODE_DETERMINISTIC);
+            if ($aiMode === AiStatusSchema::MODE_PROVIDER) {
+                return new ProviderQuoteContentProcessor(
+                    $this->app->make(ProviderDocumentIntelligenceClientInterface::class),
+                    $this->app->make(TenantContextInterface::class),
+                );
+            }
+
             $mode = (string) config('atomy.quote_intelligence.mode', 'deterministic');
 
             if ($mode === 'deterministic') {

--- a/apps/atomy-q/API/app/Providers/AppServiceProvider.php
+++ b/apps/atomy-q/API/app/Providers/AppServiceProvider.php
@@ -8,9 +8,11 @@ use App\Adapters\Ai\AiRuntimeStatusAdapter;
 use App\Adapters\Ai\AtomyAiCapabilityCatalog;
 use App\Adapters\Ai\ConfiguredAiEndpointRegistry;
 use App\Adapters\Ai\ConfiguredAiHealthProbe;
-use App\Adapters\Ai\Contracts\ComparisonAwardAiClientInterface;
 use App\Adapters\Ai\Contracts\AiEndpointRegistryInterface;
 use App\Adapters\Ai\Contracts\AiRuntimeStatusInterface;
+use App\Adapters\Ai\Contracts\ComparisonAwardAiClientInterface;
+use App\Adapters\Ai\Contracts\DocumentExtractionMapperInterface;
+use App\Adapters\Ai\Contracts\DocumentPayloadFactoryInterface;
 use App\Adapters\Ai\Contracts\ProviderAiTransportInterface;
 use App\Adapters\Ai\Contracts\ProviderDocumentIntelligenceClientInterface;
 use App\Adapters\Ai\Contracts\ProviderGovernanceClientInterface;
@@ -245,12 +247,20 @@ class AppServiceProvider extends ServiceProvider
                 maxFileSizeBytes: (int) config('atomy.ai.endpoints.document.max_file_size_bytes', 10_485_760),
             );
         });
+        $this->app->singleton(
+            DocumentPayloadFactoryInterface::class,
+            static fn ($app): DocumentPayloadFactoryInterface => $app->make(OpenRouterDocumentPayloadFactory::class),
+        );
         $this->app->singleton(OpenRouterDocumentExtractionMapper::class, function (): OpenRouterDocumentExtractionMapper {
             /** @var array<string, string> $currencyMappings */
             $currencyMappings = (array) config('atomy.ai.endpoints.document.currency_mappings', ['RM' => 'MYR']);
 
             return new OpenRouterDocumentExtractionMapper($currencyMappings);
         });
+        $this->app->singleton(
+            DocumentExtractionMapperInterface::class,
+            static fn ($app): DocumentExtractionMapperInterface => $app->make(OpenRouterDocumentExtractionMapper::class),
+        );
         $this->app->singleton(ProviderDocumentIntelligenceClient::class);
         $this->app->singleton(
             ProviderDocumentIntelligenceClientInterface::class,

--- a/apps/atomy-q/API/composer.json
+++ b/apps/atomy-q/API/composer.json
@@ -84,8 +84,7 @@
         "nexus/uom": "*@dev",
         "nexus/vendor": "*@dev",
         "nexus/vendor-laravel-adapter": "*@dev",
-        "nexus/workflow": "*@dev",
-        "predis/predis": "^3.4"
+        "nexus/workflow": "*@dev"
     },
     "require-dev": {
         "dedoc/scramble": "^0.13.15",

--- a/apps/atomy-q/API/composer.json
+++ b/apps/atomy-q/API/composer.json
@@ -46,8 +46,8 @@
         "nexus/idempotency": "*@dev",
         "nexus/identity": "*@dev",
         "nexus/identity-operations": "*@dev",
-        "nexus/intelligence-operations": "*@dev",
         "nexus/insight-operations": "*@dev",
+        "nexus/intelligence-operations": "*@dev",
         "nexus/laravel-approval-operations-adapter": "*@dev",
         "nexus/laravel-idempotency-adapter": "*@dev",
         "nexus/laravel-identity-adapter": "*@dev",
@@ -85,7 +85,7 @@
         "nexus/vendor": "*@dev",
         "nexus/vendor-laravel-adapter": "*@dev",
         "nexus/workflow": "*@dev",
-        "predis/predis": "^2.2"
+        "predis/predis": "^3.4"
     },
     "require-dev": {
         "dedoc/scramble": "^0.13.15",

--- a/apps/atomy-q/API/config/atomy.php
+++ b/apps/atomy-q/API/config/atomy.php
@@ -51,6 +51,7 @@ return [
 
     'ai' => [
         'mode' => (string) env('AI_MODE', AiStatusSchema::MODE_DETERMINISTIC),
+        'sample_path' => (string) env('AI_SAMPLE_PATH', ''),
         'provider' => [
             'key' => (string) env('AI_PROVIDER', 'openrouter'),
             'name' => (string) env('AI_PROVIDER_NAME', ''),
@@ -97,8 +98,20 @@ return [
                         }
 
                         $decoded = json_decode($value, true);
+                        if (!is_array($decoded)) {
+                            return [];
+                        }
 
-                        return is_array($decoded) ? $decoded : [];
+                        $filtered = [];
+                        foreach ($decoded as $key => $mappedValue) {
+                            if (!is_string($key) || trim($key) === '' || !is_string($mappedValue) || trim($mappedValue) === '') {
+                                continue;
+                            }
+
+                            $filtered[trim($key)] = trim($mappedValue);
+                        }
+
+                        return $filtered;
                     })(env('AI_DOCUMENT_CURRENCY_MAPPINGS'))
                 ),
                 'health_url' => (string) env('AI_DOCUMENT_HEALTH_URL', (string) env('HF_DOCUMENT_HEALTH_URL', '')),

--- a/apps/atomy-q/API/config/atomy.php
+++ b/apps/atomy-q/API/config/atomy.php
@@ -86,6 +86,21 @@ return [
                 'retry_backoff_ms' => (int) env('AI_DOCUMENT_RETRY_BACKOFF_MS', (int) env('HF_DOCUMENT_RETRY_BACKOFF_MS', 0)),
                 'model_id' => (string) env('AI_DOCUMENT_MODEL_ID', (string) env('HF_DOCUMENT_MODEL_ID', '')),
                 'model_revision' => (string) env('AI_DOCUMENT_MODEL_REVISION', (string) env('HF_DOCUMENT_MODEL_REVISION', '')),
+                'parser_plugin' => (string) env('AI_DOCUMENT_PARSER_PLUGIN', 'file-parser'),
+                'pdf_engine' => (string) env('AI_DOCUMENT_PDF_ENGINE', 'mistral-ocr'),
+                'max_file_size_bytes' => (int) env('AI_DOCUMENT_MAX_FILE_SIZE_BYTES', 10 * 1024 * 1024),
+                'currency_mappings' => array_replace(
+                    ['RM' => 'MYR'],
+                    (static function (mixed $value): array {
+                        if (!is_string($value) || trim($value) === '') {
+                            return [];
+                        }
+
+                        $decoded = json_decode($value, true);
+
+                        return is_array($decoded) ? $decoded : [];
+                    })(env('AI_DOCUMENT_CURRENCY_MAPPINGS'))
+                ),
                 'health_url' => (string) env('AI_DOCUMENT_HEALTH_URL', (string) env('HF_DOCUMENT_HEALTH_URL', '')),
                 'health_path' => (string) env('AI_DOCUMENT_HEALTH_PATH', (string) env('HF_DOCUMENT_HEALTH_PATH', '/health')),
                 'health_method' => (string) env('AI_DOCUMENT_HEALTH_METHOD', (string) env('HF_DOCUMENT_HEALTH_METHOD', 'GET')),

--- a/apps/atomy-q/API/tests/Feature/Console/AiConsoleCommandsTest.php
+++ b/apps/atomy-q/API/tests/Feature/Console/AiConsoleCommandsTest.php
@@ -30,6 +30,8 @@ use App\Adapters\Ai\DTOs\InsightSummaryRequest;
 use App\Adapters\Ai\ProviderDocumentIntelligenceClient;
 use App\Adapters\Ai\ProviderNormalizationClient;
 use App\Adapters\Ai\ProviderSourcingRecommendationClient;
+use App\Adapters\Ai\Support\OpenRouterDocumentExtractionMapper;
+use App\Adapters\Ai\Support\OpenRouterDocumentPayloadFactory;
 use Illuminate\Contracts\Cache\Factory as CacheFactory;
 use Illuminate\Log\LogManager;
 use App\Services\Ai\AiOperationalAlertPublisher;
@@ -116,7 +118,11 @@ final class AiConsoleCommandsTest extends TestCase
             ->withAnyParameters()
             ->willReturn(['ok' => true]);
 
-        $this->app->instance(ProviderDocumentIntelligenceClient::class, new ProviderDocumentIntelligenceClient($transport));
+        $this->app->instance(ProviderDocumentIntelligenceClient::class, new ProviderDocumentIntelligenceClient(
+            $transport,
+            new OpenRouterDocumentPayloadFactory('model-a', 'file-parser', 'mistral-ocr'),
+            new OpenRouterDocumentExtractionMapper(),
+        ));
         $this->app->instance(ProviderDocumentIntelligenceClientInterface::class, $this->app->make(ProviderDocumentIntelligenceClient::class));
         $this->app->instance(ProviderNormalizationClient::class, new ProviderNormalizationClient($transport));
         $this->app->instance(ProviderNormalizationClientInterface::class, $this->app->make(ProviderNormalizationClient::class));

--- a/apps/atomy-q/API/tests/Feature/ProviderQuoteExtractionTest.php
+++ b/apps/atomy-q/API/tests/Feature/ProviderQuoteExtractionTest.php
@@ -6,25 +6,31 @@ namespace Tests\Feature;
 
 use App\Adapters\Ai\ConfiguredAiEndpointRegistry;
 use App\Adapters\Ai\Contracts\AiEndpointRegistryInterface;
+use App\Adapters\Ai\Contracts\DocumentExtractionMapperInterface;
+use App\Adapters\Ai\Contracts\DocumentPayloadFactoryInterface;
 use App\Adapters\Ai\Contracts\ProviderAiTransportInterface;
 use App\Adapters\Ai\Contracts\ProviderDocumentIntelligenceClientInterface;
+use App\Adapters\Ai\Exceptions\AiTransportFailedException;
+use App\Adapters\Ai\Support\OpenRouterDocumentExtractionMapper;
+use App\Adapters\Ai\Support\OpenRouterDocumentPayloadFactory;
+use App\Adapters\Ai\Support\SamplePath;
 use App\Adapters\Ai\ProviderDocumentIntelligenceClient;
-use Tests\Support\FakeOpenRouterDocumentResponses;
-use Illuminate\Support\Str;
 use App\Models\QuoteSubmission;
+use App\Models\Rfq;
+use App\Models\RfqLineItem;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Hash;
-use App\Models\Rfq;
-use App\Models\User;
-use App\Models\RfqLineItem;
+use Illuminate\Support\Str;
 use Nexus\QuoteIngestion\QuoteIngestionOrchestrator;
 use Nexus\IntelligenceOperations\DTOs\AiCapabilityStatus;
 use Nexus\IntelligenceOperations\DTOs\AiStatusSchema;
 use Nexus\QuotationIntelligence\Contracts\OrchestratorContentProcessorInterface;
 use Nexus\QuotationIntelligence\Contracts\QuotationIntelligenceCoordinatorInterface;
+use Tests\Support\FakeOpenRouterDocumentResponses;
 use Tests\Feature\Api\ApiTestCase;
 use Tests\Feature\Api\Concerns\BindsAiRuntimeStatus;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 
 final class ProviderQuoteExtractionTest extends ApiTestCase
 {
@@ -111,7 +117,7 @@ final class ProviderQuoteExtractionTest extends ApiTestCase
 
     private function sampleQuotePdf(): UploadedFile
     {
-        $path = realpath(base_path('../../../sample/1A/1A-1.pdf'));
+        $path = realpath(SamplePath::root() . '/1A/1A-1.pdf');
         self::assertNotFalse($path);
         self::assertFileExists($path);
 
@@ -123,9 +129,13 @@ final class ProviderQuoteExtractionTest extends ApiTestCase
         foreach ([
             ConfiguredAiEndpointRegistry::class,
             AiEndpointRegistryInterface::class,
+            DocumentPayloadFactoryInterface::class,
+            DocumentExtractionMapperInterface::class,
             ProviderAiTransportInterface::class,
             ProviderDocumentIntelligenceClient::class,
             ProviderDocumentIntelligenceClientInterface::class,
+            OpenRouterDocumentPayloadFactory::class,
+            OpenRouterDocumentExtractionMapper::class,
             OrchestratorContentProcessorInterface::class,
             QuotationIntelligenceCoordinatorInterface::class,
             QuoteIngestionOrchestrator::class,
@@ -136,12 +146,7 @@ final class ProviderQuoteExtractionTest extends ApiTestCase
 
     public function testProviderModeUploadPersistsExtractedSourceLinesFromDocumentAi(): void
     {
-        config()->set('atomy.ai.mode', 'provider');
-        config()->set('atomy.ai.endpoints.document.uri', 'https://openrouter.example.test/chat/completions');
-        config()->set('atomy.ai.endpoints.document.model_id', 'baidu/qianfan-ocr-fast:free');
-        config()->set('atomy.ai.endpoints.document.parser_plugin', 'file-parser');
-        config()->set('atomy.ai.endpoints.document.pdf_engine', 'mistral-ocr');
-        config()->set('atomy.ai.endpoints.document.health_url', 'https://openrouter.example.test/chat/completions/health');
+        $this->configureProviderDocumentEndpoint();
         $transport = new class implements ProviderAiTransportInterface {
             /** @var array<string, mixed> */
             public array $payload = [];
@@ -180,5 +185,97 @@ final class ProviderQuoteExtractionTest extends ApiTestCase
         );
 
         self::assertSame('mistral-ocr', $transport->payload['plugins'][0]['pdf']['engine'] ?? null);
+    }
+
+    public function testProviderModeUploadHandlesTransportErrors(): void
+    {
+        $this->configureProviderDocumentEndpoint();
+        $this->bindTransport(new class implements ProviderAiTransportInterface {
+            public function invoke(string $endpointGroup, array $payload): array
+            {
+                throw new AiTransportFailedException('AI endpoint [document] returned an unsuccessful response.');
+            }
+        });
+
+        $response = $this->uploadSampleQuote();
+
+        $response->assertCreated();
+        $response->assertJsonPath('data.status', 'failed');
+        $response->assertJsonPath('data.error_code', 'INTELLIGENCE_FAILED');
+        self::assertSame('failed', QuoteSubmission::query()->findOrFail((string) $response->json('data.id'))->status);
+        self::assertSame(0, QuoteSubmission::query()->findOrFail((string) $response->json('data.id'))->normalizationSourceLines()->count());
+    }
+
+    public function testProviderModeUploadHandlesInvalidJson(): void
+    {
+        $this->configureProviderDocumentEndpoint();
+        $this->bindTransport(new class implements ProviderAiTransportInterface {
+            public function invoke(string $endpointGroup, array $payload): array
+            {
+                return [
+                    'choices' => [[
+                        'message' => [
+                            'content' => '{invalid-json',
+                        ],
+                    ]],
+                ];
+            }
+        });
+
+        $response = $this->uploadSampleQuote();
+
+        $response->assertCreated();
+        $response->assertJsonPath('data.status', 'failed');
+        $response->assertJsonPath('data.error_code', 'INTELLIGENCE_FAILED');
+    }
+
+    public function testProviderModeUploadHandlesOversizedFile(): void
+    {
+        $this->configureProviderDocumentEndpoint();
+        config()->set('atomy.ai.endpoints.document.max_file_size_bytes', 1);
+        $transport = new class implements ProviderAiTransportInterface {
+            public function invoke(string $endpointGroup, array $payload): array
+            {
+                self::fail('Transport should not be invoked when the provider payload factory rejects an oversized file.');
+            }
+        };
+        $this->bindTransport($transport);
+
+        $response = $this->uploadSampleQuote();
+
+        $response->assertCreated();
+        $response->assertJsonPath('data.status', 'failed');
+        $response->assertJsonPath('data.error_code', 'INTELLIGENCE_FAILED');
+    }
+
+    private function configureProviderDocumentEndpoint(): void
+    {
+        config()->set('atomy.ai.mode', 'provider');
+        config()->set('atomy.ai.endpoints.document.uri', 'https://openrouter.example.test/chat/completions');
+        config()->set('atomy.ai.endpoints.document.model_id', 'baidu/qianfan-ocr-fast:free');
+        config()->set('atomy.ai.endpoints.document.parser_plugin', 'file-parser');
+        config()->set('atomy.ai.endpoints.document.pdf_engine', 'mistral-ocr');
+        config()->set('atomy.ai.endpoints.document.health_url', 'https://openrouter.example.test/chat/completions/health');
+    }
+
+    private function bindTransport(ProviderAiTransportInterface $transport): void
+    {
+        $this->app->instance(ProviderAiTransportInterface::class, $transport);
+        $this->refreshProviderBindings();
+        $this->app->instance(ProviderAiTransportInterface::class, $transport);
+    }
+
+    private function uploadSampleQuote(): \Illuminate\Testing\TestResponse
+    {
+        $user = $this->createUser();
+        $rfq = $this->createRfq($user);
+
+        return $this->withHeaders($this->authHeaders((string) $user->tenant_id, (string) $user->id))
+            ->post('/api/v1/quote-submissions/upload', [
+                'rfq_id' => $rfq->id,
+                'vendor_id' => (string) Str::ulid(),
+                'vendor_name' => 'Kuching Utama Sdn Bhd',
+                'file' => $this->sampleQuotePdf(),
+            ]);
     }
 }

--- a/apps/atomy-q/API/tests/Feature/ProviderQuoteExtractionTest.php
+++ b/apps/atomy-q/API/tests/Feature/ProviderQuoteExtractionTest.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Adapters\Ai\ConfiguredAiEndpointRegistry;
+use App\Adapters\Ai\Contracts\AiEndpointRegistryInterface;
+use App\Adapters\Ai\Contracts\ProviderAiTransportInterface;
+use App\Adapters\Ai\Contracts\ProviderDocumentIntelligenceClientInterface;
+use App\Adapters\Ai\ProviderDocumentIntelligenceClient;
+use Tests\Support\FakeOpenRouterDocumentResponses;
+use Illuminate\Support\Str;
+use App\Models\QuoteSubmission;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Hash;
+use App\Models\Rfq;
+use App\Models\User;
+use App\Models\RfqLineItem;
+use Nexus\QuoteIngestion\QuoteIngestionOrchestrator;
+use Nexus\IntelligenceOperations\DTOs\AiCapabilityStatus;
+use Nexus\IntelligenceOperations\DTOs\AiStatusSchema;
+use Nexus\QuotationIntelligence\Contracts\OrchestratorContentProcessorInterface;
+use Nexus\QuotationIntelligence\Contracts\QuotationIntelligenceCoordinatorInterface;
+use Tests\Feature\Api\ApiTestCase;
+use Tests\Feature\Api\Concerns\BindsAiRuntimeStatus;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+final class ProviderQuoteExtractionTest extends ApiTestCase
+{
+    use BindsAiRuntimeStatus;
+    use RefreshDatabase;
+
+    public function createApplication(): \Illuminate\Foundation\Application
+    {
+        $app = parent::createApplication();
+        $app['config']->set('database.default', 'sqlite');
+        $app['config']->set('database.connections.sqlite', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+            'foreign_key_constraints' => true,
+        ]);
+        $app['config']->set('queue.default', 'sync');
+
+        return $app;
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->bindAiRuntimeStatus([
+            'quote_document_extraction' => new AiCapabilityStatus(
+                featureKey: 'quote_document_extraction',
+                capabilityGroup: AiStatusSchema::CAPABILITY_GROUP_DOCUMENT_INTELLIGENCE,
+                endpointGroup: AiStatusSchema::ENDPOINT_GROUP_DOCUMENT,
+                fallbackUiMode: AiStatusSchema::FALLBACK_UI_MODE_SHOW_MANUAL_CONTINUITY_BANNER,
+                messageKey: 'ai.quote_document_extraction.available',
+                status: AiStatusSchema::CAPABILITY_STATUS_AVAILABLE,
+                available: true,
+                reasonCodes: ['provider_available'],
+                operatorCritical: true,
+                diagnostics: ['mode' => AiStatusSchema::MODE_PROVIDER],
+            ),
+        ]);
+    }
+
+    private function createUser(): User
+    {
+        /** @var User $user */
+        $user = User::query()->create([
+            'tenant_id' => (string) Str::ulid(),
+            'email' => 'provider-' . Str::lower((string) Str::ulid()) . '@example.com',
+            'name' => 'Provider Test User',
+            'password_hash' => Hash::make('password'),
+            'role' => 'admin',
+            'status' => 'active',
+            'timezone' => 'UTC',
+            'locale' => 'en',
+            'email_verified_at' => now(),
+        ]);
+
+        return $user;
+    }
+
+    private function createRfq(User $user): Rfq
+    {
+        $rfq = Rfq::query()->create([
+            'tenant_id' => $user->tenant_id,
+            'rfq_number' => 'RFQ-PROVIDER-' . Str::upper(Str::random(6)),
+            'title' => 'Provider Test RFQ',
+            'owner_id' => $user->id,
+            'submission_deadline' => now()->addDays(14),
+            'status' => 'draft',
+        ]);
+
+        RfqLineItem::query()->create([
+            'tenant_id' => $user->tenant_id,
+            'rfq_id' => $rfq->id,
+            'description' => 'Breakdown assist jump start vehicle',
+            'quantity' => 1,
+            'uom' => 'EA',
+            'unit_price' => 80.0,
+            'currency' => 'RM',
+            'sort_order' => 0,
+        ]);
+
+        return $rfq;
+    }
+
+    private function sampleQuotePdf(): UploadedFile
+    {
+        $path = realpath(base_path('../../../sample/1A/1A-1.pdf'));
+        self::assertNotFalse($path);
+        self::assertFileExists($path);
+
+        return new UploadedFile($path, '1A-1.pdf', 'application/pdf', null, true);
+    }
+
+    private function refreshProviderBindings(): void
+    {
+        foreach ([
+            ConfiguredAiEndpointRegistry::class,
+            AiEndpointRegistryInterface::class,
+            ProviderAiTransportInterface::class,
+            ProviderDocumentIntelligenceClient::class,
+            ProviderDocumentIntelligenceClientInterface::class,
+            OrchestratorContentProcessorInterface::class,
+            QuotationIntelligenceCoordinatorInterface::class,
+            QuoteIngestionOrchestrator::class,
+        ] as $abstract) {
+            app()->forgetInstance($abstract);
+        }
+    }
+
+    public function testProviderModeUploadPersistsExtractedSourceLinesFromDocumentAi(): void
+    {
+        config()->set('atomy.ai.mode', 'provider');
+        config()->set('atomy.ai.endpoints.document.uri', 'https://openrouter.example.test/chat/completions');
+        config()->set('atomy.ai.endpoints.document.model_id', 'baidu/qianfan-ocr-fast:free');
+        config()->set('atomy.ai.endpoints.document.parser_plugin', 'file-parser');
+        config()->set('atomy.ai.endpoints.document.pdf_engine', 'mistral-ocr');
+        config()->set('atomy.ai.endpoints.document.health_url', 'https://openrouter.example.test/chat/completions/health');
+        $transport = new class implements ProviderAiTransportInterface {
+            /** @var array<string, mixed> */
+            public array $payload = [];
+
+            public function invoke(string $endpointGroup, array $payload): array
+            {
+                $this->payload = $payload;
+
+                return FakeOpenRouterDocumentResponses::successfulQuoteExtraction();
+            }
+        };
+        $this->app->instance(ProviderAiTransportInterface::class, $transport);
+        $this->refreshProviderBindings();
+        $this->app->instance(ProviderAiTransportInterface::class, $transport);
+
+        $user = $this->createUser();
+        $rfq = $this->createRfq($user);
+
+        $response = $this->withHeaders($this->authHeaders((string) $user->tenant_id, (string) $user->id))
+            ->post('/api/v1/quote-submissions/upload', [
+                'rfq_id' => $rfq->id,
+                'vendor_id' => (string) Str::ulid(),
+                'vendor_name' => 'Kuching Utama Sdn Bhd',
+                'file' => $this->sampleQuotePdf(),
+            ]);
+
+        $response->assertCreated();
+        self::assertContains($response->json('data.status'), ['ready', 'needs_review']);
+
+        $submission = QuoteSubmission::query()->findOrFail((string) $response->json('data.id'));
+        self::assertContains($submission->status, ['ready', 'needs_review']);
+        self::assertSame(1, $submission->normalizationSourceLines()->count());
+        self::assertSame(
+            'BREAKDOWN ASSIST JUMP START VEHICLE',
+            $submission->normalizationSourceLines()->firstOrFail()->source_description,
+        );
+
+        self::assertSame('mistral-ocr', $transport->payload['plugins'][0]['pdf']['engine'] ?? null);
+    }
+}

--- a/apps/atomy-q/API/tests/Feature/QuoteIngestionPipelineTest.php
+++ b/apps/atomy-q/API/tests/Feature/QuoteIngestionPipelineTest.php
@@ -309,7 +309,7 @@ final class QuoteIngestionPipelineTest extends ApiTestCase
         $response->assertJsonPath('data.error_code', 'EXTRACTION_UNAVAILABLE');
         $response->assertJsonPath('data.ai_status.extraction.status', 'degraded');
         $response->assertJsonPath('data.ai_status.extraction.manual_action_required', true);
-        $response->assertJsonPath('data.ai_status.normalization.status', 'available');
+        $response->assertJsonPath('data.ai_status.normalization.status', 'degraded');
         $response->assertJsonPath('data.confidence', null);
 
         $submission = QuoteSubmission::query()->findOrFail((string) $response->json('data.id'));

--- a/apps/atomy-q/API/tests/Feature/QuoteIngestionPipelineTest.php
+++ b/apps/atomy-q/API/tests/Feature/QuoteIngestionPipelineTest.php
@@ -20,8 +20,12 @@ use App\Adapters\QuotationIntelligence\DeterministicContentProcessor;
 use App\Adapters\QuotationIntelligence\DeterministicSemanticMapper;
 use App\Adapters\QuotationIntelligence\DormantLlmContentProcessor;
 use App\Adapters\QuotationIntelligence\DormantLlmSemanticMapper;
+use App\Adapters\QuotationIntelligence\ProviderQuoteContentProcessor;
 use App\Adapters\Ai\ProviderDocumentIntelligenceClient;
 use App\Adapters\Ai\ProviderNormalizationClient;
+use App\Adapters\Ai\Contracts\AiEndpointRegistryInterface;
+use App\Adapters\Ai\Contracts\AiRuntimeStatusInterface;
+use App\Adapters\Ai\ConfiguredAiEndpointRegistry;
 use App\Jobs\ProcessQuoteSubmissionJob;
 use App\Models\QuoteSubmission;
 use App\Models\Rfq;
@@ -44,6 +48,7 @@ final class QuoteIngestionPipelineTest extends ApiTestCase
             'foreign_key_constraints' => true,
         ]);
         $app['config']->set('queue.default', 'sync');
+        $app['config']->set('atomy.ai.mode', 'deterministic');
 
         return $app;
     }
@@ -120,6 +125,9 @@ final class QuoteIngestionPipelineTest extends ApiTestCase
         app()->forgetInstance(QuotationIntelligenceCoordinatorInterface::class);
         app()->forgetInstance(QuoteIngestionOrchestrator::class);
         app()->forgetInstance(BatchQuoteComparisonCoordinatorInterface::class);
+        app()->forgetInstance(ConfiguredAiEndpointRegistry::class);
+        app()->forgetInstance(AiEndpointRegistryInterface::class);
+        app()->forgetInstance(AiRuntimeStatusInterface::class);
     }
 
     /**
@@ -241,9 +249,9 @@ final class QuoteIngestionPipelineTest extends ApiTestCase
             ]);
 
         $response->assertCreated();
-        $response->assertJsonPath('data.status', 'needs_review');
-        $response->assertJsonPath('data.error_code', 'EXTRACTION_UNAVAILABLE');
-        $response->assertJsonPath('data.error_message', 'Quote document extraction is unavailable. Manual action required.');
+        $response->assertJsonPath('data.status', 'failed');
+        $response->assertJsonPath('data.error_code', 'INTELLIGENCE_FAILED');
+        $response->assertJsonPath('data.error_message', QuoteIngestionOrchestrator::GENERIC_FAILURE_MESSAGE);
     }
 
     public function test_quote_intelligence_llm_mode_semantic_mapper_is_dormant(): void
@@ -280,10 +288,10 @@ final class QuoteIngestionPipelineTest extends ApiTestCase
 
     public function test_upload_preserves_manual_continuity_when_document_ai_is_unavailable(): void
     {
-        $this->resetQuoteIntelligenceBindings();
         config()->set('atomy.ai.mode', 'provider');
         config()->set('atomy.ai.endpoints.document.uri', '');
         config()->set('atomy.quote_intelligence.mode', 'deterministic');
+        $this->resetQuoteIntelligenceBindings();
 
         $user = $this->createUser();
         $rfq = $this->createRfq($user);
@@ -301,7 +309,7 @@ final class QuoteIngestionPipelineTest extends ApiTestCase
         $response->assertJsonPath('data.error_code', 'EXTRACTION_UNAVAILABLE');
         $response->assertJsonPath('data.ai_status.extraction.status', 'degraded');
         $response->assertJsonPath('data.ai_status.extraction.manual_action_required', true);
-        $response->assertJsonPath('data.ai_status.normalization.status', 'degraded');
+        $response->assertJsonPath('data.ai_status.normalization.status', 'available');
         $response->assertJsonPath('data.confidence', null);
 
         $submission = QuoteSubmission::query()->findOrFail((string) $response->json('data.id'));
@@ -313,9 +321,9 @@ final class QuoteIngestionPipelineTest extends ApiTestCase
 
     public function test_provider_ai_clients_are_bound_without_legacy_quote_mode_overriding_plan_status(): void
     {
-        $this->resetQuoteIntelligenceBindings();
         config()->set('atomy.ai.mode', 'off');
         config()->set('atomy.quote_intelligence.mode', 'deterministic');
+        $this->resetQuoteIntelligenceBindings();
 
         self::assertInstanceOf(ProviderDocumentIntelligenceClient::class, app()->make(ProviderDocumentIntelligenceClient::class));
         self::assertInstanceOf(ProviderNormalizationClient::class, app()->make(ProviderNormalizationClient::class));
@@ -335,6 +343,18 @@ final class QuoteIngestionPipelineTest extends ApiTestCase
         $response->assertJsonPath('data.status', 'needs_review');
         $response->assertJsonPath('data.error_code', 'EXTRACTION_DISABLED');
         $response->assertJsonPath('data.ai_status.extraction.available', false);
+    }
+
+    public function test_provider_mode_binds_provider_quote_content_processor_without_legacy_override(): void
+    {
+        config()->set('atomy.ai.mode', 'provider');
+        config()->set('atomy.quote_intelligence.mode', 'unsupported-mode');
+        $this->resetQuoteIntelligenceBindings();
+
+        self::assertInstanceOf(
+            ProviderQuoteContentProcessor::class,
+            app()->make(OrchestratorContentProcessorInterface::class),
+        );
     }
 
     public function test_unsupported_quote_intelligence_mode_fails_safe_through_pipeline(): void
@@ -360,9 +380,9 @@ final class QuoteIngestionPipelineTest extends ApiTestCase
             ]);
 
         $response->assertCreated();
-        $response->assertJsonPath('data.status', 'needs_review');
-        $response->assertJsonPath('data.error_code', 'EXTRACTION_UNAVAILABLE');
-        $response->assertJsonPath('data.error_message', 'Quote document extraction is unavailable. Manual action required.');
+        $response->assertJsonPath('data.status', 'failed');
+        $response->assertJsonPath('data.error_code', 'INTELLIGENCE_FAILED');
+        $response->assertJsonPath('data.error_message', QuoteIngestionOrchestrator::GENERIC_FAILURE_MESSAGE);
     }
 
     public function test_job_failed_path_sanitizes_retry_exhaustion_error_message(): void

--- a/apps/atomy-q/API/tests/Support/FakeOpenRouterDocumentResponses.php
+++ b/apps/atomy-q/API/tests/Support/FakeOpenRouterDocumentResponses.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Support;
+
+final class FakeOpenRouterDocumentResponses
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public static function successfulQuoteExtraction(): array
+    {
+        return [
+            'choices' => [[
+                'message' => [
+                    'content' => json_encode([
+                        'vendor_name' => 'Kuching Utama Sdn Bhd',
+                        'quote_number' => '1809/2975',
+                        'currency' => 'RM',
+                        'total_amount' => 84.8,
+                        'line_items' => [[
+                            'description' => 'BREAKDOWN ASSIST JUMP START VEHICLE',
+                            'quantity' => 1,
+                            'unit_price' => 80,
+                            'total' => 84.8,
+                        ]],
+                        'payment_terms' => '50% deposit required before work can be carried out',
+                        'validity' => '30 days',
+                    ], JSON_THROW_ON_ERROR),
+                ],
+            ]],
+        ];
+    }
+}

--- a/apps/atomy-q/API/tests/Unit/Adapters/Ai/AiAdaptersTest.php
+++ b/apps/atomy-q/API/tests/Unit/Adapters/Ai/AiAdaptersTest.php
@@ -101,6 +101,28 @@ final class AiAdaptersTest extends TestCase
         self::assertSame('HEAD', $endpointConfig->metadata['probe_method'] ?? null);
     }
 
+    public function testConfiguredEndpointRegistryHonorsExplicitHealthPathAndMethodBeforeProviderDefaults(): void
+    {
+        $registry = new ConfiguredAiEndpointRegistry([
+            'provider' => [
+                'key' => 'openrouter',
+            ],
+            'endpoints' => [
+                'document' => [
+                    'uri' => 'https://openrouter.ai/api/v1/chat/completions',
+                    'health_path' => '/status',
+                    'health_method' => 'post',
+                ],
+            ],
+        ]);
+
+        $endpointConfig = $registry->endpointConfig('document');
+
+        self::assertInstanceOf(AiEndpointConfig::class, $endpointConfig);
+        self::assertSame('https://openrouter.ai/api/v1/chat/completions/status', $endpointConfig->metadata['probe_url'] ?? null);
+        self::assertSame('POST', $endpointConfig->metadata['probe_method'] ?? null);
+    }
+
     public function testAwardGuidanceRequestCanonicalizesIdentifiersBeforePersistingPayload(): void
     {
         $request = new AwardGuidanceRequest(

--- a/apps/atomy-q/API/tests/Unit/Adapters/Ai/AiAdaptersTest.php
+++ b/apps/atomy-q/API/tests/Unit/Adapters/Ai/AiAdaptersTest.php
@@ -21,7 +21,7 @@ final class AiAdaptersTest extends TestCase
         $definitions = $catalog->all();
         $definitionsAgain = $catalog->all();
 
-        self::assertCount(20, $definitions);
+        self::assertGreaterThanOrEqual(20, count($definitions));
         self::assertSame($definitions[0], $definitionsAgain[0]);
         self::assertSame(
             $definitions[0],
@@ -54,6 +54,51 @@ final class AiAdaptersTest extends TestCase
         self::assertSame('anthropic', $registry->providerName());
         self::assertInstanceOf(AiEndpointConfig::class, $endpointConfig);
         self::assertSame('anthropic', $endpointConfig->providerName);
+    }
+
+    public function testConfiguredEndpointRegistryDefaultsOpenRouterProbeToModelsEndpoint(): void
+    {
+        $registry = new ConfiguredAiEndpointRegistry([
+            'provider' => [
+                'key' => 'openrouter',
+            ],
+            'endpoints' => [
+                'document' => [
+                    'uri' => 'https://openrouter.ai/api/v1/chat/completions',
+                ],
+            ],
+        ]);
+
+        $endpointConfig = $registry->endpointConfig('document');
+
+        self::assertInstanceOf(AiEndpointConfig::class, $endpointConfig);
+        self::assertSame(
+            'https://openrouter.ai/api/v1/models',
+            $endpointConfig->metadata['probe_url'] ?? null,
+        );
+        self::assertSame('GET', $endpointConfig->metadata['probe_method'] ?? null);
+    }
+
+    public function testConfiguredEndpointRegistryHonorsExplicitProbeOverrideForOpenRouter(): void
+    {
+        $registry = new ConfiguredAiEndpointRegistry([
+            'provider' => [
+                'key' => 'openrouter',
+            ],
+            'endpoints' => [
+                'document' => [
+                    'uri' => 'https://openrouter.ai/api/v1/chat/completions',
+                    'health_url' => 'https://status.example.test/ready',
+                    'health_method' => 'HEAD',
+                ],
+            ],
+        ]);
+
+        $endpointConfig = $registry->endpointConfig('document');
+
+        self::assertInstanceOf(AiEndpointConfig::class, $endpointConfig);
+        self::assertSame('https://status.example.test/ready', $endpointConfig->metadata['probe_url'] ?? null);
+        self::assertSame('HEAD', $endpointConfig->metadata['probe_method'] ?? null);
     }
 
     public function testAwardGuidanceRequestCanonicalizesIdentifiersBeforePersistingPayload(): void

--- a/apps/atomy-q/API/tests/Unit/Adapters/Ai/DocumentExtractionRequestTest.php
+++ b/apps/atomy-q/API/tests/Unit/Adapters/Ai/DocumentExtractionRequestTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Adapters\Ai;
+
+use App\Adapters\Ai\DTOs\DocumentExtractionRequest;
+use PHPUnit\Framework\TestCase;
+
+final class DocumentExtractionRequestTest extends TestCase
+{
+    /** @var list<string> */
+    private array $tempFiles = [];
+
+    public function testItRecognizesForwardSlashWindowsAbsolutePaths(): void
+    {
+        $request = $this->makeRequest();
+
+        $isAbsolutePath = \Closure::bind(
+            fn (string $path): bool => $this->isAbsolutePath($path),
+            $request,
+            DocumentExtractionRequest::class,
+        );
+
+        self::assertTrue($isAbsolutePath('C:/quotes/input.pdf'));
+        self::assertTrue($isAbsolutePath('C:\\quotes\\input.pdf'));
+    }
+
+    public function testItRejectsSiblingPrefixPathsOutsideAllowedBases(): void
+    {
+        $request = $this->makeRequest();
+
+        $pathWithinAllowedBases = \Closure::bind(
+            fn (string $path): bool => $this->pathWithinAllowedBases($path),
+            $request,
+            DocumentExtractionRequest::class,
+        );
+
+        self::assertFalse($pathWithinAllowedBases('/tmp-storage-evil/quote.pdf'));
+        self::assertTrue($pathWithinAllowedBases('/tmp/quote.pdf'));
+    }
+
+    private function makeRequest(): DocumentExtractionRequest
+    {
+        $file = tempnam(sys_get_temp_dir(), 'quote-doc-');
+        self::assertIsString($file);
+        file_put_contents($file, 'fixture');
+        $this->tempFiles[] = $file;
+
+        return new DocumentExtractionRequest(
+            tenantId: 'tenant-1',
+            rfqId: 'rfq-1',
+            quoteSubmissionId: 'quote-1',
+            filename: 'quote.pdf',
+            mimeType: 'application/pdf',
+            absolutePath: $file,
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->tempFiles as $file) {
+            @unlink($file);
+        }
+
+        parent::tearDown();
+    }
+}

--- a/apps/atomy-q/API/tests/Unit/Adapters/Ai/OpenRouterDocumentExtractionMapperTest.php
+++ b/apps/atomy-q/API/tests/Unit/Adapters/Ai/OpenRouterDocumentExtractionMapperTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Adapters\Ai;
+
+use PHPUnit\Framework\TestCase;
+use App\Adapters\Ai\Support\OpenRouterDocumentExtractionMapper;
+
+final class OpenRouterDocumentExtractionMapperTest extends TestCase
+{
+    public function testItMapsOpenRouterJsonContentToExtractedLines(): void
+    {
+        $mapper = new OpenRouterDocumentExtractionMapper();
+
+        $result = $mapper->map([
+            'choices' => [[
+                'message' => [
+                    'content' => json_encode([
+                        'vendor_name' => 'Kuching Utama Sdn Bhd',
+                        'quote_number' => '1809/2975',
+                        'currency' => 'RM',
+                        'total_amount' => 84.8,
+                        'line_items' => [[
+                            'description' => 'BREAKDOWN ASSIST JUMP START VEHICLE',
+                            'quantity' => 1,
+                            'unit_price' => 80,
+                            'total' => 84.8,
+                        ]],
+                        'payment_terms' => '50% deposit required before work can be carried out',
+                        'validity' => '30 days',
+                    ], JSON_THROW_ON_ERROR),
+                ],
+            ]],
+        ]);
+
+        self::assertSame('Kuching Utama Sdn Bhd', $result['vendor_name']);
+        self::assertSame('1809/2975', $result['quote_number']);
+        self::assertSame('MYR', $result['currency']);
+        self::assertSame(84.8, $result['total_amount']);
+        self::assertSame('BREAKDOWN ASSIST JUMP START VEHICLE', $result['lines'][0]['description']);
+        self::assertSame(1.0, $result['lines'][0]['quantity']);
+        self::assertSame(80.0, $result['lines'][0]['unit_price']);
+        self::assertSame(84.8, $result['lines'][0]['total']);
+        self::assertSame('50% deposit required before work can be carried out', $result['payment_terms']);
+        self::assertSame('30 days', $result['validity']);
+    }
+
+    public function testItMapsEmptyLineItemsAndMissingOptionalFields(): void
+    {
+        $mapper = new OpenRouterDocumentExtractionMapper();
+
+        $result = $mapper->map([
+            'choices' => [[
+                'message' => [
+                    'content' => json_encode([
+                        'vendor_name' => 'Kuching Utama Sdn Bhd',
+                        'quote_number' => '1809/2975',
+                        'currency' => 'RM',
+                        'total_amount' => 84.8,
+                        'line_items' => [],
+                    ], JSON_THROW_ON_ERROR),
+                ],
+            ]],
+        ]);
+
+        self::assertSame([], $result['lines']);
+        self::assertNull($result['payment_terms']);
+        self::assertNull($result['validity']);
+    }
+
+    public function testItThrowsWhenResponseContentIsNotJson(): void
+    {
+        $mapper = new OpenRouterDocumentExtractionMapper();
+
+        $this->expectException(\App\Adapters\Ai\Exceptions\AiTransportInvalidResponseException::class);
+        $this->expectExceptionMessage('Document provider response content was not valid JSON.');
+
+        $mapper->map([
+            'choices' => [[
+                'message' => [
+                    'content' => 'not-json',
+                ],
+            ]],
+        ]);
+    }
+
+    public function testItThrowsWhenChoicesAreMissing(): void
+    {
+        $mapper = new OpenRouterDocumentExtractionMapper();
+
+        $this->expectException(\App\Adapters\Ai\Exceptions\AiTransportInvalidResponseException::class);
+        $this->expectExceptionMessage('Document provider response did not include message content.');
+
+        $mapper->map([]);
+    }
+}

--- a/apps/atomy-q/API/tests/Unit/Adapters/Ai/OpenRouterDocumentExtractionMapperTest.php
+++ b/apps/atomy-q/API/tests/Unit/Adapters/Ai/OpenRouterDocumentExtractionMapperTest.php
@@ -4,8 +4,9 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Adapters\Ai;
 
-use PHPUnit\Framework\TestCase;
+use App\Adapters\Ai\Exceptions\AiTransportInvalidResponseException;
 use App\Adapters\Ai\Support\OpenRouterDocumentExtractionMapper;
+use PHPUnit\Framework\TestCase;
 
 final class OpenRouterDocumentExtractionMapperTest extends TestCase
 {
@@ -73,7 +74,7 @@ final class OpenRouterDocumentExtractionMapperTest extends TestCase
     {
         $mapper = new OpenRouterDocumentExtractionMapper();
 
-        $this->expectException(\App\Adapters\Ai\Exceptions\AiTransportInvalidResponseException::class);
+        $this->expectException(AiTransportInvalidResponseException::class);
         $this->expectExceptionMessage('Document provider response content was not valid JSON.');
 
         $mapper->map([
@@ -89,9 +90,59 @@ final class OpenRouterDocumentExtractionMapperTest extends TestCase
     {
         $mapper = new OpenRouterDocumentExtractionMapper();
 
-        $this->expectException(\App\Adapters\Ai\Exceptions\AiTransportInvalidResponseException::class);
+        $this->expectException(AiTransportInvalidResponseException::class);
         $this->expectExceptionMessage('Document provider response did not include message content.');
 
         $mapper->map([]);
+    }
+
+    public function testItStripsAnyCaseInsensitiveMarkdownFenceAndParsesFormattedNumbers(): void
+    {
+        $mapper = new OpenRouterDocumentExtractionMapper();
+
+        $result = $mapper->map([
+            'choices' => [[
+                'message' => [
+                    'content' => <<<JSON
+```JSON
+{"currency":"RM","total_amount":"(1,234.56)","line_items":[{"description":"Pump","quantity":"1,234.56","unit_price":"(45.67)","total":"1,188.89"}]}
+```
+JSON,
+                ],
+            ]],
+        ]);
+
+        self::assertSame('MYR', $result['currency']);
+        self::assertSame(-1234.56, $result['total_amount']);
+        self::assertSame(1234.56, $result['lines'][0]['quantity']);
+        self::assertSame(-45.67, $result['lines'][0]['unit_price']);
+        self::assertSame(1188.89, $result['lines'][0]['total']);
+    }
+
+    public function testItRejectsAmbiguousLocaleFormattedNumbers(): void
+    {
+        $mapper = new OpenRouterDocumentExtractionMapper();
+
+        $result = $mapper->map([
+            'choices' => [[
+                'message' => [
+                    'content' => json_encode([
+                        'currency' => 'RM',
+                        'total_amount' => '1.234,56',
+                        'line_items' => [[
+                            'description' => 'Pump',
+                            'quantity' => '1.234,56',
+                            'unit_price' => '12-3',
+                            'total' => '1.234,56',
+                        ]],
+                    ], JSON_THROW_ON_ERROR),
+                ],
+            ]],
+        ]);
+
+        self::assertNull($result['total_amount']);
+        self::assertSame(1.0, $result['lines'][0]['quantity']);
+        self::assertNull($result['lines'][0]['unit_price']);
+        self::assertNull($result['lines'][0]['total']);
     }
 }

--- a/apps/atomy-q/API/tests/Unit/Adapters/Ai/OpenRouterDocumentPayloadFactoryTest.php
+++ b/apps/atomy-q/API/tests/Unit/Adapters/Ai/OpenRouterDocumentPayloadFactoryTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Adapters\Ai;
+
+use PHPUnit\Framework\TestCase;
+use App\Adapters\Ai\DTOs\DocumentExtractionRequest;
+use App\Adapters\Ai\Support\OpenRouterDocumentPayloadFactory;
+
+final class OpenRouterDocumentPayloadFactoryTest extends TestCase
+{
+    public function testItBuildsOpenRouterPdfPayloadWithMistralOcrPlugin(): void
+    {
+        $file = tempnam(sys_get_temp_dir(), 'quote-pdf-');
+        self::assertIsString($file);
+        file_put_contents($file, '%PDF-1.7 sample');
+
+        $factory = new OpenRouterDocumentPayloadFactory(
+            modelId: 'baidu/qianfan-ocr-fast:free',
+            parserPlugin: 'file-parser',
+            pdfEngine: 'mistral-ocr',
+        );
+
+        try {
+            $payload = $factory->build(new DocumentExtractionRequest(
+                tenantId: 'tenant-1',
+                rfqId: 'rfq-1',
+                quoteSubmissionId: 'quote-1',
+                filename: 'quote.pdf',
+                mimeType: 'application/pdf',
+                absolutePath: $file,
+            ));
+
+            self::assertSame('baidu/qianfan-ocr-fast:free', $payload['model']);
+            self::assertArrayHasKey('plugins', $payload);
+            self::assertIsArray($payload['plugins']);
+            self::assertCount(1, $payload['plugins']);
+            self::assertArrayHasKey(0, $payload['plugins']);
+            self::assertArrayHasKey('id', $payload['plugins'][0]);
+            self::assertArrayHasKey('pdf', $payload['plugins'][0]);
+            self::assertSame('file-parser', $payload['plugins'][0]['id']);
+            self::assertSame('mistral-ocr', $payload['plugins'][0]['pdf']['engine']);
+            self::assertArrayHasKey('messages', $payload);
+            self::assertIsArray($payload['messages']);
+            self::assertCount(1, $payload['messages']);
+            self::assertArrayHasKey('content', $payload['messages'][0]);
+            self::assertIsArray($payload['messages'][0]['content']);
+            self::assertCount(2, $payload['messages'][0]['content']);
+            self::assertSame('file', $payload['messages'][0]['content'][1]['type']);
+            self::assertArrayHasKey('file', $payload['messages'][0]['content'][1]);
+            self::assertArrayHasKey('file_data', $payload['messages'][0]['content'][1]['file']);
+            self::assertStringStartsWith(
+                'data:application/pdf;base64,',
+                $payload['messages'][0]['content'][1]['file']['file_data'],
+            );
+        } finally {
+            @unlink($file);
+        }
+    }
+
+    public function testItRejectsFilesAboveConfiguredMaxSize(): void
+    {
+        $file = tempnam(sys_get_temp_dir(), 'quote-pdf-');
+        self::assertIsString($file);
+        file_put_contents($file, '123456');
+
+        $factory = new OpenRouterDocumentPayloadFactory(
+            modelId: 'baidu/qianfan-ocr-fast:free',
+            parserPlugin: 'file-parser',
+            pdfEngine: 'mistral-ocr',
+            maxFileSizeBytes: 5,
+        );
+
+        try {
+            $this->expectException(\InvalidArgumentException::class);
+            $this->expectExceptionMessage('Quote document file exceeds the maximum supported size');
+
+            $factory->build(new DocumentExtractionRequest(
+                tenantId: 'tenant-1',
+                rfqId: 'rfq-1',
+                quoteSubmissionId: 'quote-1',
+                filename: 'quote.pdf',
+                mimeType: 'application/pdf',
+                absolutePath: $file,
+            ));
+        } finally {
+            @unlink($file);
+        }
+    }
+}

--- a/apps/atomy-q/API/tests/Unit/Adapters/Ai/ProviderDocumentIntelligenceClientTest.php
+++ b/apps/atomy-q/API/tests/Unit/Adapters/Ai/ProviderDocumentIntelligenceClientTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Adapters\Ai;
+
+use Nexus\IntelligenceOperations\DTOs\AiStatusSchema;
+use App\Adapters\Ai\ProviderDocumentIntelligenceClient;
+use App\Adapters\Ai\Contracts\ProviderAiTransportInterface;
+use App\Adapters\Ai\DTOs\DocumentExtractionRequest;
+use App\Adapters\Ai\Support\OpenRouterDocumentExtractionMapper;
+use App\Adapters\Ai\Support\OpenRouterDocumentPayloadFactory;
+use PHPUnit\Framework\TestCase;
+
+final class ProviderDocumentIntelligenceClientTest extends TestCase
+{
+    public function testExtractDocumentBuildsPayloadAndMapsResponse(): void
+    {
+        $file = tempnam(sys_get_temp_dir(), 'quote-pdf-');
+        self::assertIsString($file);
+        file_put_contents($file, '%PDF-1.7 sample');
+
+        try {
+            $transport = new class implements ProviderAiTransportInterface {
+                /** @var array<string, mixed> */
+                public array $payload = [];
+
+                public function invoke(string $endpointGroup, array $payload): array
+                {
+                    TestCase::assertSame(AiStatusSchema::ENDPOINT_GROUP_DOCUMENT, $endpointGroup);
+                    $this->payload = $payload;
+
+                    return [
+                        'choices' => [[
+                            'message' => [
+                                'content' => '{"line_items":[{"description":"Pump","quantity":2,"unit_price":10}]}',
+                            ],
+                        ]],
+                    ];
+                }
+            };
+
+            $client = new ProviderDocumentIntelligenceClient(
+                transport: $transport,
+                payloadFactory: new OpenRouterDocumentPayloadFactory('model-a', 'file-parser', 'mistral-ocr'),
+                mapper: new OpenRouterDocumentExtractionMapper(),
+            );
+
+            $result = $client->extractDocument(new DocumentExtractionRequest(
+                tenantId: 'tenant-1',
+                rfqId: 'rfq-1',
+                quoteSubmissionId: 'quote-1',
+                filename: 'quote.pdf',
+                mimeType: 'application/pdf',
+                absolutePath: $file,
+            ));
+
+            self::assertSame('model-a', $transport->payload['model']);
+            self::assertSame('Pump', $result['lines'][0]['description']);
+        } finally {
+            @unlink($file);
+        }
+    }
+}

--- a/apps/atomy-q/API/tests/Unit/Adapters/Ai/ProviderDocumentIntelligenceClientTest.php
+++ b/apps/atomy-q/API/tests/Unit/Adapters/Ai/ProviderDocumentIntelligenceClientTest.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Tests\Unit\Adapters\Ai;
 
 use Nexus\IntelligenceOperations\DTOs\AiStatusSchema;
-use App\Adapters\Ai\ProviderDocumentIntelligenceClient;
 use App\Adapters\Ai\Contracts\ProviderAiTransportInterface;
 use App\Adapters\Ai\DTOs\DocumentExtractionRequest;
+use App\Adapters\Ai\ProviderDocumentIntelligenceClient;
 use App\Adapters\Ai\Support\OpenRouterDocumentExtractionMapper;
 use App\Adapters\Ai\Support\OpenRouterDocumentPayloadFactory;
 use PHPUnit\Framework\TestCase;

--- a/apps/atomy-q/WEB/package-lock.json
+++ b/apps/atomy-q/WEB/package-lock.json
@@ -35,6 +35,7 @@
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "cross-env": "^10.1.0",
         "eslint": "^9",
         "eslint-config-next": "16.1.6",
         "jsdom": "^26.1.0",
@@ -481,6 +482,13 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@epic-web/invariant": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
+      "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.4",
@@ -4349,6 +4357,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cross-env": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.1.0.tgz",
+      "integrity": "sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@epic-web/invariant": "^1.0.0",
+        "cross-spawn": "^7.0.6"
+      },
+      "bin": {
+        "cross-env": "dist/bin/cross-env.js",
+        "cross-env-shell": "dist/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -5603,6 +5629,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/apps/atomy-q/WEB/package.json
+++ b/apps/atomy-q/WEB/package.json
@@ -10,12 +10,15 @@
     "generate:api": "openapi-ts -i ../openapi/openapi.json -o src/generated/api -c @hey-api/client-fetch",
     "test:unit": "vitest run",
     "test:unit:watch": "vitest",
+    "test:unit:provider-quote-fixtures": "vitest run --config tests/support/vitest.provider-quote.config.ts",
     "test:e2e": "playwright test",
     "test:e2e:ci": "playwright test --reporter=line",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:headed": "playwright test --headed",
     "test:e2e:debug": "PWDEBUG=1 playwright test",
-    "test:e2e:install": "playwright install --with-deps"
+    "test:e2e:install": "playwright install --with-deps",
+    "test:e2e:provider-quote:fake": "cross-env NEXT_PUBLIC_AI_MODE=provider playwright test tests/provider-quote-e2e.spec.ts",
+    "test:e2e:provider-quote:live": "cross-env AI_PROVIDER_E2E=true AI_MODE=provider NEXT_PUBLIC_AI_MODE=provider playwright test tests/provider-quote-live.spec.ts"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
@@ -45,6 +48,7 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "cross-env": "^10.1.0",
     "eslint": "^9",
     "eslint-config-next": "16.1.6",
     "jsdom": "^26.1.0",

--- a/apps/atomy-q/WEB/playwright.config.ts
+++ b/apps/atomy-q/WEB/playwright.config.ts
@@ -12,6 +12,15 @@ const webServerCommand =
   process.env.PLAYWRIGHT_WEB_SERVER_COMMAND ?? `npm run dev -- --port ${port}`;
 // When USE_EXISTING_SERVER=1, assume app is already running (no webServer). Set PLAYWRIGHT_BASE_URL if not on 3100.
 const useExistingServer = process.env.PLAYWRIGHT_USE_EXISTING_SERVER === '1';
+const webServerEnv: Record<string, string> = {
+  NEXT_PUBLIC_USE_MOCKS: process.env.NEXT_PUBLIC_USE_MOCKS ?? 'false',
+  NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:8000/api/v1',
+  E2E_API_URL: process.env.E2E_API_URL ?? process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:8000/api/v1',
+};
+
+if (process.env.NEXT_PUBLIC_AI_MODE !== undefined) {
+  webServerEnv.NEXT_PUBLIC_AI_MODE = process.env.NEXT_PUBLIC_AI_MODE;
+}
 
 export default defineConfig({
   testDir: './tests',
@@ -34,11 +43,7 @@ export default defineConfig({
           url: baseURL,
           reuseExistingServer: !isCI,
           timeout: 120000,
-          env: {
-            NEXT_PUBLIC_USE_MOCKS: process.env.NEXT_PUBLIC_USE_MOCKS ?? 'false',
-            NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL,
-            E2E_API_URL: process.env.E2E_API_URL,
-          },
+          env: webServerEnv,
         },
       }),
   projects: [

--- a/apps/atomy-q/WEB/tests/provider-quote-e2e.spec.ts
+++ b/apps/atomy-q/WEB/tests/provider-quote-e2e.spec.ts
@@ -5,7 +5,7 @@ import { expect, test } from '@playwright/test';
 import { seedAuthSession } from './playwright-auth-bootstrap';
 import { discoverProviderQuoteFixtures } from './support/providerQuoteFixtures';
 
-const fixtures = discoverProviderQuoteFixtures(path.resolve(process.cwd(), '../../..', 'sample'));
+const fixtures = discoverProviderQuoteFixtures(path.resolve(__dirname, '../../../../sample'));
 const fixture = fixtures[0];
 const rfqId = 'rfq-provider-fake';
 

--- a/apps/atomy-q/WEB/tests/provider-quote-e2e.spec.ts
+++ b/apps/atomy-q/WEB/tests/provider-quote-e2e.spec.ts
@@ -1,0 +1,142 @@
+import path from 'node:path';
+
+import { expect, test } from '@playwright/test';
+
+import { seedAuthSession } from './playwright-auth-bootstrap';
+import { discoverProviderQuoteFixtures } from './support/providerQuoteFixtures';
+
+const fixtures = discoverProviderQuoteFixtures(path.resolve(process.cwd(), '../../..', 'sample'));
+const fixture = fixtures[0];
+const rfqId = 'rfq-provider-fake';
+
+test.describe('provider quote e2e with mocked API responses', () => {
+  test.skip(!fixture, 'No sample requisition metadata folders found under sample/.');
+
+  test('renders quote-intake provider extraction state from folder fixtures', async ({ page }) => {
+    if (!fixture) {
+      test.fail(true, 'Fixture discovery returned no sample folders.');
+      return;
+    }
+
+    await seedAuthSession(page, {
+      id: 'user-provider-fake',
+      name: fixture.buyer.name,
+      email: 'provider-fake@example.com',
+      role: 'admin',
+      tenantId: fixture.buyer.tenantReference,
+    });
+
+    await page.route('**/api/v1/**', async (route) => {
+      const url = new URL(route.request().url());
+      const pathname = url.pathname;
+
+      if (pathname.endsWith('/ai/status')) {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            data: {
+              mode: 'provider',
+              global_health: 'healthy',
+              provider_name: 'openrouter-fake',
+              reason_codes: ['provider_available'],
+              capability_statuses: {
+                quote_document_extraction: {
+                  available: true,
+                  status: 'available',
+                  fallback_ui_mode: 'show_manual_continuity_banner',
+                  operator_critical: true,
+                  reason_codes: ['provider_available'],
+                },
+                normalization_suggestions: {
+                  available: true,
+                  status: 'available',
+                  fallback_ui_mode: 'show_manual_continuity_banner',
+                  operator_critical: true,
+                  reason_codes: ['provider_available'],
+                },
+              },
+            },
+          }),
+        });
+        return;
+      }
+
+      if (pathname.endsWith(`/rfqs/${rfqId}`)) {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            data: {
+              id: rfqId,
+              title: fixture.title,
+              description: `${fixture.title} fixture`,
+              status: 'draft',
+              quotes_count: fixture.quotes.length,
+              vendors_count: fixture.quotes.length,
+              submission_deadline: new Date(Date.now() + fixture.submissionDeadlineDaysFromNow * 86400000).toISOString(),
+            },
+          }),
+        });
+        return;
+      }
+
+      if (pathname.endsWith('/quote-submissions') && url.searchParams.get('rfq_id') === rfqId) {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            data: fixture.quotes.map((quote, index) => ({
+              id: `quote-${index + 1}`,
+              rfq_id: rfqId,
+              vendor_id: `vendor-${index + 1}`,
+              vendor_name: quote.vendorName,
+              original_filename: quote.file,
+              file_name: quote.file,
+              status: fixture.e2e.assertions.uploadStatus[0] ?? 'needs_review',
+              confidence: 91,
+              submitted_at: new Date().toISOString(),
+              blocking_issue_count: 0,
+              extraction_origin: 'provider',
+              provider_name: 'openrouter-fake',
+            })),
+            meta: {
+              total: fixture.quotes.length,
+            },
+          }),
+        });
+        return;
+      }
+
+      if (pathname.endsWith(`/normalization/${rfqId}/conflicts`)) {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            data: [],
+            meta: {
+              rfq_id: rfqId,
+              has_blocking_issues: false,
+              blocking_issue_count: 0,
+            },
+          }),
+        });
+        return;
+      }
+
+      await route.fulfill({
+        status: 404,
+        contentType: 'application/json',
+        body: JSON.stringify({ message: `Unhandled mocked API path: ${pathname}` }),
+      });
+    });
+
+    await page.goto(`/rfqs/${rfqId}/quote-intake`);
+
+    await expect(page.getByText(/AI-assisted quote extraction/i)).toBeVisible();
+    await expect(page.getByText(/provider extraction active via openrouter-fake/i)).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Quote Intake' })).toBeVisible();
+    await expect(page.getByRole('cell', { name: fixture.quotes[0]?.vendorName ?? '' })).toBeVisible();
+    await expect(page.getByText(fixture.quotes[0]?.file ?? '')).toBeVisible();
+  });
+});

--- a/apps/atomy-q/WEB/tests/provider-quote-live.spec.ts
+++ b/apps/atomy-q/WEB/tests/provider-quote-live.spec.ts
@@ -1,0 +1,168 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { expect, test } from '@playwright/test';
+
+import { seedAuthSession } from './playwright-auth-bootstrap';
+import { discoverProviderQuoteFixtures } from './support/providerQuoteFixtures';
+
+const liveEnabled = process.env.AI_PROVIDER_E2E === 'true';
+const requestedFixtureId = process.env.PROVIDER_QUOTE_FIXTURE?.trim() ?? '';
+const sampleRoot = path.resolve(__dirname, '../../../../sample');
+const discoveredFixtures = discoverProviderQuoteFixtures(sampleRoot);
+const fixtures = requestedFixtureId === ''
+  ? discoveredFixtures.slice(0, 1)
+  : discoveredFixtures.filter((fixture) => fixture.requisitionId === requestedFixtureId);
+
+test.describe('provider-backed quote e2e with live OpenRouter', () => {
+  test.describe.configure({ mode: 'serial' });
+  test.setTimeout(180_000);
+  test.skip(!liveEnabled, 'Set AI_PROVIDER_E2E=true to run live provider quote e2e.');
+  test.skip(discoveredFixtures.length === 0, 'No sample requisition metadata folders found under sample/.');
+  test.skip(
+    requestedFixtureId !== '' && fixtures.length === 0,
+    `No sample requisition matched PROVIDER_QUOTE_FIXTURE=${requestedFixtureId}.`,
+  );
+
+  for (const fixture of fixtures) {
+    test(`uploads provider quotes for ${fixture.requisitionId}`, async ({ page, request }) => {
+      const apiBase = process.env.NEXT_PUBLIC_API_URL ?? process.env.E2E_API_URL ?? 'http://localhost:8000/api/v1';
+      const email = process.env.E2E_EMAIL ?? 'user1@example.com';
+      const password = process.env.E2E_PASSWORD ?? 'secret';
+
+      expect(process.env.AI_MODE).toBe('provider');
+      expect(fixture.e2e.provider).toBe('openrouter');
+      expect(fixture.e2e.documentParser.pdfEngine).toBe('mistral-ocr');
+
+      const loginResponse = await request.post(`${apiBase}/auth/login`, {
+        data: { email, password },
+      });
+      expect(loginResponse.ok()).toBeTruthy();
+
+      const loginPayload = await loginResponse.json();
+      const token = String(loginPayload.access_token ?? loginPayload.token ?? '');
+      expect(token).not.toBe('');
+
+      const user = loginPayload.user as {
+        id: string;
+        name: string;
+        email: string;
+        role: string;
+        tenant_id?: string;
+        tenantId?: string;
+      };
+
+      await seedAuthSession(page, {
+        id: user.id,
+        name: user.name,
+        email: user.email,
+        role: user.role,
+        tenantId: String(user.tenant_id ?? user.tenantId ?? ''),
+      }, {
+        token,
+        refreshToken: loginPayload.refresh_token ?? null,
+      });
+
+      const timestamp = Date.now();
+      const createRfqResponse = await request.post(`${apiBase}/rfqs`, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+          'Idempotency-Key': `provider-quote-rfq-${fixture.requisitionId}-${timestamp}`,
+        },
+        data: {
+          title: `${fixture.title} ${timestamp}`,
+          description: fixture.title,
+          category: 'Services',
+          department: 'Procurement',
+          estimated_value: 1000,
+          submission_deadline: new Date(Date.now() + fixture.submissionDeadlineDaysFromNow * 86400000).toISOString(),
+        },
+      });
+      expect(createRfqResponse.ok()).toBeTruthy();
+      const createRfqPayload = await createRfqResponse.json();
+      const rfqId = String(createRfqPayload.data?.id ?? '');
+      expect(rfqId).not.toBe('');
+
+      for (const lineItem of fixture.rfqLineItems) {
+        const lineResponse = await request.post(`${apiBase}/rfqs/${encodeURIComponent(rfqId)}/line-items`, {
+          headers: {
+            Authorization: `Bearer ${token}`,
+            'Content-Type': 'application/json',
+          },
+          data: {
+            description: lineItem.description,
+            quantity: lineItem.quantity,
+            uom: lineItem.uom,
+            unit_price: 0,
+            currency: fixture.currency,
+          },
+        });
+        expect(lineResponse.ok()).toBeTruthy();
+      }
+
+      for (const [index, quote] of fixture.quotes.entries()) {
+        const uploadResponse = await request.post(`${apiBase}/quote-submissions/upload`, {
+          headers: {
+            Authorization: `Bearer ${token}`,
+            'Idempotency-Key': `provider-quote-upload-${fixture.requisitionId}-${index}-${timestamp}`,
+          },
+          multipart: {
+            rfq_id: rfqId,
+            vendor_id: `vendor-${index + 1}`,
+            vendor_name: quote.vendorName,
+            file: {
+              name: quote.file,
+              mimeType: quote.mimeType,
+              buffer: fs.readFileSync(quote.filePath),
+            },
+          },
+        });
+        expect(uploadResponse.ok()).toBeTruthy();
+
+        const uploadPayload = await uploadResponse.json();
+        expect(['uploaded', ...fixture.e2e.assertions.uploadStatus]).toContain(uploadPayload.data?.status);
+      }
+
+      await expect
+        .poll(async () => {
+          const sourceLinesResponse = await request.get(
+            `${apiBase}/normalization/${encodeURIComponent(rfqId)}/source-lines`,
+            {
+              headers: {
+                Authorization: `Bearer ${token}`,
+              },
+            },
+          );
+          expect(sourceLinesResponse.ok()).toBeTruthy();
+
+          const sourceLinesPayload = await sourceLinesResponse.json();
+          expect(Array.isArray(sourceLinesPayload.data)).toBeTruthy();
+
+          return sourceLinesPayload.data.length;
+        }, {
+          timeout: 120_000,
+          intervals: [1_000, 2_000, 5_000],
+        })
+        .toBeGreaterThanOrEqual(fixture.e2e.assertions.sourceLinesMin);
+
+      const quoteSubmissionsResponse = await request.get(
+        `${apiBase}/quote-submissions?rfq_id=${encodeURIComponent(rfqId)}`,
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        },
+      );
+      expect(quoteSubmissionsResponse.ok()).toBeTruthy();
+
+      const quoteSubmissionsPayload = await quoteSubmissionsResponse.json();
+      const visibleVendorName = (quoteSubmissionsPayload.data as Array<{ vendor_name?: string; status?: string }> | undefined)
+        ?.find((submission) => submission.status !== 'failed' && submission.vendor_name)?.vendor_name;
+      expect(visibleVendorName).toBeTruthy();
+
+      await page.goto(`/rfqs/${encodeURIComponent(rfqId)}/quote-intake`);
+      await expect(page.getByRole('heading', { name: 'Quote Intake' })).toBeVisible();
+    });
+  }
+});

--- a/apps/atomy-q/WEB/tests/provider-quote-live.spec.ts
+++ b/apps/atomy-q/WEB/tests/provider-quote-live.spec.ts
@@ -10,6 +10,8 @@ const liveEnabled = process.env.AI_PROVIDER_E2E === 'true';
 const requestedFixtureId = process.env.PROVIDER_QUOTE_FIXTURE?.trim() ?? '';
 const sampleRoot = path.resolve(__dirname, '../../../../sample');
 const discoveredFixtures = discoverProviderQuoteFixtures(sampleRoot);
+// Default to one live fixture to control provider cost and quota pressure; set
+// AI_PROVIDER_E2E=true plus PROVIDER_QUOTE_FIXTURE=<requisition_id> to target another sample.
 const fixtures = requestedFixtureId === ''
   ? discoveredFixtures.slice(0, 1)
   : discoveredFixtures.filter((fixture) => fixture.requisitionId === requestedFixtureId);
@@ -121,7 +123,7 @@ test.describe('provider-backed quote e2e with live OpenRouter', () => {
         expect(uploadResponse.ok()).toBeTruthy();
 
         const uploadPayload = await uploadResponse.json();
-        expect(['uploaded', ...fixture.e2e.assertions.uploadStatus]).toContain(uploadPayload.data?.status);
+        expect(fixture.e2e.assertions.uploadStatus).toContain(uploadPayload.data?.status);
       }
 
       await expect

--- a/apps/atomy-q/WEB/tests/support/providerQuoteFixtures.test.ts
+++ b/apps/atomy-q/WEB/tests/support/providerQuoteFixtures.test.ts
@@ -7,7 +7,7 @@ import { discoverProviderQuoteFixtures, parseProviderQuoteFixture } from './prov
 
 describe('providerQuoteFixtures', () => {
   it('parses the sample metadata example and resolves quote pdf paths', () => {
-    const sampleDir = path.resolve(process.cwd(), '../../..', 'sample');
+    const sampleDir = path.resolve(__dirname, '../../../../../sample');
     const fixture = parseProviderQuoteFixture({
       baseDir: sampleDir,
       metadataPath: path.resolve(sampleDir, 'metadata.example.json'),
@@ -24,7 +24,7 @@ describe('providerQuoteFixtures', () => {
   });
 
   it('discovers folder-based metadata fixtures and ignores the root example file', () => {
-    const sampleDir = path.resolve(process.cwd(), '../../..', 'sample');
+    const sampleDir = path.resolve(__dirname, '../../../../../sample');
     const fixtures = discoverProviderQuoteFixtures(sampleDir);
 
     expect(fixtures.length).toBeGreaterThan(0);

--- a/apps/atomy-q/WEB/tests/support/providerQuoteFixtures.test.ts
+++ b/apps/atomy-q/WEB/tests/support/providerQuoteFixtures.test.ts
@@ -1,0 +1,40 @@
+import path from 'node:path';
+import fs from 'node:fs';
+
+import { describe, expect, it } from 'vitest';
+
+import { discoverProviderQuoteFixtures, parseProviderQuoteFixture } from './providerQuoteFixtures';
+
+describe('providerQuoteFixtures', () => {
+  it('parses the sample metadata example and resolves quote pdf paths', () => {
+    const sampleDir = path.resolve(process.cwd(), '../../..', 'sample');
+    const fixture = parseProviderQuoteFixture({
+      baseDir: sampleDir,
+      metadataPath: path.resolve(sampleDir, 'metadata.example.json'),
+    });
+
+    expect(fixture.requisitionId).toBe('vehicle-service-rfq');
+    expect(fixture.rfqLineItems).toHaveLength(1);
+    expect(fixture.quotes).toHaveLength(1);
+    expect(fixture.quotes[0]?.file).toBe('1A/1A-1.pdf');
+    expect(fixture.quotes[0]?.filePath).toBe(
+      path.resolve(sampleDir, '1A/1A-1.pdf'),
+    );
+    expect(fixture.e2e.documentParser.pdfEngine).toBe('mistral-ocr');
+  });
+
+  it('discovers folder-based metadata fixtures and ignores the root example file', () => {
+    const sampleDir = path.resolve(process.cwd(), '../../..', 'sample');
+    const fixtures = discoverProviderQuoteFixtures(sampleDir);
+
+    expect(fixtures.length).toBeGreaterThan(0);
+    fixtures.forEach((fixture) => {
+      expect(path.basename(fixture.metadataPath)).toBe('metadata.json');
+      expect(fixture.requisitionId).not.toBe('vehicle-service-rfq');
+      expect(fixture.e2e.requiresLiveProvider).toBe(true);
+      fixture.quotes.forEach((quote) => {
+        expect(fs.existsSync(quote.filePath), quote.filePath).toBe(true);
+      });
+    });
+  });
+});

--- a/apps/atomy-q/WEB/tests/support/providerQuoteFixtures.ts
+++ b/apps/atomy-q/WEB/tests/support/providerQuoteFixtures.ts
@@ -144,8 +144,13 @@ function parseQuote(
   const quote = expectRecord(value, name);
   const expected = expectRecord(quote.expected, `${name}.expected`);
   const file = expectString(quote.file, `${name}.file`);
-  const filePath = path.join(baseDir, file);
-  if (!fs.existsSync(filePath)) {
+  const filePath = path.resolve(baseDir, file);
+  const relativePath = path.relative(baseDir, filePath);
+  if (
+    relativePath.startsWith('..')
+    || path.isAbsolute(relativePath)
+    || !fs.existsSync(filePath)
+  ) {
     throw new Error(`Invalid provider quote fixture: ${name}.file resolved to missing file ${filePath}.`);
   }
 
@@ -217,7 +222,7 @@ function expectString(value: unknown, name: string): string {
     throw new Error(`Invalid provider quote fixture: ${name} must be a non-empty string.`);
   }
 
-  return value;
+  return value.trim();
 }
 
 function expectStringArray(value: unknown, name: string): string[] {

--- a/apps/atomy-q/WEB/tests/support/providerQuoteFixtures.ts
+++ b/apps/atomy-q/WEB/tests/support/providerQuoteFixtures.ts
@@ -1,0 +1,257 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+export interface ProviderQuoteFixtureInput {
+  baseDir: string;
+  metadataPath: string;
+}
+
+export interface ProviderQuoteFixture {
+  metadataPath: string;
+  baseDir: string;
+  requisitionId: string;
+  title: string;
+  buyer: {
+    name: string;
+    tenantReference: string;
+  };
+  currency: string;
+  submissionDeadlineDaysFromNow: number;
+  rfqLineItems: Array<{
+    lineReference: string;
+    description: string;
+    quantity: number;
+    uom: string;
+    expectedKeywords: string[];
+  }>;
+  quotes: Array<{
+    vendorReference: string;
+    vendorName: string;
+    file: string;
+    filePath: string;
+    mimeType: string;
+    expected: {
+      quoteNumber: string | null;
+      quoteDate: string | null;
+      currency: string | null;
+      totalAmount: number | null;
+      subtotalAmount: number | null;
+      discountAmount: number | null;
+      lineCountMin: number;
+      lineKeywords: string[];
+      paymentTermsKeywords: string[];
+      validityKeywords: string[];
+    };
+  }>;
+  e2e: {
+    requiresLiveProvider: boolean;
+    provider: string;
+    documentParser: {
+      plugin: string;
+      pdfEngine: string;
+    };
+    assertions: {
+      uploadStatus: string[];
+      sourceLinesMin: number;
+      allowManualMappingCompletion: boolean;
+    };
+  };
+}
+
+export function discoverProviderQuoteFixtures(sampleRoot: string): ProviderQuoteFixture[] {
+  const absoluteRoot = path.resolve(sampleRoot);
+  if (!fs.existsSync(absoluteRoot)) {
+    return [];
+  }
+
+  return fs
+    .readdirSync(absoluteRoot, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => {
+      const baseDir = path.join(absoluteRoot, entry.name);
+
+      return parseProviderQuoteFixture({
+        baseDir,
+        metadataPath: path.join(baseDir, 'metadata.json'),
+      });
+    })
+    .sort((left, right) => left.requisitionId.localeCompare(right.requisitionId));
+}
+
+export function parseProviderQuoteFixture(input: ProviderQuoteFixtureInput): ProviderQuoteFixture {
+  const metadataPath = path.resolve(input.metadataPath);
+  const baseDir = path.resolve(input.baseDir);
+
+  if (!fs.existsSync(metadataPath)) {
+    throw new Error(`Provider quote fixture metadata not found: ${metadataPath}`);
+  }
+
+  let raw: Record<string, unknown>;
+
+  try {
+    raw = JSON.parse(fs.readFileSync(metadataPath, 'utf8')) as Record<string, unknown>;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to parse JSON at ${metadataPath}: ${message}`);
+  }
+
+  return {
+    metadataPath,
+    baseDir,
+    requisitionId: expectString(raw.requisition_id, 'requisition_id'),
+    title: expectString(raw.title, 'title'),
+    buyer: parseBuyer(raw.buyer),
+    currency: expectString(raw.currency, 'currency'),
+    submissionDeadlineDaysFromNow: expectNumber(
+      raw.submission_deadline_days_from_now,
+      'submission_deadline_days_from_now',
+    ),
+    rfqLineItems: expectArray(raw.rfq_line_items, 'rfq_line_items').map((value, index) =>
+      parseLineItem(value, `rfq_line_items[${index}]`),
+    ),
+    quotes: expectArray(raw.quotes, 'quotes').map((value, index) => parseQuote(value, `quotes[${index}]`, baseDir)),
+    e2e: parseE2e(raw.e2e),
+  };
+}
+
+function parseBuyer(value: unknown): ProviderQuoteFixture['buyer'] {
+  const buyer = expectRecord(value, 'buyer');
+  return {
+    name: expectString(buyer.name, 'buyer.name'),
+    tenantReference: expectString(buyer.tenant_reference, 'buyer.tenant_reference'),
+  };
+}
+
+function parseLineItem(
+  value: unknown,
+  name: string,
+): ProviderQuoteFixture['rfqLineItems'][number] {
+  const line = expectRecord(value, name);
+  return {
+    lineReference: expectString(line.line_reference, `${name}.line_reference`),
+    description: expectString(line.description, `${name}.description`),
+    quantity: expectNumber(line.quantity, `${name}.quantity`),
+    uom: expectString(line.uom, `${name}.uom`),
+    expectedKeywords: expectStringArray(line.expected_keywords, `${name}.expected_keywords`),
+  };
+}
+
+function parseQuote(
+  value: unknown,
+  name: string,
+  baseDir: string,
+): ProviderQuoteFixture['quotes'][number] {
+  const quote = expectRecord(value, name);
+  const expected = expectRecord(quote.expected, `${name}.expected`);
+  const file = expectString(quote.file, `${name}.file`);
+  const filePath = path.join(baseDir, file);
+  if (!fs.existsSync(filePath)) {
+    throw new Error(`Invalid provider quote fixture: ${name}.file resolved to missing file ${filePath}.`);
+  }
+
+  return {
+    vendorReference: expectString(quote.vendor_reference, `${name}.vendor_reference`),
+    vendorName: expectString(quote.vendor_name, `${name}.vendor_name`),
+    file,
+    filePath,
+    mimeType: expectString(quote.mime_type, `${name}.mime_type`),
+    expected: {
+      quoteNumber: optionalString(expected.quote_number, `${name}.expected.quote_number`),
+      quoteDate: optionalString(expected.quote_date, `${name}.expected.quote_date`),
+      currency: optionalString(expected.currency, `${name}.expected.currency`),
+      totalAmount: optionalNumber(expected.total_amount, `${name}.expected.total_amount`),
+      subtotalAmount: optionalNumber(expected.subtotal_amount, `${name}.expected.subtotal_amount`),
+      discountAmount: optionalNumber(expected.discount_amount, `${name}.expected.discount_amount`),
+      lineCountMin: expectNumber(expected.line_count_min, `${name}.expected.line_count_min`),
+      lineKeywords: expectStringArray(expected.line_keywords, `${name}.expected.line_keywords`),
+      paymentTermsKeywords: expectStringArray(
+        expected.payment_terms_keywords,
+        `${name}.expected.payment_terms_keywords`,
+      ),
+      validityKeywords: expectStringArray(expected.validity_keywords, `${name}.expected.validity_keywords`),
+    },
+  };
+}
+
+function parseE2e(value: unknown): ProviderQuoteFixture['e2e'] {
+  const e2e = expectRecord(value, 'e2e');
+  const documentParser = expectRecord(e2e.document_parser, 'e2e.document_parser');
+  const assertions = expectRecord(e2e.assertions, 'e2e.assertions');
+
+  return {
+    requiresLiveProvider: expectBoolean(e2e.requires_live_provider, 'e2e.requires_live_provider'),
+    provider: expectString(e2e.provider, 'e2e.provider'),
+    documentParser: {
+      plugin: expectString(documentParser.plugin, 'e2e.document_parser.plugin'),
+      pdfEngine: expectString(documentParser.pdf_engine, 'e2e.document_parser.pdf_engine'),
+    },
+    assertions: {
+      uploadStatus: expectStringArray(assertions.upload_status, 'e2e.assertions.upload_status'),
+      sourceLinesMin: expectNumber(assertions.source_lines_min, 'e2e.assertions.source_lines_min'),
+      allowManualMappingCompletion: expectBoolean(
+        assertions.allow_manual_mapping_completion,
+        'e2e.assertions.allow_manual_mapping_completion',
+      ),
+    },
+  };
+}
+
+function expectRecord(value: unknown, name: string): Record<string, unknown> {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`Invalid provider quote fixture: ${name} must be an object.`);
+  }
+
+  return value as Record<string, unknown>;
+}
+
+function expectArray(value: unknown, name: string): unknown[] {
+  if (!Array.isArray(value)) {
+    throw new Error(`Invalid provider quote fixture: ${name} must be an array.`);
+  }
+
+  return value;
+}
+
+function expectString(value: unknown, name: string): string {
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new Error(`Invalid provider quote fixture: ${name} must be a non-empty string.`);
+  }
+
+  return value;
+}
+
+function expectStringArray(value: unknown, name: string): string[] {
+  return expectArray(value, name).map((entry, index) => expectString(entry, `${name}[${index}]`));
+}
+
+function expectNumber(value: unknown, name: string): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    throw new Error(`Invalid provider quote fixture: ${name} must be a finite number.`);
+  }
+
+  return value;
+}
+
+function optionalNumber(value: unknown, name: string): number | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  return expectNumber(value, name);
+}
+
+function optionalString(value: unknown, name: string): string | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  return expectString(value, name);
+}
+
+function expectBoolean(value: unknown, name: string): boolean {
+  if (typeof value !== 'boolean') {
+    throw new Error(`Invalid provider quote fixture: ${name} must be a boolean.`);
+  }
+
+  return value;
+}

--- a/apps/atomy-q/WEB/tests/support/vitest.provider-quote.config.ts
+++ b/apps/atomy-q/WEB/tests/support/vitest.provider-quote.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+    include: ['tests/support/providerQuoteFixtures.test.ts'],
+    passWithNoTests: false,
+  },
+});

--- a/apps/atomy-q/docs/02-release-management/current-release/release-checklist.md
+++ b/apps/atomy-q/docs/02-release-management/current-release/release-checklist.md
@@ -58,12 +58,21 @@ The strongest rectification signal is that the alpha-critical backend flows pass
 - Operator: pending.
 - WEB URL: pending.
 - API URL: pending.
-- Runtime posture: pending; expected `NEXT_PUBLIC_USE_MOCKS=false`, `QUEUE_CONNECTION=sync`, `QUOTE_INTELLIGENCE_MODE=deterministic`.
+- Runtime posture: pending; expected `NEXT_PUBLIC_USE_MOCKS=false`, `AI_MODE=provider`, `NEXT_PUBLIC_AI_MODE=provider`, `QUEUE_CONNECTION=sync`, `AI_DOCUMENT_PARSER_PLUGIN=file-parser`, `AI_DOCUMENT_PDF_ENGINE=mistral-ocr`.
 - Storage verification result: pending; expected `php artisan atomy:verify-storage-disk --disk=s3 --path-prefix=alpha-storage-smoke`.
 - Queue verification note: pending; not required for the main alpha smoke because the staging posture is `QUEUE_CONNECTION=sync`.
 - Golden-path smoke result: pending; requires a true staging mocks-off run against deployed WEB and API origins.
 
 If a true staging mocks-off smoke has not been completed, design-partner readiness is not yet earned and the release remains internal alpha only.
+
+## Latest Provider Quote Fixture Support Evidence - 2026-04-25
+
+This section is preparatory local-support evidence for the provider-backed quote-upload release gate. It does not replace staging verification or a live-provider smoke run.
+
+- `cd apps/atomy-q/WEB && npm run test:unit:provider-quote-fixtures`: PASS. 1 file, 2 tests. This proves the WEB support loader reads the current `sample/*/metadata.json` folders, ignores `sample/metadata.example.json`, and resolves quotation PDF paths from each requisition folder.
+- `cd apps/atomy-q/WEB && npx playwright test tests/provider-quote-e2e.spec.ts --list`: PASS. Fixture-backed fake-provider Playwright entrypoint loads successfully.
+- `cd apps/atomy-q/WEB && npx playwright test tests/provider-quote-live.spec.ts --list`: PASS. Live-provider Playwright entrypoint loads successfully with the `AI_PROVIDER_E2E=true` gate still enforced inside the spec.
+- Local blocker: end-to-end browser/API verification for provider-backed quote upload and normalization was not run in this slice because no confirmed local API/provider stack was exercised here. The support layer is ready for that run once the target services are available.
 
 ## Alpha Change Control Ledger (Post-Task-8 Remediation)
 

--- a/docs/agentic/AGENTIC_CODING_GUIDELINES.md
+++ b/docs/agentic/AGENTIC_CODING_GUIDELINES.md
@@ -79,6 +79,11 @@ On-demand guidance for recurring implementation and review patterns. Keep this f
 - Cause: review threads remain open after fixes, tests contain dead helpers, or assertions only cover happy-path payload shape.
 - Fix: sweep unresolved threads, remove dead test code, and assert contract-critical fields.
 
+### Review-loop memory drift
+
+- Cause: review findings are fixed locally, but the reusable lesson is left only in the conversation or PR thread.
+- Fix: after each review cycle, capture the durable rule in `docs/agentic/AGENT_LEARNINGS.md` and/or this file before finalizing the branch.
+
 ## Pre-Finalization Checklist
 
 - [ ] Tenant-safe reads, writes, eager loads, deletes, and ACL checks verified.
@@ -91,6 +96,7 @@ On-demand guidance for recurring implementation and review patterns. Keep this f
 - [ ] Exceptions are domain-specific and sanitized for operator-facing output.
 - [ ] Numeric, array, identifier, and readonly-constructor edge cases are guarded.
 - [ ] Tests and docs match the final behavior.
+- [ ] Reusable review-loop lessons from this cycle were captured in `docs/agentic/`.
 
 ## Multi-Agent Roles
 
@@ -98,4 +104,3 @@ On-demand guidance for recurring implementation and review patterns. Keep this f
 - Developer: implementation and local logic against agreed contracts.
 - QA: verification, regression coverage, and edge-case review.
 - Maintenance: dependency, documentation, and cleanup work.
-

--- a/docs/agentic/AGENT_LEARNINGS.md
+++ b/docs/agentic/AGENT_LEARNINGS.md
@@ -87,3 +87,9 @@ Use compact pattern entries:
 - Guardrail: sweep unresolved threads; resolve fixed items; leave intentional deferrals open with rationale and follow-up.
 - Source: #340, #349.
 
+### Pattern: Review-cycle lesson capture
+
+- Trigger: Finishing an implementation slice after inline PR comments, CodeRabbit findings, or follow-up review fixes.
+- Risk: the same review nuance repeats in later turns because the reusable rule never gets written down.
+- Guardrail: after every review cycle, update `docs/agentic/AGENT_LEARNINGS.md` and/or `docs/agentic/AGENTIC_CODING_GUIDELINES.md` with the reusable pattern before closing the branch.
+- Source: #388 follow-up review hardening.

--- a/orchestrators/QuotationIntelligence/src/Coordinators/QuotationIntelligenceCoordinator.php
+++ b/orchestrators/QuotationIntelligence/src/Coordinators/QuotationIntelligenceCoordinator.php
@@ -18,6 +18,7 @@ use Nexus\QuotationIntelligence\Exceptions\InvalidNormalizationContextException;
 use Nexus\QuotationIntelligence\Exceptions\MissingRfqContextException;
 use Nexus\QuotationIntelligence\Exceptions\TenantContextNotFoundException;
 use Nexus\QuotationIntelligence\Exceptions\SemanticMappingException;
+use Nexus\QuotationIntelligence\Exceptions\UomNormalizationException;
 use Nexus\QuotationIntelligence\DTOs\NormalizedQuoteLine;
 use Nexus\QuotationIntelligence\ValueObjects\NormalizationContext;
 use Nexus\QuotationIntelligence\ValueObjects\ExtractionEvidence;
@@ -145,14 +146,35 @@ final readonly class QuotationIntelligenceCoordinator implements QuotationIntell
                     sprintf('Invalid taxonomy mapping payload for RFQ line "%s"', (string)$line['rfq_line_id'])
                 );
             }
+            $lineConfidence = (float) $mapping['confidence'];
+            $normalizationWarnings = [];
 
             // B. Normalization (UoM)
             $quotedUnit = $line['unit'] ?? 'UNIT';
-            $normQty = $this->normalizationService->normalizeQuantity(
-                (float)$line['quantity'],
-                (string)$quotedUnit,
-                $baseUnit
-            );
+            try {
+                $normQty = $this->normalizationService->normalizeQuantity(
+                    (float)$line['quantity'],
+                    (string)$quotedUnit,
+                    $baseUnit
+                );
+            } catch (UomNormalizationException $exception) {
+                $this->logger->warning('Proceeding with quoted quantity after UoM normalization failure', [
+                    'document_id' => $documentId,
+                    'rfq_id' => $rfqId,
+                    'rfq_line_id' => (string) $line['rfq_line_id'],
+                    'quoted_unit' => (string) $quotedUnit,
+                    'base_unit' => $baseUnit,
+                    'error_message' => $exception->getMessage(),
+                ]);
+                $normQty = (float) $line['quantity'];
+                $lineConfidence = min($lineConfidence, 0.6);
+                $normalizationWarnings[] = [
+                    'code' => 'uom_conversion_failed',
+                    'quoted_unit' => (string) $quotedUnit,
+                    'base_unit' => $baseUnit,
+                    'message' => $exception->getMessage(),
+                ];
+            }
 
             // C. Normalization (Currency)
             $quotedCurrency = $line['currency'] ?? $baseCurrency;
@@ -186,13 +208,14 @@ final readonly class QuotationIntelligenceCoordinator implements QuotationIntell
                 normalizedQuantity: (float)$normQty,
                 quotedUnitPrice: (float)$line['unit_price'],
                 normalizedUnitPrice: (float)$normPrice,
-                aiConfidence: (float)$mapping['confidence'],
+                aiConfidence: $lineConfidence,
                 snippets: [$snippet],
                 metadata: [
                     'vendor_id' => (string)($document->getMetadata()['vendor_id'] ?? ''),
                     'mapping_version' => (string)$mapping['version'],
                     'normalization_context' => $normalizationContext->toArray(),
                     'commercial_terms' => $commercialTerms,
+                    'normalization_warnings' => $normalizationWarnings,
                 ]
             );
         }

--- a/orchestrators/QuotationIntelligence/tests/Feature/EndToEndQuoteProcessingTest.php
+++ b/orchestrators/QuotationIntelligence/tests/Feature/EndToEndQuoteProcessingTest.php
@@ -584,5 +584,17 @@ final class EndToEndQuoteProcessingTest extends TestCase
             'uom_conversion_failed',
             $result['lines'][0]['metadata']['normalization_warnings'][0]['code']
         );
+        $this->assertSame(
+            'EA',
+            $result['lines'][0]['metadata']['normalization_warnings'][0]['quoted_unit']
+        );
+        $this->assertSame(
+            'JOB',
+            $result['lines'][0]['metadata']['normalization_warnings'][0]['base_unit']
+        );
+        $this->assertSame(
+            'Cannot convert EA to JOB',
+            $result['lines'][0]['metadata']['normalization_warnings'][0]['message']
+        );
     }
 }

--- a/orchestrators/QuotationIntelligence/tests/Feature/EndToEndQuoteProcessingTest.php
+++ b/orchestrators/QuotationIntelligence/tests/Feature/EndToEndQuoteProcessingTest.php
@@ -23,6 +23,7 @@ use Nexus\QuotationIntelligence\Exceptions\InvalidNormalizationContextException;
 use Nexus\QuotationIntelligence\Exceptions\MissingRfqContextException;
 use Nexus\QuotationIntelligence\Exceptions\SemanticMappingException;
 use Nexus\QuotationIntelligence\Exceptions\TenantContextNotFoundException;
+use Nexus\QuotationIntelligence\Exceptions\UomNormalizationException;
 use Nexus\Document\ValueObjects\ContentAnalysisResult;
 use Nexus\Document\ValueObjects\DocumentType;
 use Psr\Log\LoggerInterface;
@@ -506,5 +507,82 @@ final class EndToEndQuoteProcessingTest extends TestCase
 
         $this->assertCount(1, $result['lines']);
         $this->assertSame('rfq-line-1', $result['lines'][0]['rfq_line_id']);
+    }
+
+    public function test_preserves_line_and_degrades_confidence_when_uom_normalization_fails(): void
+    {
+        $processor = $this->createMock(OrchestratorContentProcessorInterface::class);
+        $repo = $this->createMock(OrchestratorDocumentRepositoryInterface::class);
+        $tenantRepository = $this->createMock(OrchestratorTenantRepositoryInterface::class);
+        $procurementManager = $this->createMock(OrchestratorProcurementManagerInterface::class);
+        $mapper = $this->createMock(SemanticMapperInterface::class);
+        $normService = $this->createMock(QuoteNormalizationServiceInterface::class);
+        $termsExtractor = $this->createMock(CommercialTermsExtractorInterface::class);
+        $riskService = $this->createMock(RiskAssessmentServiceInterface::class);
+        $logger = $this->createMock(LoggerInterface::class);
+
+        $document = $this->createMock(QuotationDocumentInterface::class);
+        $document->method('getTenantId')->willReturn('tenant-1');
+        $document->method('getMetadata')->willReturn(['rfq_id' => 'rfq-1']);
+        $document->method('getStoragePath')->willReturn('/tmp/quote.pdf');
+        $repo->method('findById')->willReturn($document);
+
+        $tenant = $this->createMock(OrchestratorTenantInterface::class);
+        $tenant->method('getCurrency')->willReturn('USD');
+        $tenantRepository->method('findById')->willReturn($tenant);
+
+        $line = $this->createMock(OrchestratorRequisitionLineInterface::class);
+        $line->method('getUnit')->willReturn('JOB');
+        $requisition = $this->createMock(OrchestratorRequisitionInterface::class);
+        $requisition->method('getLines')->willReturn([$line]);
+        $procurementManager->method('getRequisition')->willReturn($requisition);
+
+        $analysis = new ContentAnalysisResult(
+            predictedType: DocumentType::PDF,
+            confidenceScore: 0.95,
+            extractedMetadata: [
+                'lines' => [[
+                    'rfq_line_id' => 'rfq-line-1',
+                    'description' => 'Honeywell thermostat',
+                    'quantity' => 1,
+                    'unit' => 'EA',
+                    'unit_price' => 185,
+                ]],
+            ],
+            containsPII: false,
+            suggestedTags: [],
+            rawAnalysis: []
+        );
+        $processor->method('analyze')->willReturn($analysis);
+
+        $mapper->method('mapToTaxonomy')->willReturn(['code' => '41112209', 'confidence' => 0.95, 'version' => '1.0.0']);
+        $mapper->method('validateCode')->willReturn(true);
+        $normService->method('normalizeQuantity')
+            ->willThrowException(new UomNormalizationException('Cannot convert EA to JOB'));
+        $normService->method('normalizePrice')->willReturn(185.0);
+        $termsExtractor->method('extract')->willReturn([]);
+        $riskService->method('assess')->willReturn([]);
+
+        $coordinator = new QuotationIntelligenceCoordinator(
+            $processor,
+            $repo,
+            $tenantRepository,
+            $procurementManager,
+            $mapper,
+            $normService,
+            $termsExtractor,
+            $riskService,
+            $logger
+        );
+
+        $result = $coordinator->processQuote('tenant-1', 'doc-123');
+
+        $this->assertCount(1, $result['lines']);
+        $this->assertSame(1.0, $result['lines'][0]['normalized_quantity']);
+        $this->assertSame(0.6, $result['lines'][0]['ai_confidence']);
+        $this->assertSame(
+            'uom_conversion_failed',
+            $result['lines'][0]['metadata']['normalization_warnings'][0]['code']
+        );
     }
 }

--- a/sample/1A/metadata.json
+++ b/sample/1A/metadata.json
@@ -74,6 +74,7 @@
     },
     "assertions": {
       "upload_status": [
+        "uploaded",
         "ready",
         "needs_review"
       ],

--- a/sample/1B/metadata.json
+++ b/sample/1B/metadata.json
@@ -62,6 +62,7 @@
     },
     "assertions": {
       "upload_status": [
+        "uploaded",
         "ready",
         "needs_review"
       ],

--- a/sample/1C/metadata.json
+++ b/sample/1C/metadata.json
@@ -74,6 +74,7 @@
     },
     "assertions": {
       "upload_status": [
+        "uploaded",
         "ready",
         "needs_review"
       ],

--- a/sample/1D/metadata.json
+++ b/sample/1D/metadata.json
@@ -74,6 +74,7 @@
     },
     "assertions": {
       "upload_status": [
+        "uploaded",
         "ready",
         "needs_review"
       ],

--- a/sample/1E/metadata.json
+++ b/sample/1E/metadata.json
@@ -81,6 +81,7 @@
     },
     "assertions": {
       "upload_status": [
+        "uploaded",
         "ready",
         "needs_review"
       ],

--- a/sample/1F/metadata.json
+++ b/sample/1F/metadata.json
@@ -89,6 +89,7 @@
     },
     "assertions": {
       "upload_status": [
+        "uploaded",
         "ready",
         "needs_review"
       ],

--- a/sample/1G/metadata.json
+++ b/sample/1G/metadata.json
@@ -131,6 +131,7 @@
     },
     "assertions": {
       "upload_status": [
+        "uploaded",
         "ready",
         "needs_review"
       ],

--- a/sample/README.md
+++ b/sample/README.md
@@ -16,6 +16,28 @@ sample/
 - uploads each vendor PDF
 - checks provider extraction anchors
 - verifies normalization/comparison readiness path
+- is auto-discovered from `sample/*/metadata.json` by the WEB fixture loader
 
 Root-level PDFs are allowed for ad-hoc smoke tests, but release e2e should use folder fixtures with `metadata.json`.
 
+WEB support commands:
+
+- `cd apps/atomy-q/WEB && npm run test:unit:provider-quote-fixtures`
+- `cd apps/atomy-q/WEB && npm run test:e2e:provider-quote:fake`
+- `cd apps/atomy-q/WEB && AI_PROVIDER_E2E=true npm run test:e2e:provider-quote:live`
+
+Live-provider defaults:
+
+- `npm run test:e2e:provider-quote:live` runs one discovered requisition fixture by default.
+- Set `PROVIDER_QUOTE_FIXTURE=<requisition_id>` to target a specific folder under `sample/`.
+
+Cross-platform examples:
+
+- POSIX shell:
+  - `cd apps/atomy-q/WEB && PROVIDER_QUOTE_FIXTURE=aircond-compressor-repair-rfq-sibu-2019 AI_PROVIDER_E2E=true npm run test:e2e:provider-quote:live`
+- `npm` script with bundled `cross-env`:
+  - `cd apps/atomy-q/WEB && npm run test:e2e:provider-quote:live -- --grep "aircond-compressor-repair-rfq-sibu-2019"`
+- Windows PowerShell:
+  - `cd apps/atomy-q/WEB; $env:AI_PROVIDER_E2E='true'; $env:PROVIDER_QUOTE_FIXTURE='aircond-compressor-repair-rfq-sibu-2019'; npm run test:e2e:provider-quote:live`
+- Windows CMD:
+  - `cd apps/atomy-q/WEB && set AI_PROVIDER_E2E=true && set PROVIDER_QUOTE_FIXTURE=aircond-compressor-repair-rfq-sibu-2019 && npm run test:e2e:provider-quote:live`

--- a/sample/README.md
+++ b/sample/README.md
@@ -35,8 +35,8 @@ Cross-platform examples:
 
 - POSIX shell:
   - `cd apps/atomy-q/WEB && PROVIDER_QUOTE_FIXTURE=aircond-compressor-repair-rfq-sibu-2019 AI_PROVIDER_E2E=true npm run test:e2e:provider-quote:live`
-- `npm` script with bundled `cross-env`:
-  - `cd apps/atomy-q/WEB && npm run test:e2e:provider-quote:live -- --grep "aircond-compressor-repair-rfq-sibu-2019"`
+- `npm` script with bundled `cross-env` and fixture selection:
+  - `cd apps/atomy-q/WEB && npx cross-env AI_PROVIDER_E2E=true PROVIDER_QUOTE_FIXTURE=aircond-compressor-repair-rfq-sibu-2019 npm run test:e2e:provider-quote:live`
 - Windows PowerShell:
   - `cd apps/atomy-q/WEB; $env:AI_PROVIDER_E2E='true'; $env:PROVIDER_QUOTE_FIXTURE='aircond-compressor-repair-rfq-sibu-2019'; npm run test:e2e:provider-quote:live`
 - Windows CMD:

--- a/sample/metadata.example.json
+++ b/sample/metadata.example.json
@@ -53,6 +53,7 @@
     },
     "assertions": {
       "upload_status": [
+        "uploaded",
         "ready",
         "needs_review"
       ],

--- a/sample/metadata.example.json
+++ b/sample/metadata.example.json
@@ -24,7 +24,7 @@
     {
       "vendor_reference": "kuching-utama",
       "vendor_name": "Kuching Utama Sdn Bhd",
-      "file": "5b99b82bd0fda101329131.pdf",
+      "file": "1A/1A-1.pdf",
       "mime_type": "application/pdf",
       "expected": {
         "quote_number": "1809/2975",


### PR DESCRIPTION
## Summary
- wire provider-backed quote extraction through the Atomy-Q upload pipeline with OpenRouter PDF payload support and safer document request validation
- harden the provider runtime around OpenRouter probing, storage-path resolution, decision-trail sequencing, and degraded UOM normalization handling
- add fake/live provider quote fixture support, cross-platform Playwright scripts, and sample/release documentation updates for the alpha e2e flow

## Verification
- `cd apps/atomy-q/API && ./vendor/bin/phpunit tests/Unit/Adapters/Ai/OpenRouterDocumentPayloadFactoryTest.php tests/Unit/Adapters/Ai/OpenRouterDocumentExtractionMapperTest.php tests/Unit/Adapters/Ai/ProviderDocumentIntelligenceClientTest.php tests/Feature/ProviderQuoteExtractionTest.php tests/Feature/QuoteIngestionPipelineTest.php tests/Feature/Console/AiConsoleCommandsTest.php`
- `cd apps/atomy-q/WEB && npm run test:unit:provider-quote-fixtures`
- `cd apps/atomy-q/WEB && npx playwright test --list tests/provider-quote-live.spec.ts`
- `cd apps/atomy-q/WEB && npx playwright test --list tests/provider-quote-e2e.spec.ts`

## Review
- Ran `cr review --agent --type all` and applied the necessary fixes before this PR.