### PR TITLE
[codex] add AI provider check command

### DIFF
--- a/apps/atomy-q/API/IMPLEMENTATION_SUMMARY.md
+++ b/apps/atomy-q/API/IMPLEMENTATION_SUMMARY.md
@@ -1,5 +1,9 @@
 # Implementation Summary - Atomy-Q Backend API
 
+## 2026-05-02 AI Provider Check Command
+
+- Added `php artisan atomy:ai-provider-check` as the safe operator readiness check for configured AI providers, with JSON output and endpoint-group filtering for targeted diagnostics.
+
 ## 2026-04-30 Alpha RFQ Duplication And Quote Intake Readiness Repair
 
 - RFQ line-item `specifications` now remains a text value end-to-end instead of being JSON-cast, so RFQ duplication preserves exact string/null values for copied line items.

--- a/apps/atomy-q/API/app/Console/Commands/AiProviderCheckCommand.php
+++ b/apps/atomy-q/API/app/Console/Commands/AiProviderCheckCommand.php
@@ -18,6 +18,8 @@ use Nexus\IntelligenceOperations\DTOs\AiStatusSchema;
  */
 final class AiProviderCheckCommand extends Command
 {
+    private const FAIL_ON_WARNING = 'warning';
+
     protected $signature = 'atomy:ai-provider-check
         {--endpoint-group=* : Restrict checks to one or more endpoint groups}
         {--deep : Run provider contract checks after readiness probes}
@@ -52,6 +54,13 @@ final class AiProviderCheckCommand extends Command
             return self::FAILURE;
         }
 
+        $failOn = strtolower(trim((string) $this->option('fail-on')));
+        if (! in_array($failOn, ['', self::FAIL_ON_WARNING], true)) {
+            $this->error('Unsupported --fail-on value ['.$failOn.']. Supported values: warning.');
+
+            return self::FAILURE;
+        }
+
         $endpointGroups = $this->requestedEndpointGroups();
         $unsupported = array_values(array_diff($endpointGroups, AiStatusSchema::endpointGroups()));
         if ($unsupported !== []) {
@@ -76,7 +85,7 @@ final class AiProviderCheckCommand extends Command
             $this->writeHumanOutput($result);
         }
 
-        return $this->exitCodeFor($result);
+        return $this->exitCodeFor($result, $failOn);
     }
 
     /**
@@ -176,15 +185,14 @@ final class AiProviderCheckCommand extends Command
         return $prefix.': '.$finding->message.$suffix;
     }
 
-    private function exitCodeFor(AiProviderReadinessResult $result): int
+    private function exitCodeFor(AiProviderReadinessResult $result, string $failOn): int
     {
         $severity = $result->exitSeverity();
         if ($severity === AiProviderCheckSeverity::FAILED) {
             return self::FAILURE;
         }
 
-        $failOn = strtolower(trim((string) $this->option('fail-on')));
-        if ($severity === AiProviderCheckSeverity::WARNING && $failOn === AiProviderCheckSeverity::WARNING) {
+        if ($severity === AiProviderCheckSeverity::WARNING && $failOn === self::FAIL_ON_WARNING) {
             return self::FAILURE;
         }
 

--- a/apps/atomy-q/API/app/Console/Commands/AiProviderCheckCommand.php
+++ b/apps/atomy-q/API/app/Console/Commands/AiProviderCheckCommand.php
@@ -1,0 +1,193 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\Ai\AiProviderCheckFinding;
+use App\Services\Ai\AiProviderCheckSeverity;
+use App\Services\Ai\AiProviderEndpointCheck;
+use App\Services\Ai\AiProviderReadinessResult;
+use App\Services\Ai\Contracts\AiProviderReadinessCheckerInterface;
+use Illuminate\Console\Command;
+use JsonException;
+use Nexus\IntelligenceOperations\DTOs\AiStatusSchema;
+
+/**
+ * Reports Atomy-Q AI provider readiness for operator preflight checks.
+ */
+final class AiProviderCheckCommand extends Command
+{
+    protected $signature = 'atomy:ai-provider-check
+        {--endpoint-group=* : Restrict checks to one or more endpoint groups}
+        {--deep : Run provider contract checks after readiness probes}
+        {--json : Emit machine-readable JSON output}
+        {--fail-on= : Exit non-zero for warnings when set to "warning"}
+        {--publish-alerts : Publish operational alerts from the current AI status snapshot}
+        {--tenant-id=plan6-tenant : Tenant identifier used in deep provider sample payloads}
+        {--rfq-id=plan6-rfq : RFQ identifier used in deep provider sample payloads}';
+
+    protected $description = 'Check Atomy-Q AI provider readiness across configured endpoint groups.';
+
+    public function __construct(
+        private readonly AiProviderReadinessCheckerInterface $checker,
+    ) {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        $tenantId = trim((string) $this->option('tenant-id'));
+        $rfqId = trim((string) $this->option('rfq-id'));
+
+        if ($tenantId === '') {
+            $this->error('The --tenant-id option must be non-empty.');
+
+            return self::FAILURE;
+        }
+
+        if ($rfqId === '') {
+            $this->error('The --rfq-id option must be non-empty.');
+
+            return self::FAILURE;
+        }
+
+        $endpointGroups = $this->requestedEndpointGroups();
+        $unsupported = array_values(array_diff($endpointGroups, AiStatusSchema::endpointGroups()));
+        if ($unsupported !== []) {
+            $this->error('Unsupported endpoint group(s): '.implode(', ', $unsupported));
+
+            return self::FAILURE;
+        }
+
+        $result = $this->checker->check(
+            endpointGroups: $endpointGroups,
+            deep: (bool) $this->option('deep'),
+            publishAlerts: (bool) $this->option('publish-alerts'),
+            tenantId: $tenantId,
+            rfqId: $rfqId,
+        );
+
+        if ((bool) $this->option('json')) {
+            if (! $this->writeJsonOutput($result)) {
+                return self::FAILURE;
+            }
+        } else {
+            $this->writeHumanOutput($result);
+        }
+
+        return $this->exitCodeFor($result);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function requestedEndpointGroups(): array
+    {
+        $requested = $this->option('endpoint-group');
+        if (! is_array($requested) || $requested === []) {
+            return AiStatusSchema::endpointGroups();
+        }
+
+        $filtered = array_values(array_filter(array_map(
+            static function (mixed $value): ?string {
+                if (! is_string($value)) {
+                    return null;
+                }
+
+                $normalized = trim($value);
+
+                return $normalized !== '' ? $normalized : null;
+            },
+            $requested,
+        )));
+
+        return $filtered === [] ? AiStatusSchema::endpointGroups() : $filtered;
+    }
+
+    private function writeJsonOutput(AiProviderReadinessResult $result): bool
+    {
+        try {
+            $json = json_encode(
+                $result->toArray(),
+                JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR,
+            );
+        } catch (JsonException) {
+            $this->error('Failed to encode AI provider check payload.');
+
+            return false;
+        }
+
+        foreach (explode(PHP_EOL, $json) as $line) {
+            $this->line($line);
+        }
+
+        return true;
+    }
+
+    private function writeHumanOutput(AiProviderReadinessResult $result): void
+    {
+        $this->info('Atomy-Q AI provider readiness');
+        $this->line('Checked at: '.$result->checkedAt);
+        $this->line('Mode: '.$result->mode);
+        $this->line('Provider: '.$result->provider);
+        $this->line('Deep checks: '.($result->deep ? 'yes' : 'no'));
+        $this->line('Exit severity: '.$result->exitSeverity());
+        $this->newLine();
+
+        $this->table(
+            ['Endpoint group', 'Severity', 'Configured', 'Enabled', 'Health', 'Latency', 'Reasons'],
+            array_map(
+                static fn (AiProviderEndpointCheck $check): array => [
+                    $check->endpointGroup,
+                    $check->severity,
+                    $check->configured ? 'yes' : 'no',
+                    $check->enabled ? 'yes' : 'no',
+                    $check->probeHealth ?? '-',
+                    $check->latencyMs === null ? '-' : (string) $check->latencyMs.'ms',
+                    implode(', ', $check->reasonCodes),
+                ],
+                $result->endpointGroups,
+            ),
+        );
+
+        $this->newLine();
+        $this->info('Operator findings');
+        if ($result->operatorFindings === []) {
+            $this->line('None.');
+
+            return;
+        }
+
+        foreach ($result->operatorFindings as $finding) {
+            $this->line($this->formatFinding($finding));
+        }
+    }
+
+    private function formatFinding(AiProviderCheckFinding $finding): string
+    {
+        $prefix = '['.$finding->severity.'] '.$finding->area;
+        if ($finding->endpointGroup !== null) {
+            $prefix .= ' '.$finding->endpointGroup;
+        }
+
+        $suffix = $finding->reasonCode === null ? '' : ' ('.$finding->reasonCode.')';
+
+        return $prefix.': '.$finding->message.$suffix;
+    }
+
+    private function exitCodeFor(AiProviderReadinessResult $result): int
+    {
+        $severity = $result->exitSeverity();
+        if ($severity === AiProviderCheckSeverity::FAILED) {
+            return self::FAILURE;
+        }
+
+        $failOn = strtolower(trim((string) $this->option('fail-on')));
+        if ($severity === AiProviderCheckSeverity::WARNING && $failOn === AiProviderCheckSeverity::WARNING) {
+            return self::FAILURE;
+        }
+
+        return self::SUCCESS;
+    }
+}

--- a/apps/atomy-q/API/app/Console/Commands/AiVerifyContractsCommand.php
+++ b/apps/atomy-q/API/app/Console/Commands/AiVerifyContractsCommand.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace App\Console\Commands;
 
 use App\Services\Ai\Contracts\ProviderContractVerifierInterface;
-use App\Services\Ai\ProviderContractVerificationService;
 use InvalidArgumentException;
 use Illuminate\Console\Command;
 
@@ -76,7 +75,7 @@ final class AiVerifyContractsCommand extends Command
     {
         $requested = $this->option('endpoint-group');
         if (! is_array($requested) || $requested === []) {
-            return ProviderContractVerificationService::ENDPOINT_GROUPS;
+            return $this->verifier->endpointGroups();
         }
 
         $filtered = array_values(array_filter(array_map(
@@ -93,14 +92,7 @@ final class AiVerifyContractsCommand extends Command
         )));
 
         if ($filtered === []) {
-            return ProviderContractVerificationService::ENDPOINT_GROUPS;
-        }
-
-        $unsupported = array_values(array_diff($filtered, ProviderContractVerificationService::ENDPOINT_GROUPS));
-        if ($unsupported !== []) {
-            throw new InvalidArgumentException(
-                'Unsupported endpoint group(s): ' . implode(', ', $unsupported),
-            );
+            return $this->verifier->endpointGroups();
         }
 
         return $filtered;

--- a/apps/atomy-q/API/app/Console/Commands/AiVerifyContractsCommand.php
+++ b/apps/atomy-q/API/app/Console/Commands/AiVerifyContractsCommand.php
@@ -4,19 +4,10 @@ declare(strict_types=1);
 
 namespace App\Console\Commands;
 
+use App\Services\Ai\Contracts\ProviderContractVerifierInterface;
+use App\Services\Ai\ProviderContractVerificationService;
 use InvalidArgumentException;
-use App\Adapters\Ai\Contracts\ComparisonAwardAiClientInterface;
-use App\Adapters\Ai\Contracts\ProviderDocumentIntelligenceClientInterface;
-use App\Adapters\Ai\Contracts\ProviderGovernanceClientInterface;
-use App\Adapters\Ai\Contracts\ProviderInsightClientInterface;
-use App\Adapters\Ai\Contracts\ProviderNormalizationClientInterface;
-use App\Adapters\Ai\Contracts\ProviderSourcingRecommendationClientInterface;
-use App\Adapters\Ai\DTOs\ComparisonOverlayRequest;
-use App\Adapters\Ai\DTOs\GovernanceNarrativeRequest;
-use App\Adapters\Ai\DTOs\InsightSummaryRequest;
 use Illuminate\Console\Command;
-use Nexus\ProcurementOperations\DTOs\VendorRecommendation\VendorRecommendationRequest;
-use Nexus\ProcurementOperations\DTOs\VendorRecommendation\VendorRecommendationScoredCandidate;
 
 /**
  * Sends representative payloads through every configured AI endpoint group.
@@ -27,15 +18,6 @@ use Nexus\ProcurementOperations\DTOs\VendorRecommendation\VendorRecommendationSc
  */
 final class AiVerifyContractsCommand extends Command
 {
-    private const ENDPOINT_GROUPS = [
-        'document',
-        'normalization',
-        'sourcing_recommendation',
-        'comparison_award',
-        'insight',
-        'governance',
-    ];
-
     protected $signature = 'atomy:ai-verify-contracts
         {--endpoint-group=* : Restrict verification to one or more endpoint groups}
         {--tenant-id=plan6-tenant : Tenant identifier used in sample payloads}
@@ -44,12 +26,7 @@ final class AiVerifyContractsCommand extends Command
     protected $description = 'Run provider contract verification requests for every configured Atomy-Q AI endpoint group.';
 
     public function __construct(
-        private readonly ProviderDocumentIntelligenceClientInterface $documentClient,
-        private readonly ProviderNormalizationClientInterface $normalizationClient,
-        private readonly ProviderSourcingRecommendationClientInterface $recommendationClient,
-        private readonly ComparisonAwardAiClientInterface $comparisonAwardClient,
-        private readonly ProviderInsightClientInterface $insightClient,
-        private readonly ProviderGovernanceClientInterface $governanceClient,
+        private readonly ProviderContractVerifierInterface $verifier,
     ) {
         parent::__construct();
     }
@@ -72,84 +49,21 @@ final class AiVerifyContractsCommand extends Command
 
         try {
             $endpointGroups = $this->requestedEndpointGroups();
+            $this->verifier->assertEndpointGroups($endpointGroups);
         } catch (InvalidArgumentException $exception) {
             $this->error($exception->getMessage());
 
             return self::FAILURE;
         }
 
-        $verifiers = [
-            'document' => fn (): array => $this->documentClient->extract([
-                'tenant_id' => $tenantId,
-                'rfq_id' => $rfqId,
-                'document_id' => 'plan6-doc',
-                'filename' => 'plan6.pdf',
-                'mime_type' => 'application/pdf',
-            ]),
-            'normalization' => fn (): array => $this->normalizationClient->suggest([
-                'tenant_id' => $tenantId,
-                'rfq_id' => $rfqId,
-                'source_lines' => [['id' => 'src-1', 'text' => 'Plan 6 source line']],
-            ]),
-            'sourcing_recommendation' => fn (): array => $this->recommendationClient->enrich(
-                new VendorRecommendationRequest(
-                    tenantId: $tenantId,
-                    rfqId: $rfqId,
-                    categories: ['services'],
-                    description: 'Operational hardening contract verification',
-                    geography: 'MY',
-                    spendBand: 'mid',
-                    lineItemSummary: ['Line-item summary'],
-                    candidates: [],
-                ),
-                [
-                    new VendorRecommendationScoredCandidate(
-                        vendorId: 'vendor-1',
-                        vendorName: 'Vendor 1',
-                        fitScore: 80,
-                        confidenceBand: 'high',
-                        recommendedReasonSummary: 'Meets deterministic fit checks.',
-                        deterministicReasons: ['coverage'],
-                    ),
-                ],
-            ),
-            'comparison_award' => fn (): array => $this->comparisonAwardClient->comparisonOverlay(new ComparisonOverlayRequest(
-                tenantId: $tenantId,
-                rfqId: $rfqId,
-                mode: 'preview',
-                comparison: ['summary' => 'Plan 6 comparison contract verification'],
-                snapshot: null,
-            ))->payload,
-            'insight' => fn (): array => $this->insightClient->summarize(new InsightSummaryRequest(
-                featureKey: 'dashboard_ai_summary',
-                tenantId: $tenantId,
-                subjectType: 'dashboard_kpis',
-                facts: ['active_rfqs' => 0],
-            )),
-            'governance' => fn (): array => $this->governanceClient->narrate(new GovernanceNarrativeRequest(
-                featureKey: 'governance_ai_narrative',
-                tenantId: $tenantId,
-                vendorId: 'vendor-1',
-                facts: ['summary_scores' => ['compliance' => 90], 'warning_flags' => []],
-            )),
-        ];
-
-        foreach ($endpointGroups as $endpointGroup) {
-            $verifier = $verifiers[$endpointGroup] ?? null;
-            if (! is_callable($verifier)) {
-                $this->error('Unsupported endpoint group: ' . $endpointGroup);
+        foreach ($this->verifier->verify($endpointGroups, $tenantId, $rfqId) as $result) {
+            if (! $result->verified) {
+                $this->error($result->message);
 
                 return self::FAILURE;
             }
 
-            $result = $verifier();
-            if (! is_array($result) || array_is_list($result)) {
-                $this->error('Provider contract verification returned an invalid payload for ' . $endpointGroup);
-
-                return self::FAILURE;
-            }
-
-            $this->info('Verified provider contract for ' . $endpointGroup);
+            $this->info($result->message);
         }
 
         return self::SUCCESS;
@@ -162,7 +76,7 @@ final class AiVerifyContractsCommand extends Command
     {
         $requested = $this->option('endpoint-group');
         if (! is_array($requested) || $requested === []) {
-            return self::ENDPOINT_GROUPS;
+            return ProviderContractVerificationService::ENDPOINT_GROUPS;
         }
 
         $filtered = array_values(array_filter(array_map(
@@ -179,10 +93,10 @@ final class AiVerifyContractsCommand extends Command
         )));
 
         if ($filtered === []) {
-            return self::ENDPOINT_GROUPS;
+            return ProviderContractVerificationService::ENDPOINT_GROUPS;
         }
 
-        $unsupported = array_values(array_diff($filtered, self::ENDPOINT_GROUPS));
+        $unsupported = array_values(array_diff($filtered, ProviderContractVerificationService::ENDPOINT_GROUPS));
         if ($unsupported !== []) {
             throw new InvalidArgumentException(
                 'Unsupported endpoint group(s): ' . implode(', ', $unsupported),

--- a/apps/atomy-q/API/app/Console/Commands/AiVerifyContractsCommand.php
+++ b/apps/atomy-q/API/app/Console/Commands/AiVerifyContractsCommand.php
@@ -55,17 +55,20 @@ final class AiVerifyContractsCommand extends Command
             return self::FAILURE;
         }
 
+        $hasFailures = false;
+
         foreach ($this->verifier->verify($endpointGroups, $tenantId, $rfqId) as $result) {
             if (! $result->verified) {
                 $this->error($result->message);
+                $hasFailures = true;
 
-                return self::FAILURE;
+                continue;
             }
 
             $this->info($result->message);
         }
 
-        return self::SUCCESS;
+        return $hasFailures ? self::FAILURE : self::SUCCESS;
     }
 
     /**

--- a/apps/atomy-q/API/app/Providers/AppServiceProvider.php
+++ b/apps/atomy-q/API/app/Providers/AppServiceProvider.php
@@ -55,7 +55,9 @@ use App\Services\Identity\AtomyUserPersist;
 use App\Services\Identity\AtomyUserQuery;
 use App\Services\Auth\PasswordResetService;
 use App\Services\Ai\AiOperationalAlertPublisher;
+use App\Services\Ai\AiProviderReadinessChecker;
 use App\Services\Ai\Contracts\AiOperationalAlertPublisherInterface;
+use App\Services\Ai\Contracts\AiProviderReadinessCheckerInterface;
 use App\Services\Ai\Contracts\ProviderContractVerifierInterface;
 use App\Services\Ai\ProviderContractVerificationService;
 use App\Services\JwtService;
@@ -470,6 +472,10 @@ class AppServiceProvider extends ServiceProvider
         $this->app->singleton(
             ProviderContractVerifierInterface::class,
             ProviderContractVerificationService::class,
+        );
+        $this->app->singleton(
+            AiProviderReadinessCheckerInterface::class,
+            AiProviderReadinessChecker::class,
         );
         $this->app->singleton(
             OutboxStoreInterface::class,

--- a/apps/atomy-q/API/app/Providers/AppServiceProvider.php
+++ b/apps/atomy-q/API/app/Providers/AppServiceProvider.php
@@ -56,6 +56,8 @@ use App\Services\Identity\AtomyUserQuery;
 use App\Services\Auth\PasswordResetService;
 use App\Services\Ai\AiOperationalAlertPublisher;
 use App\Services\Ai\Contracts\AiOperationalAlertPublisherInterface;
+use App\Services\Ai\Contracts\ProviderContractVerifierInterface;
+use App\Services\Ai\ProviderContractVerificationService;
 use App\Services\JwtService;
 use App\Services\Project\AtomyIncompleteTaskCount;
 use App\Services\Project\AtomyProjectPersist;
@@ -464,6 +466,10 @@ class AppServiceProvider extends ServiceProvider
         $this->app->singleton(
             AiRuntimeStatusInterface::class,
             AiRuntimeStatusAdapter::class,
+        );
+        $this->app->singleton(
+            ProviderContractVerifierInterface::class,
+            ProviderContractVerificationService::class,
         );
         $this->app->singleton(
             OutboxStoreInterface::class,

--- a/apps/atomy-q/API/app/Services/Ai/AiProviderCheckFinding.php
+++ b/apps/atomy-q/API/app/Services/Ai/AiProviderCheckFinding.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Ai;
+
+final readonly class AiProviderCheckFinding
+{
+    public function __construct(
+        public string $severity,
+        public string $area,
+        public string $message,
+        public ?string $endpointGroup = null,
+        public ?string $reasonCode = null,
+    ) {
+    }
+
+    /**
+     * @return array<string, string|null>
+     */
+    public function toArray(): array
+    {
+        return [
+            'severity' => $this->severity,
+            'area' => $this->area,
+            'message' => $this->message,
+            'endpoint_group' => $this->endpointGroup,
+            'reason_code' => $this->reasonCode,
+        ];
+    }
+}

--- a/apps/atomy-q/API/app/Services/Ai/AiProviderCheckSeverity.php
+++ b/apps/atomy-q/API/app/Services/Ai/AiProviderCheckSeverity.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Ai;
+
+final class AiProviderCheckSeverity
+{
+    public const OK = 'ok';
+    public const WARNING = 'warning';
+    public const FAILED = 'failed';
+    public const SKIPPED = 'skipped';
+    public const UNKNOWN = 'unknown';
+
+    public static function rank(string $severity): int
+    {
+        return match ($severity) {
+            self::FAILED => 50,
+            self::WARNING => 40,
+            self::UNKNOWN => 30,
+            self::SKIPPED => 20,
+            self::OK => 10,
+            default => 0,
+        };
+    }
+
+    public static function worse(string $left, string $right): string
+    {
+        return self::rank($left) >= self::rank($right) ? $left : $right;
+    }
+}

--- a/apps/atomy-q/API/app/Services/Ai/AiProviderCheckSeverity.php
+++ b/apps/atomy-q/API/app/Services/Ai/AiProviderCheckSeverity.php
@@ -20,7 +20,7 @@ final class AiProviderCheckSeverity
             self::UNKNOWN => 30,
             self::SKIPPED => 20,
             self::OK => 10,
-            default => 0,
+            default => 30,
         };
     }
 

--- a/apps/atomy-q/API/app/Services/Ai/AiProviderEndpointCheck.php
+++ b/apps/atomy-q/API/app/Services/Ai/AiProviderEndpointCheck.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Ai;
+
+final readonly class AiProviderEndpointCheck
+{
+    /**
+     * @param list<string> $reasonCodes
+     * @param array<string, scalar|null> $diagnostics
+     */
+    public function __construct(
+        public string $endpointGroup,
+        public bool $configured,
+        public bool $enabled,
+        public ?string $endpointUri,
+        public ?string $probeHealth,
+        public ?int $latencyMs,
+        public string $severity,
+        public array $reasonCodes,
+        public array $diagnostics = [],
+    ) {
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'endpoint_group' => $this->endpointGroup,
+            'configured' => $this->configured,
+            'enabled' => $this->enabled,
+            'endpoint_uri' => $this->endpointUri,
+            'probe_health' => $this->probeHealth,
+            'latency_ms' => $this->latencyMs,
+            'severity' => $this->severity,
+            'reason_codes' => $this->reasonCodes,
+            'diagnostics' => $this->diagnostics,
+        ];
+    }
+}

--- a/apps/atomy-q/API/app/Services/Ai/AiProviderReadinessChecker.php
+++ b/apps/atomy-q/API/app/Services/Ai/AiProviderReadinessChecker.php
@@ -53,20 +53,36 @@ final readonly class AiProviderReadinessChecker implements AiProviderReadinessCh
         }
 
         if ($deep) {
-            foreach ($this->contractVerifier->verify($selectedGroups, $tenantId, $rfqId) as $deepResult) {
+            try {
+                foreach ($this->contractVerifier->verify($selectedGroups, $tenantId, $rfqId) as $deepResult) {
+                    $findings[] = new AiProviderCheckFinding(
+                        severity: $deepResult->severity,
+                        area: 'deep_contract',
+                        message: $deepResult->message,
+                        endpointGroup: $deepResult->endpointGroup,
+                        reasonCode: $deepResult->reasonCodes[0] ?? null,
+                    );
+                }
+            } catch (Throwable $exception) {
                 $findings[] = new AiProviderCheckFinding(
-                    severity: $deepResult->severity,
+                    severity: AiProviderCheckSeverity::FAILED,
                     area: 'deep_contract',
-                    message: $deepResult->message,
-                    endpointGroup: $deepResult->endpointGroup,
-                    reasonCode: $deepResult->reasonCodes[0] ?? null,
+                    message: $exception->getMessage(),
                 );
             }
         }
 
         $publishedAlerts = [];
         if ($publishAlerts && $this->alertPublisher instanceof AiOperationalAlertPublisherInterface) {
-            $publishedAlerts = $this->alertPublisher->publishSnapshot($this->runtimeStatus->snapshot());
+            try {
+                $publishedAlerts = $this->alertPublisher->publishSnapshot($this->runtimeStatus->snapshot());
+            } catch (Throwable $exception) {
+                $findings[] = new AiProviderCheckFinding(
+                    severity: AiProviderCheckSeverity::FAILED,
+                    area: 'alert_publish',
+                    message: $exception->getMessage(),
+                );
+            }
         }
 
         return new AiProviderReadinessResult(
@@ -83,11 +99,11 @@ final readonly class AiProviderReadinessChecker implements AiProviderReadinessCh
     private function checkEndpoint(string $endpointGroup, string $mode, ?AiEndpointConfig $config): AiProviderEndpointCheck
     {
         if ($mode === AiStatusSchema::MODE_OFF) {
-            return $this->skippedEndpoint($endpointGroup, ['ai_disabled_by_config']);
+            return $this->skippedEndpoint($endpointGroup, ['ai_disabled_by_config'], $config);
         }
 
         if ($mode === AiStatusSchema::MODE_DETERMINISTIC) {
-            return $this->skippedEndpoint($endpointGroup, ['deterministic_fallback_mode']);
+            return $this->skippedEndpoint($endpointGroup, ['deterministic_fallback_mode'], $config);
         }
 
         if ($config === null) {
@@ -150,18 +166,18 @@ final readonly class AiProviderReadinessChecker implements AiProviderReadinessCh
     /**
      * @param  list<string>  $reasonCodes
      */
-    private function skippedEndpoint(string $endpointGroup, array $reasonCodes): AiProviderEndpointCheck
+    private function skippedEndpoint(string $endpointGroup, array $reasonCodes, ?AiEndpointConfig $config = null): AiProviderEndpointCheck
     {
         return new AiProviderEndpointCheck(
             endpointGroup: $endpointGroup,
-            configured: false,
-            enabled: false,
-            endpointUri: null,
+            configured: $config !== null,
+            enabled: $config?->enabled ?? false,
+            endpointUri: $config !== null ? $this->sanitizedEndpointUri($config->endpointUri) : null,
             probeHealth: AiHealth::DISABLED->value,
             latencyMs: null,
             severity: AiProviderCheckSeverity::SKIPPED,
             reasonCodes: $reasonCodes,
-            diagnostics: [],
+            diagnostics: $config !== null ? ['provider_name' => $config->providerName] : [],
         );
     }
 

--- a/apps/atomy-q/API/app/Services/Ai/AiProviderReadinessChecker.php
+++ b/apps/atomy-q/API/app/Services/Ai/AiProviderReadinessChecker.php
@@ -1,0 +1,305 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Ai;
+
+use App\Adapters\Ai\Contracts\AiEndpointRegistryInterface;
+use App\Adapters\Ai\Contracts\AiRuntimeStatusInterface;
+use App\Services\Ai\Contracts\AiOperationalAlertPublisherInterface;
+use App\Services\Ai\Contracts\AiProviderReadinessCheckerInterface;
+use App\Services\Ai\Contracts\ProviderContractVerifierInterface;
+use DateTimeImmutable;
+use DateTimeZone;
+use Nexus\IntelligenceOperations\DTOs\AiStatusSchema;
+use Nexus\MachineLearning\Contracts\AiHealthProbeInterface;
+use Nexus\MachineLearning\Enums\AiHealth;
+use Nexus\MachineLearning\ValueObjects\AiEndpointConfig;
+use Throwable;
+
+final readonly class AiProviderReadinessChecker implements AiProviderReadinessCheckerInterface
+{
+    public function __construct(
+        private AiEndpointRegistryInterface $endpointRegistry,
+        private AiHealthProbeInterface $healthProbe,
+        private AiRuntimeStatusInterface $runtimeStatus,
+        private ProviderContractVerifierInterface $contractVerifier,
+        private ?AiOperationalAlertPublisherInterface $alertPublisher = null,
+    ) {}
+
+    /**
+     * @param  list<string>  $endpointGroups
+     */
+    public function check(
+        array $endpointGroups,
+        bool $deep,
+        bool $publishAlerts,
+        string $tenantId,
+        string $rfqId,
+    ): AiProviderReadinessResult {
+        $mode = $this->endpointRegistry->mode();
+        $checkedAt = new DateTimeImmutable('now', new DateTimeZone('UTC'));
+        $selectedGroups = $endpointGroups === []
+            ? $this->endpointRegistry->endpointGroups()
+            : array_values($endpointGroups);
+        $endpointChecks = [];
+        $findings = [];
+
+        foreach ($selectedGroups as $endpointGroup) {
+            $config = $this->endpointRegistry->endpointConfig($endpointGroup);
+
+            $endpointChecks[] = $this->checkEndpoint($endpointGroup, $mode, $config);
+            array_push($findings, ...$this->configurationFindings($endpointGroup, $mode, $config));
+        }
+
+        if ($deep) {
+            foreach ($this->contractVerifier->verify($selectedGroups, $tenantId, $rfqId) as $deepResult) {
+                $findings[] = new AiProviderCheckFinding(
+                    severity: $deepResult->severity,
+                    area: 'deep_contract',
+                    message: $deepResult->message,
+                    endpointGroup: $deepResult->endpointGroup,
+                    reasonCode: $deepResult->reasonCodes[0] ?? null,
+                );
+            }
+        }
+
+        $publishedAlerts = [];
+        if ($publishAlerts && $this->alertPublisher instanceof AiOperationalAlertPublisherInterface) {
+            $publishedAlerts = $this->alertPublisher->publishSnapshot($this->runtimeStatus->snapshot());
+        }
+
+        return new AiProviderReadinessResult(
+            checkedAt: $checkedAt->format(DATE_ATOM),
+            mode: $mode,
+            provider: $this->endpointRegistry->providerName(),
+            deep: $deep,
+            endpointGroups: $endpointChecks,
+            operatorFindings: $findings,
+            publishedAlerts: $publishedAlerts,
+        );
+    }
+
+    private function checkEndpoint(string $endpointGroup, string $mode, ?AiEndpointConfig $config): AiProviderEndpointCheck
+    {
+        if ($mode === AiStatusSchema::MODE_OFF) {
+            return $this->skippedEndpoint($endpointGroup, ['ai_disabled_by_config']);
+        }
+
+        if ($mode === AiStatusSchema::MODE_DETERMINISTIC) {
+            return $this->skippedEndpoint($endpointGroup, ['deterministic_fallback_mode']);
+        }
+
+        if ($config === null) {
+            return new AiProviderEndpointCheck(
+                endpointGroup: $endpointGroup,
+                configured: false,
+                enabled: false,
+                endpointUri: null,
+                probeHealth: null,
+                latencyMs: null,
+                severity: AiProviderCheckSeverity::FAILED,
+                reasonCodes: ['endpoint_not_configured'],
+                diagnostics: [],
+            );
+        }
+
+        if (! $config->enabled) {
+            return new AiProviderEndpointCheck(
+                endpointGroup: $endpointGroup,
+                configured: true,
+                enabled: false,
+                endpointUri: $this->sanitizedEndpointUri($config->endpointUri),
+                probeHealth: AiHealth::DISABLED->value,
+                latencyMs: null,
+                severity: AiProviderCheckSeverity::SKIPPED,
+                reasonCodes: ['endpoint_disabled_by_config'],
+                diagnostics: ['provider_name' => $config->providerName],
+            );
+        }
+
+        try {
+            $snapshot = $this->healthProbe->probe($config);
+        } catch (Throwable) {
+            return new AiProviderEndpointCheck(
+                endpointGroup: $endpointGroup,
+                configured: true,
+                enabled: true,
+                endpointUri: $this->sanitizedEndpointUri($config->endpointUri),
+                probeHealth: AiHealth::UNAVAILABLE->value,
+                latencyMs: null,
+                severity: AiProviderCheckSeverity::FAILED,
+                reasonCodes: ['health_probe_failed'],
+                diagnostics: ['provider_name' => $config->providerName],
+            );
+        }
+
+        return new AiProviderEndpointCheck(
+            endpointGroup: $endpointGroup,
+            configured: true,
+            enabled: true,
+            endpointUri: $this->sanitizedEndpointUri($config->endpointUri),
+            probeHealth: $snapshot->health->value,
+            latencyMs: $snapshot->latencyMs,
+            severity: $this->severityForHealth($snapshot->health),
+            reasonCodes: $snapshot->reasonCodes,
+            diagnostics: $this->sanitizedDiagnostics($snapshot->diagnostics),
+        );
+    }
+
+    /**
+     * @param  list<string>  $reasonCodes
+     */
+    private function skippedEndpoint(string $endpointGroup, array $reasonCodes): AiProviderEndpointCheck
+    {
+        return new AiProviderEndpointCheck(
+            endpointGroup: $endpointGroup,
+            configured: false,
+            enabled: false,
+            endpointUri: null,
+            probeHealth: AiHealth::DISABLED->value,
+            latencyMs: null,
+            severity: AiProviderCheckSeverity::SKIPPED,
+            reasonCodes: $reasonCodes,
+            diagnostics: [],
+        );
+    }
+
+    private function severityForHealth(AiHealth $health): string
+    {
+        return match ($health) {
+            AiHealth::HEALTHY => AiProviderCheckSeverity::OK,
+            AiHealth::DEGRADED => AiProviderCheckSeverity::WARNING,
+            AiHealth::UNAVAILABLE => AiProviderCheckSeverity::FAILED,
+            AiHealth::DISABLED => AiProviderCheckSeverity::SKIPPED,
+        };
+    }
+
+    /**
+     * @return list<AiProviderCheckFinding>
+     */
+    private function configurationFindings(string $endpointGroup, string $mode, ?AiEndpointConfig $config): array
+    {
+        if ($mode !== AiStatusSchema::MODE_PROVIDER || $config === null) {
+            return [];
+        }
+
+        $findings = [];
+        $authToken = $config->metadata['auth_token'] ?? null;
+
+        if (! is_string($authToken) || trim($authToken) === '') {
+            $findings[] = new AiProviderCheckFinding(
+                severity: AiProviderCheckSeverity::WARNING,
+                area: 'auth',
+                message: 'Endpoint ['.$endpointGroup.'] has no configured provider token.',
+                endpointGroup: $endpointGroup,
+                reasonCode: 'missing_auth_token',
+            );
+        }
+
+        if ($this->usesPlainHttpOutsideLocal($config->endpointUri)) {
+            $findings[] = new AiProviderCheckFinding(
+                severity: AiProviderCheckSeverity::WARNING,
+                area: 'security',
+                message: 'Endpoint ['.$endpointGroup.'] uses plain HTTP outside local development.',
+                endpointGroup: $endpointGroup,
+                reasonCode: 'plain_http_endpoint',
+            );
+        }
+
+        if ($config->timeoutSeconds <= 2) {
+            $findings[] = new AiProviderCheckFinding(
+                severity: AiProviderCheckSeverity::WARNING,
+                area: 'timeout',
+                message: 'Endpoint ['.$endpointGroup.'] timeout is very low for provider calls.',
+                endpointGroup: $endpointGroup,
+                reasonCode: 'low_timeout_seconds',
+            );
+        }
+
+        return $findings;
+    }
+
+    private function usesPlainHttpOutsideLocal(string $uri): bool
+    {
+        $parts = parse_url($uri);
+        if (! is_array($parts)) {
+            return false;
+        }
+
+        $scheme = strtolower((string) ($parts['scheme'] ?? ''));
+        $host = strtolower((string) ($parts['host'] ?? ''));
+
+        return $scheme === 'http' && ! in_array($host, ['localhost', '127.0.0.1', '::1'], true);
+    }
+
+    private function sanitizedEndpointUri(string $uri): string
+    {
+        $parts = parse_url($uri);
+        if (! is_array($parts)) {
+            return '[invalid-endpoint-uri]';
+        }
+
+        $scheme = isset($parts['scheme']) ? $parts['scheme'].'://' : '';
+        $host = (string) ($parts['host'] ?? '');
+        $port = isset($parts['port']) ? ':'.$parts['port'] : '';
+        $path = (string) ($parts['path'] ?? '');
+        $query = isset($parts['query']) ? '?'.$this->sanitizedQuery($parts['query']) : '';
+
+        return $scheme.$host.$port.$path.$query;
+    }
+
+    private function sanitizedQuery(string $query): string
+    {
+        $pairs = [];
+
+        foreach (explode('&', $query) as $pair) {
+            if ($pair === '') {
+                continue;
+            }
+
+            [$key] = explode('=', $pair, 2) + [1 => ''];
+            if (! $this->isSensitiveKey(rawurldecode($key))) {
+                $pairs[] = $pair;
+
+                continue;
+            }
+
+            $pairs[] = $key.'=[redacted]';
+        }
+
+        return implode('&', $pairs);
+    }
+
+    private function isSensitiveKey(string $key): bool
+    {
+        $lowerKey = strtolower($key);
+
+        return str_contains($lowerKey, 'key')
+            || str_contains($lowerKey, 'token')
+            || str_contains($lowerKey, 'secret')
+            || str_contains($lowerKey, 'signature')
+            || str_contains($lowerKey, 'credential')
+            || str_contains($lowerKey, 'password')
+            || str_contains($lowerKey, 'auth');
+    }
+
+    /**
+     * @param  array<string, scalar|null>  $diagnostics
+     * @return array<string, scalar|null>
+     */
+    private function sanitizedDiagnostics(array $diagnostics): array
+    {
+        $sanitized = [];
+
+        foreach ($diagnostics as $key => $value) {
+            if ($this->isSensitiveKey($key)) {
+                continue;
+            }
+
+            $sanitized[$key] = $value;
+        }
+
+        return $sanitized;
+    }
+}

--- a/apps/atomy-q/API/app/Services/Ai/AiProviderReadinessResult.php
+++ b/apps/atomy-q/API/app/Services/Ai/AiProviderReadinessResult.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Ai;
+
+final readonly class AiProviderReadinessResult
+{
+    /**
+     * @param list<AiProviderEndpointCheck> $endpointGroups
+     * @param list<AiProviderCheckFinding> $operatorFindings
+     * @param list<array<string, mixed>> $publishedAlerts
+     */
+    public function __construct(
+        public string $checkedAt,
+        public string $mode,
+        public string $provider,
+        public bool $deep,
+        public array $endpointGroups,
+        public array $operatorFindings,
+        public array $publishedAlerts = [],
+    ) {
+    }
+
+    public function exitSeverity(): string
+    {
+        $severity = AiProviderCheckSeverity::OK;
+
+        foreach ($this->endpointGroups as $endpointGroup) {
+            $severity = AiProviderCheckSeverity::worse($severity, $endpointGroup->severity);
+        }
+
+        foreach ($this->operatorFindings as $finding) {
+            $severity = AiProviderCheckSeverity::worse($severity, $finding->severity);
+        }
+
+        return $severity;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $exitSeverity = $this->exitSeverity();
+
+        return [
+            'checked_at' => $this->checkedAt,
+            'mode' => $this->mode,
+            'provider' => $this->provider,
+            'global_status' => $exitSeverity,
+            'deep' => $this->deep,
+            'endpoint_groups' => array_map(
+                static fn (AiProviderEndpointCheck $endpointGroup): array => $endpointGroup->toArray(),
+                $this->endpointGroups,
+            ),
+            'operator_findings' => array_map(
+                static fn (AiProviderCheckFinding $finding): array => $finding->toArray(),
+                $this->operatorFindings,
+            ),
+            'published_alerts' => $this->publishedAlerts,
+            'exit_severity' => $exitSeverity,
+        ];
+    }
+}

--- a/apps/atomy-q/API/app/Services/Ai/Contracts/AiProviderReadinessCheckerInterface.php
+++ b/apps/atomy-q/API/app/Services/Ai/Contracts/AiProviderReadinessCheckerInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Ai\Contracts;
+
+use App\Services\Ai\AiProviderReadinessResult;
+
+interface AiProviderReadinessCheckerInterface
+{
+    /**
+     * @param  list<string>  $endpointGroups
+     */
+    public function check(
+        array $endpointGroups,
+        bool $deep,
+        bool $publishAlerts,
+        string $tenantId,
+        string $rfqId,
+    ): AiProviderReadinessResult;
+}

--- a/apps/atomy-q/API/app/Services/Ai/Contracts/ProviderContractVerifierInterface.php
+++ b/apps/atomy-q/API/app/Services/Ai/Contracts/ProviderContractVerifierInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Ai\Contracts;
+
+use App\Services\Ai\ProviderContractVerificationResult;
+
+interface ProviderContractVerifierInterface
+{
+    /**
+     * @param list<string> $endpointGroups
+     */
+    public function assertEndpointGroups(array $endpointGroups): void;
+
+    /**
+     * @param list<string> $endpointGroups
+     *
+     * @return list<ProviderContractVerificationResult>
+     */
+    public function verify(array $endpointGroups, string $tenantId, string $rfqId): array;
+}

--- a/apps/atomy-q/API/app/Services/Ai/Contracts/ProviderContractVerifierInterface.php
+++ b/apps/atomy-q/API/app/Services/Ai/Contracts/ProviderContractVerifierInterface.php
@@ -9,6 +9,11 @@ use App\Services\Ai\ProviderContractVerificationResult;
 interface ProviderContractVerifierInterface
 {
     /**
+     * @return list<string>
+     */
+    public function endpointGroups(): array;
+
+    /**
      * @param list<string> $endpointGroups
      */
     public function assertEndpointGroups(array $endpointGroups): void;

--- a/apps/atomy-q/API/app/Services/Ai/ProviderContractVerificationResult.php
+++ b/apps/atomy-q/API/app/Services/Ai/ProviderContractVerificationResult.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Ai;
+
+final readonly class ProviderContractVerificationResult
+{
+    /**
+     * @param list<string> $reasonCodes
+     */
+    public function __construct(
+        public string $endpointGroup,
+        public string $severity,
+        public bool $verified,
+        public array $reasonCodes,
+        public string $message,
+    ) {
+    }
+
+    /**
+     * @return array{
+     *     endpoint_group: string,
+     *     severity: string,
+     *     verified: bool,
+     *     reason_codes: list<string>,
+     *     message: string
+     * }
+     */
+    public function toArray(): array
+    {
+        return [
+            'endpoint_group' => $this->endpointGroup,
+            'severity' => $this->severity,
+            'verified' => $this->verified,
+            'reason_codes' => $this->reasonCodes,
+            'message' => $this->message,
+        ];
+    }
+}

--- a/apps/atomy-q/API/app/Services/Ai/ProviderContractVerificationService.php
+++ b/apps/atomy-q/API/app/Services/Ai/ProviderContractVerificationService.php
@@ -1,0 +1,191 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Ai;
+
+use App\Adapters\Ai\Contracts\ComparisonAwardAiClientInterface;
+use App\Adapters\Ai\Contracts\ProviderDocumentIntelligenceClientInterface;
+use App\Adapters\Ai\Contracts\ProviderGovernanceClientInterface;
+use App\Adapters\Ai\Contracts\ProviderInsightClientInterface;
+use App\Adapters\Ai\Contracts\ProviderNormalizationClientInterface;
+use App\Adapters\Ai\Contracts\ProviderSourcingRecommendationClientInterface;
+use App\Adapters\Ai\DTOs\ComparisonOverlayRequest;
+use App\Adapters\Ai\DTOs\GovernanceNarrativeRequest;
+use App\Adapters\Ai\DTOs\InsightSummaryRequest;
+use App\Adapters\Ai\Exceptions\AiTransportFailedException;
+use App\Adapters\Ai\Exceptions\AiTransportInvalidResponseException;
+use App\Adapters\Ai\Exceptions\AiTransportUnavailableException;
+use App\Adapters\Ai\Exceptions\ComparisonAwardAiException;
+use App\Services\Ai\Contracts\ProviderContractVerifierInterface;
+use InvalidArgumentException;
+use Nexus\ProcurementOperations\DTOs\VendorRecommendation\VendorRecommendationRequest;
+use Nexus\ProcurementOperations\DTOs\VendorRecommendation\VendorRecommendationScoredCandidate;
+use RuntimeException;
+
+final readonly class ProviderContractVerificationService implements ProviderContractVerifierInterface
+{
+    public const ENDPOINT_GROUPS = [
+        'document',
+        'normalization',
+        'sourcing_recommendation',
+        'comparison_award',
+        'insight',
+        'governance',
+    ];
+
+    public function __construct(
+        private ProviderDocumentIntelligenceClientInterface $documentClient,
+        private ProviderNormalizationClientInterface $normalizationClient,
+        private ProviderSourcingRecommendationClientInterface $recommendationClient,
+        private ComparisonAwardAiClientInterface $comparisonAwardClient,
+        private ProviderInsightClientInterface $insightClient,
+        private ProviderGovernanceClientInterface $governanceClient,
+    ) {
+    }
+
+    public function assertEndpointGroups(array $endpointGroups): void
+    {
+        $unsupported = array_values(array_diff($endpointGroups, self::ENDPOINT_GROUPS));
+        if ($unsupported !== []) {
+            throw new InvalidArgumentException(
+                'Unsupported endpoint group(s): ' . implode(', ', $unsupported),
+            );
+        }
+    }
+
+    public function verify(array $endpointGroups, string $tenantId, string $rfqId): array
+    {
+        $this->assertEndpointGroups($endpointGroups);
+
+        $results = [];
+        foreach ($endpointGroups as $endpointGroup) {
+            try {
+                $payload = $this->verifyEndpointGroup($endpointGroup, $tenantId, $rfqId);
+            } catch (AiTransportInvalidResponseException $exception) {
+                $results[] = $this->failedResultForException($endpointGroup, $exception);
+
+                continue;
+            } catch (AiTransportUnavailableException $exception) {
+                $results[] = $this->failedResultForException($endpointGroup, $exception);
+
+                continue;
+            } catch (AiTransportFailedException $exception) {
+                $results[] = $this->failedResultForException($endpointGroup, $exception);
+
+                continue;
+            } catch (ComparisonAwardAiException $exception) {
+                $results[] = $this->failedResultForException($endpointGroup, $exception);
+
+                continue;
+            }
+
+            if (! is_array($payload) || array_is_list($payload)) {
+                $results[] = new ProviderContractVerificationResult(
+                    endpointGroup: $endpointGroup,
+                    severity: AiProviderCheckSeverity::FAILED,
+                    verified: false,
+                    reasonCodes: ['provider_invalid_payload'],
+                    message: 'Provider contract verification returned an invalid payload for ' . $endpointGroup,
+                );
+
+                continue;
+            }
+
+            $results[] = new ProviderContractVerificationResult(
+                endpointGroup: $endpointGroup,
+                severity: AiProviderCheckSeverity::OK,
+                verified: true,
+                reasonCodes: ['provider_available'],
+                message: 'Verified provider contract for ' . $endpointGroup,
+            );
+        }
+
+        return $results;
+    }
+
+    /**
+     * @return array<mixed>
+     */
+    private function verifyEndpointGroup(string $endpointGroup, string $tenantId, string $rfqId): array
+    {
+        return match ($endpointGroup) {
+            'document' => $this->documentClient->extract([
+                'tenant_id' => $tenantId,
+                'rfq_id' => $rfqId,
+                'document_id' => 'plan6-doc',
+                'filename' => 'plan6.pdf',
+                'mime_type' => 'application/pdf',
+            ]),
+            'normalization' => $this->normalizationClient->suggest([
+                'tenant_id' => $tenantId,
+                'rfq_id' => $rfqId,
+                'source_lines' => [['id' => 'src-1', 'text' => 'Plan 6 source line']],
+            ]),
+            'sourcing_recommendation' => $this->recommendationClient->enrich(
+                new VendorRecommendationRequest(
+                    tenantId: $tenantId,
+                    rfqId: $rfqId,
+                    categories: ['services'],
+                    description: 'Operational hardening contract verification',
+                    geography: 'MY',
+                    spendBand: 'mid',
+                    lineItemSummary: ['Line-item summary'],
+                    candidates: [],
+                ),
+                [
+                    new VendorRecommendationScoredCandidate(
+                        vendorId: 'vendor-1',
+                        vendorName: 'Vendor 1',
+                        fitScore: 80,
+                        confidenceBand: 'high',
+                        recommendedReasonSummary: 'Meets deterministic fit checks.',
+                        deterministicReasons: ['coverage'],
+                    ),
+                ],
+            ),
+            'comparison_award' => $this->comparisonAwardClient->comparisonOverlay(new ComparisonOverlayRequest(
+                tenantId: $tenantId,
+                rfqId: $rfqId,
+                mode: 'preview',
+                comparison: ['summary' => 'Plan 6 comparison contract verification'],
+                snapshot: null,
+            ))->payload,
+            'insight' => $this->insightClient->summarize(new InsightSummaryRequest(
+                featureKey: 'dashboard_ai_summary',
+                tenantId: $tenantId,
+                subjectType: 'dashboard_kpis',
+                facts: ['active_rfqs' => 0],
+            )),
+            'governance' => $this->governanceClient->narrate(new GovernanceNarrativeRequest(
+                featureKey: 'governance_ai_narrative',
+                tenantId: $tenantId,
+                vendorId: 'vendor-1',
+                facts: ['summary_scores' => ['compliance' => 90], 'warning_flags' => []],
+            )),
+            default => throw new InvalidArgumentException('Unsupported endpoint group: ' . $endpointGroup),
+        };
+    }
+
+    private function failedResultForException(string $endpointGroup, RuntimeException $exception): ProviderContractVerificationResult
+    {
+        return new ProviderContractVerificationResult(
+            endpointGroup: $endpointGroup,
+            severity: AiProviderCheckSeverity::FAILED,
+            verified: false,
+            reasonCodes: [$this->reasonCodeForException($exception)],
+            message: 'Provider contract verification failed for ' . $endpointGroup . '.',
+        );
+    }
+
+    private function reasonCodeForException(RuntimeException $exception): string
+    {
+        return match (true) {
+            $exception instanceof AiTransportInvalidResponseException => 'provider_invalid_payload',
+            $exception instanceof AiTransportUnavailableException => 'provider_unavailable',
+            $exception instanceof AiTransportFailedException => 'provider_request_failed',
+            $exception instanceof ComparisonAwardAiException => 'provider_contract_failed',
+            default => 'provider_contract_failed',
+        };
+    }
+}

--- a/apps/atomy-q/API/app/Services/Ai/ProviderContractVerificationService.php
+++ b/apps/atomy-q/API/app/Services/Ai/ProviderContractVerificationService.php
@@ -44,9 +44,14 @@ final readonly class ProviderContractVerificationService implements ProviderCont
     ) {
     }
 
+    public function endpointGroups(): array
+    {
+        return self::ENDPOINT_GROUPS;
+    }
+
     public function assertEndpointGroups(array $endpointGroups): void
     {
-        $unsupported = array_values(array_diff($endpointGroups, self::ENDPOINT_GROUPS));
+        $unsupported = array_values(array_diff($endpointGroups, $this->endpointGroups()));
         if ($unsupported !== []) {
             throw new InvalidArgumentException(
                 'Unsupported endpoint group(s): ' . implode(', ', $unsupported),

--- a/apps/atomy-q/API/composer.json
+++ b/apps/atomy-q/API/composer.json
@@ -94,6 +94,7 @@
         "laravel/sail": "^1.53",
         "mockery/mockery": "^1.6",
         "nunomaduro/collision": "^8.6",
+        "phpstan/phpstan": "^2.1",
         "phpunit/phpunit": "^11.5"
     },
     "autoload": {

--- a/apps/atomy-q/API/tests/Feature/Console/AiConsoleCommandsTest.php
+++ b/apps/atomy-q/API/tests/Feature/Console/AiConsoleCommandsTest.php
@@ -214,6 +214,13 @@ final class AiConsoleCommandsTest extends TestCase
             ->assertExitCode(1);
     }
 
+    public function testAiProviderCheckCommandFailsForUnsupportedFailOnOption(): void
+    {
+        $this->artisan('atomy:ai-provider-check --fail-on=warnng')
+            ->expectsOutputToContain('Unsupported --fail-on value [warnng]. Supported values: warning.')
+            ->assertExitCode(1);
+    }
+
     public function testAiStatusCommandEmitsJsonSnapshot(): void
     {
         $snapshot = new AiStatusSnapshot(
@@ -373,6 +380,11 @@ final class AiConsoleCommandsTest extends TestCase
     public function testAiVerifyContractsCommandFailsWhenVerifierReportsFailedResult(): void
     {
         $this->app->instance(ProviderContractVerifierInterface::class, new readonly class implements ProviderContractVerifierInterface {
+            public function endpointGroups(): array
+            {
+                return [AiStatusSchema::ENDPOINT_GROUP_DOCUMENT];
+            }
+
             public function assertEndpointGroups(array $endpointGroups): void
             {
             }

--- a/apps/atomy-q/API/tests/Feature/Console/AiConsoleCommandsTest.php
+++ b/apps/atomy-q/API/tests/Feature/Console/AiConsoleCommandsTest.php
@@ -33,17 +33,187 @@ use App\Adapters\Ai\ProviderNormalizationClient;
 use App\Adapters\Ai\ProviderSourcingRecommendationClient;
 use App\Adapters\Ai\Support\OpenRouterDocumentExtractionMapper;
 use App\Adapters\Ai\Support\OpenRouterDocumentPayloadFactory;
-use Illuminate\Contracts\Cache\Factory as CacheFactory;
-use Illuminate\Log\LogManager;
 use App\Services\Ai\AiOperationalAlertPublisher;
 use App\Services\Ai\AiProviderCheckSeverity;
+use App\Services\Ai\AiProviderCheckFinding;
+use App\Services\Ai\AiProviderEndpointCheck;
+use App\Services\Ai\AiProviderReadinessResult;
 use App\Services\Ai\Contracts\AiOperationalAlertPublisherInterface;
+use App\Services\Ai\Contracts\AiProviderReadinessCheckerInterface;
 use App\Services\Ai\Contracts\ProviderContractVerifierInterface;
 use App\Services\Ai\ProviderContractVerificationResult;
+use Illuminate\Contracts\Cache\Factory as CacheFactory;
+use Illuminate\Log\LogManager;
+use Illuminate\Support\Facades\Artisan;
 use Tests\TestCase;
 
 final class AiConsoleCommandsTest extends TestCase
 {
+    public function testAiProviderCheckCommandEmitsJsonWithSafeDefaults(): void
+    {
+        $secret = 'sk-live-provider-secret';
+        $checker = new class implements AiProviderReadinessCheckerInterface {
+            /** @var list<array<string, mixed>> */
+            public array $calls = [];
+
+            public function check(
+                array $endpointGroups,
+                bool $deep,
+                bool $publishAlerts,
+                string $tenantId,
+                string $rfqId,
+            ): AiProviderReadinessResult {
+                $this->calls[] = compact('endpointGroups', 'deep', 'publishAlerts', 'tenantId', 'rfqId');
+
+                return new AiProviderReadinessResult(
+                    checkedAt: '2026-04-24T03:00:00+00:00',
+                    mode: AiStatusSchema::MODE_PROVIDER,
+                    provider: 'openrouter',
+                    deep: false,
+                    endpointGroups: [
+                        new AiProviderEndpointCheck(
+                            endpointGroup: AiStatusSchema::ENDPOINT_GROUP_INSIGHT,
+                            configured: true,
+                            enabled: true,
+                            endpointUri: 'https://openrouter.ai/api/v1/chat/completions?api_key=[redacted]',
+                            probeHealth: AiStatusSchema::HEALTH_HEALTHY,
+                            latencyMs: 42,
+                            severity: AiProviderCheckSeverity::OK,
+                            reasonCodes: ['provider_available'],
+                            diagnostics: ['auth_token' => '[redacted]'],
+                        ),
+                    ],
+                    operatorFindings: [
+                        new AiProviderCheckFinding(
+                            severity: AiProviderCheckSeverity::OK,
+                            area: 'security',
+                            message: 'Provider token is redacted in operator output.',
+                            endpointGroup: AiStatusSchema::ENDPOINT_GROUP_INSIGHT,
+                        ),
+                    ],
+                    publishedAlerts: [
+                        ['message' => 'Provider alert payload redacted before command output.'],
+                    ],
+                );
+            }
+        };
+        $this->app->instance(AiProviderReadinessCheckerInterface::class, $checker);
+
+        $exitCode = Artisan::call('atomy:ai-provider-check', ['--json' => true]);
+        $output = Artisan::output();
+        $payload = json_decode($output, true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertSame(0, $exitCode);
+        self::assertIsArray($payload);
+        self::assertSame(AiProviderCheckSeverity::OK, $payload['global_status']);
+        self::assertSame(AiStatusSchema::ENDPOINT_GROUP_INSIGHT, $payload['endpoint_groups'][0]['endpoint_group']);
+        self::assertStringNotContainsString($secret, $output);
+        self::assertSame([
+            [
+                'endpointGroups' => AiStatusSchema::endpointGroups(),
+                'deep' => false,
+                'publishAlerts' => false,
+                'tenantId' => 'plan6-tenant',
+                'rfqId' => 'plan6-rfq',
+            ],
+        ], $checker->calls);
+    }
+
+    public function testAiProviderCheckCommandFailsWhenJsonPayloadCannotBeEncoded(): void
+    {
+        $this->app->instance(AiProviderReadinessCheckerInterface::class, new readonly class implements AiProviderReadinessCheckerInterface {
+            public function check(
+                array $endpointGroups,
+                bool $deep,
+                bool $publishAlerts,
+                string $tenantId,
+                string $rfqId,
+            ): AiProviderReadinessResult {
+                return new AiProviderReadinessResult(
+                    checkedAt: '2026-04-24T03:00:00+00:00',
+                    mode: AiStatusSchema::MODE_PROVIDER,
+                    provider: 'openrouter',
+                    deep: false,
+                    endpointGroups: [],
+                    operatorFindings: [],
+                    publishedAlerts: [
+                        ['latency_sample' => NAN],
+                    ],
+                );
+            }
+        });
+
+        $this->artisan('atomy:ai-provider-check --json')
+            ->expectsOutputToContain('Failed to encode AI provider check payload.')
+            ->assertExitCode(1);
+    }
+
+    public function testAiProviderCheckCommandFailsOnWarningsWhenConfigured(): void
+    {
+        $this->app->instance(AiProviderReadinessCheckerInterface::class, new readonly class implements AiProviderReadinessCheckerInterface {
+            public function check(
+                array $endpointGroups,
+                bool $deep,
+                bool $publishAlerts,
+                string $tenantId,
+                string $rfqId,
+            ): AiProviderReadinessResult {
+                return new AiProviderReadinessResult(
+                    checkedAt: '2026-04-24T03:00:00+00:00',
+                    mode: AiStatusSchema::MODE_PROVIDER,
+                    provider: 'openrouter',
+                    deep: true,
+                    endpointGroups: [
+                        new AiProviderEndpointCheck(
+                            endpointGroup: AiStatusSchema::ENDPOINT_GROUP_DOCUMENT,
+                            configured: true,
+                            enabled: true,
+                            endpointUri: 'https://openrouter.ai/api/v1/chat/completions',
+                            probeHealth: AiStatusSchema::HEALTH_DEGRADED,
+                            latencyMs: 120,
+                            severity: AiProviderCheckSeverity::WARNING,
+                            reasonCodes: ['provider_degraded'],
+                        ),
+                    ],
+                    operatorFindings: [
+                        new AiProviderCheckFinding(
+                            severity: AiProviderCheckSeverity::WARNING,
+                            area: 'auth',
+                            message: 'Endpoint [document] has no configured provider token.',
+                            endpointGroup: AiStatusSchema::ENDPOINT_GROUP_DOCUMENT,
+                            reasonCode: 'missing_auth_token',
+                        ),
+                    ],
+                );
+            }
+        });
+
+        $this->artisan('atomy:ai-provider-check --endpoint-group=document --deep --publish-alerts --json --fail-on=warning')
+            ->expectsOutputToContain('"exit_severity": "warning"')
+            ->assertExitCode(1);
+    }
+
+    public function testAiProviderCheckCommandFailsForUnsupportedEndpointGroup(): void
+    {
+        $this->artisan('atomy:ai-provider-check --endpoint-group=unsupported')
+            ->expectsOutputToContain('Unsupported endpoint group(s): unsupported')
+            ->assertExitCode(1);
+    }
+
+    public function testAiProviderCheckCommandFailsForBlankTenantOption(): void
+    {
+        $this->artisan('atomy:ai-provider-check --tenant-id=')
+            ->expectsOutputToContain('The --tenant-id option must be non-empty.')
+            ->assertExitCode(1);
+    }
+
+    public function testAiProviderCheckCommandFailsForBlankRfqOption(): void
+    {
+        $this->artisan('atomy:ai-provider-check --rfq-id=')
+            ->expectsOutputToContain('The --rfq-id option must be non-empty.')
+            ->assertExitCode(1);
+    }
+
     public function testAiStatusCommandEmitsJsonSnapshot(): void
     {
         $snapshot = new AiStatusSnapshot(

--- a/apps/atomy-q/API/tests/Feature/Console/AiConsoleCommandsTest.php
+++ b/apps/atomy-q/API/tests/Feature/Console/AiConsoleCommandsTest.php
@@ -27,6 +27,7 @@ use App\Adapters\Ai\DTOs\ComparisonOverlayRequest;
 use App\Adapters\Ai\DTOs\ComparisonOverlayResponse;
 use App\Adapters\Ai\DTOs\GovernanceNarrativeRequest;
 use App\Adapters\Ai\DTOs\InsightSummaryRequest;
+use App\Adapters\Ai\Exceptions\AiTransportUnavailableException;
 use App\Adapters\Ai\ProviderDocumentIntelligenceClient;
 use App\Adapters\Ai\ProviderNormalizationClient;
 use App\Adapters\Ai\ProviderSourcingRecommendationClient;
@@ -35,7 +36,10 @@ use App\Adapters\Ai\Support\OpenRouterDocumentPayloadFactory;
 use Illuminate\Contracts\Cache\Factory as CacheFactory;
 use Illuminate\Log\LogManager;
 use App\Services\Ai\AiOperationalAlertPublisher;
+use App\Services\Ai\AiProviderCheckSeverity;
 use App\Services\Ai\Contracts\AiOperationalAlertPublisherInterface;
+use App\Services\Ai\Contracts\ProviderContractVerifierInterface;
+use App\Services\Ai\ProviderContractVerificationResult;
 use Tests\TestCase;
 
 final class AiConsoleCommandsTest extends TestCase
@@ -173,5 +177,80 @@ final class AiConsoleCommandsTest extends TestCase
             ->expectsOutputToContain('Verified provider contract for insight')
             ->expectsOutputToContain('Verified provider contract for governance')
             ->assertExitCode(0);
+    }
+
+    public function testAiVerifyContractsCommandFailsForUnsupportedEndpointGroup(): void
+    {
+        $this->artisan('atomy:ai-verify-contracts --endpoint-group=unsupported')
+            ->expectsOutputToContain('Unsupported endpoint group(s): unsupported')
+            ->assertExitCode(1);
+    }
+
+    public function testAiVerifyContractsCommandFailsForBlankTenantOption(): void
+    {
+        $this->artisan('atomy:ai-verify-contracts --tenant-id=')
+            ->expectsOutputToContain('The --tenant-id option must be non-empty.')
+            ->assertExitCode(1);
+    }
+
+    public function testAiVerifyContractsCommandFailsForBlankRfqOption(): void
+    {
+        $this->artisan('atomy:ai-verify-contracts --rfq-id=')
+            ->expectsOutputToContain('The --rfq-id option must be non-empty.')
+            ->assertExitCode(1);
+    }
+
+    public function testAiVerifyContractsCommandFailsWhenVerifierReportsFailedResult(): void
+    {
+        $this->app->instance(ProviderContractVerifierInterface::class, new readonly class implements ProviderContractVerifierInterface {
+            public function assertEndpointGroups(array $endpointGroups): void
+            {
+            }
+
+            public function verify(array $endpointGroups, string $tenantId, string $rfqId): array
+            {
+                return [
+                    new ProviderContractVerificationResult(
+                        endpointGroup: 'document',
+                        severity: AiProviderCheckSeverity::FAILED,
+                        verified: false,
+                        reasonCodes: ['provider_invalid_payload'],
+                        message: 'Provider contract verification returned an invalid payload for document',
+                    ),
+                ];
+            }
+        });
+
+        $this->artisan('atomy:ai-verify-contracts --endpoint-group=document')
+            ->expectsOutputToContain('Provider contract verification returned an invalid payload for document')
+            ->assertExitCode(1);
+    }
+
+    public function testAiVerifyContractsCommandClassifiesProviderUnavailableExceptions(): void
+    {
+        $this->app->instance(ProviderInsightClientInterface::class, new readonly class implements ProviderInsightClientInterface {
+            public function summarize(InsightSummaryRequest $request): array
+            {
+                throw new AiTransportUnavailableException('AI endpoint [insight] is unavailable.');
+            }
+        });
+
+        $this->artisan('atomy:ai-verify-contracts --endpoint-group=insight')
+            ->expectsOutputToContain('Provider contract verification failed for insight.')
+            ->assertExitCode(1);
+    }
+
+    public function testAiVerifyContractsCommandFailsWhenProviderReturnsListPayload(): void
+    {
+        $this->app->instance(ProviderInsightClientInterface::class, new readonly class implements ProviderInsightClientInterface {
+            public function summarize(InsightSummaryRequest $request): array
+            {
+                return ['not-associative'];
+            }
+        });
+
+        $this->artisan('atomy:ai-verify-contracts --endpoint-group=insight')
+            ->expectsOutputToContain('Provider contract verification returned an invalid payload for insight')
+            ->assertExitCode(1);
     }
 }

--- a/apps/atomy-q/API/tests/Feature/Console/AiConsoleCommandsTest.php
+++ b/apps/atomy-q/API/tests/Feature/Console/AiConsoleCommandsTest.php
@@ -408,6 +408,48 @@ final class AiConsoleCommandsTest extends TestCase
             ->assertExitCode(1);
     }
 
+    public function testAiVerifyContractsCommandReportsAllResultsBeforeFailing(): void
+    {
+        $this->app->instance(ProviderContractVerifierInterface::class, new readonly class implements ProviderContractVerifierInterface {
+            public function endpointGroups(): array
+            {
+                return [
+                    AiStatusSchema::ENDPOINT_GROUP_DOCUMENT,
+                    AiStatusSchema::ENDPOINT_GROUP_INSIGHT,
+                ];
+            }
+
+            public function assertEndpointGroups(array $endpointGroups): void
+            {
+            }
+
+            public function verify(array $endpointGroups, string $tenantId, string $rfqId): array
+            {
+                return [
+                    new ProviderContractVerificationResult(
+                        endpointGroup: AiStatusSchema::ENDPOINT_GROUP_DOCUMENT,
+                        severity: AiProviderCheckSeverity::FAILED,
+                        verified: false,
+                        reasonCodes: ['provider_invalid_payload'],
+                        message: 'Provider contract verification returned an invalid payload for document',
+                    ),
+                    new ProviderContractVerificationResult(
+                        endpointGroup: AiStatusSchema::ENDPOINT_GROUP_INSIGHT,
+                        severity: AiProviderCheckSeverity::OK,
+                        verified: true,
+                        reasonCodes: ['provider_available'],
+                        message: 'Verified provider contract for insight',
+                    ),
+                ];
+            }
+        });
+
+        $this->artisan('atomy:ai-verify-contracts')
+            ->expectsOutputToContain('Provider contract verification returned an invalid payload for document')
+            ->expectsOutputToContain('Verified provider contract for insight')
+            ->assertExitCode(1);
+    }
+
     public function testAiVerifyContractsCommandClassifiesProviderUnavailableExceptions(): void
     {
         $this->app->instance(ProviderInsightClientInterface::class, new readonly class implements ProviderInsightClientInterface {

--- a/apps/atomy-q/API/tests/Unit/Services/AiProviderReadinessCheckerTest.php
+++ b/apps/atomy-q/API/tests/Unit/Services/AiProviderReadinessCheckerTest.php
@@ -4,15 +4,31 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Services;
 
+use App\Adapters\Ai\Contracts\AiEndpointRegistryInterface;
+use App\Adapters\Ai\Contracts\AiRuntimeStatusInterface;
 use App\Services\Ai\AiProviderCheckFinding;
 use App\Services\Ai\AiProviderCheckSeverity;
 use App\Services\Ai\AiProviderEndpointCheck;
+use App\Services\Ai\AiProviderReadinessChecker;
 use App\Services\Ai\AiProviderReadinessResult;
+use App\Services\Ai\Contracts\AiOperationalAlertPublisherInterface;
+use App\Services\Ai\Contracts\ProviderContractVerifierInterface;
+use App\Services\Ai\ProviderContractVerificationResult;
+use DateTimeImmutable;
+use Nexus\IntelligenceOperations\DTOs\AiCapabilityStatus;
+use Nexus\IntelligenceOperations\DTOs\AiStatusSchema;
+use Nexus\IntelligenceOperations\DTOs\AiStatusSnapshot;
+use Nexus\MachineLearning\Contracts\AiHealthProbeInterface;
+use Nexus\MachineLearning\Enums\AiEndpointGroup;
+use Nexus\MachineLearning\Enums\AiHealth;
+use Nexus\MachineLearning\ValueObjects\AiEndpointConfig;
+use Nexus\MachineLearning\ValueObjects\AiEndpointHealthSnapshot;
+use RuntimeException;
 use Tests\TestCase;
 
 final class AiProviderReadinessCheckerTest extends TestCase
 {
-    public function testReadinessResultRollsUpFailedSeverityAndSerializesPayload(): void
+    public function test_readiness_result_rolls_up_failed_severity_and_serializes_payload(): void
     {
         $result = new AiProviderReadinessResult(
             checkedAt: '2026-05-02T00:00:00+00:00',
@@ -54,5 +70,440 @@ final class AiProviderReadinessCheckerTest extends TestCase
         self::assertSame(AiProviderCheckSeverity::FAILED, $payload['exit_severity']);
         self::assertSame('document', $payload['endpoint_groups'][0]['endpoint_group']);
         self::assertSame('security', $payload['operator_findings'][0]['area']);
+    }
+
+    public function test_safe_check_marks_off_mode_endpoints_as_skipped_without_deep_verifier(): void
+    {
+        $checker = new AiProviderReadinessChecker(
+            endpointRegistry: new FakeEndpointRegistry('off', null),
+            healthProbe: new FakeHealthProbe,
+            runtimeStatus: FakeRuntimeStatus::withMode('off'),
+            contractVerifier: new FailingContractVerifier,
+        );
+
+        $result = $checker->check(
+            endpointGroups: ['document'],
+            deep: false,
+            publishAlerts: false,
+            tenantId: 'plan6-tenant',
+            rfqId: 'plan6-rfq',
+        );
+
+        self::assertSame(AiProviderCheckSeverity::SKIPPED, $result->endpointGroups[0]->severity);
+        self::assertSame(['ai_disabled_by_config'], $result->endpointGroups[0]->reasonCodes);
+    }
+
+    public function test_safe_check_marks_deterministic_mode_endpoints_as_skipped(): void
+    {
+        $checker = new AiProviderReadinessChecker(
+            endpointRegistry: new FakeEndpointRegistry('deterministic', null),
+            healthProbe: new FakeHealthProbe,
+            runtimeStatus: FakeRuntimeStatus::withMode('deterministic'),
+            contractVerifier: new FailingContractVerifier,
+        );
+
+        $result = $checker->check(
+            endpointGroups: ['document'],
+            deep: false,
+            publishAlerts: false,
+            tenantId: 'plan6-tenant',
+            rfqId: 'plan6-rfq',
+        );
+
+        self::assertSame(AiProviderCheckSeverity::SKIPPED, $result->endpointGroups[0]->severity);
+        self::assertSame(['deterministic_fallback_mode'], $result->endpointGroups[0]->reasonCodes);
+    }
+
+    public function test_empty_endpoint_groups_default_to_registry_endpoint_groups(): void
+    {
+        $verifier = new RecordingContractVerifier([]);
+        $checker = new AiProviderReadinessChecker(
+            endpointRegistry: new FakeEndpointRegistry('off', null, ['document', 'normalization']),
+            healthProbe: new FakeHealthProbe,
+            runtimeStatus: FakeRuntimeStatus::withMode('off'),
+            contractVerifier: $verifier,
+        );
+
+        $result = $checker->check(
+            endpointGroups: [],
+            deep: true,
+            publishAlerts: false,
+            tenantId: 'plan6-tenant',
+            rfqId: 'plan6-rfq',
+        );
+
+        self::assertSame(['document', 'normalization'], array_map(
+            static fn (AiProviderEndpointCheck $endpointCheck): string => $endpointCheck->endpointGroup,
+            $result->endpointGroups,
+        ));
+        self::assertSame([['document', 'normalization'], 'plan6-tenant', 'plan6-rfq'], $verifier->verifiedWith);
+    }
+
+    public function test_safe_check_reports_missing_provider_endpoint_as_failed(): void
+    {
+        $checker = new AiProviderReadinessChecker(
+            endpointRegistry: new FakeEndpointRegistry('provider', null),
+            healthProbe: new FakeHealthProbe,
+            runtimeStatus: FakeRuntimeStatus::withMode('provider'),
+            contractVerifier: new FailingContractVerifier,
+        );
+
+        $result = $checker->check(
+            endpointGroups: ['document'],
+            deep: false,
+            publishAlerts: false,
+            tenantId: 'plan6-tenant',
+            rfqId: 'plan6-rfq',
+        );
+
+        self::assertSame(AiProviderCheckSeverity::FAILED, $result->endpointGroups[0]->severity);
+        self::assertSame(['endpoint_not_configured'], $result->endpointGroups[0]->reasonCodes);
+    }
+
+    public function test_safe_check_uses_probe_health_and_warns_about_plain_http_without_leaking_token(): void
+    {
+        $checker = new AiProviderReadinessChecker(
+            endpointRegistry: new FakeEndpointRegistry('provider', $this->endpointConfig(
+                endpointUri: 'http://provider.example.test/ai',
+                timeoutSeconds: 10,
+                metadata: ['auth_token' => 'secret-token'],
+            )),
+            healthProbe: new FakeHealthProbe(AiHealth::HEALTHY),
+            runtimeStatus: FakeRuntimeStatus::withMode('provider'),
+            contractVerifier: new FailingContractVerifier,
+        );
+
+        $result = $checker->check(
+            endpointGroups: ['document'],
+            deep: false,
+            publishAlerts: false,
+            tenantId: 'plan6-tenant',
+            rfqId: 'plan6-rfq',
+        );
+
+        self::assertSame(AiProviderCheckSeverity::OK, $result->endpointGroups[0]->severity);
+        self::assertSame('healthy', $result->endpointGroups[0]->probeHealth);
+        self::assertSame('plain_http_endpoint', $result->operatorFindings[0]->reasonCode);
+        self::assertStringNotContainsString(
+            'secret-token',
+            json_encode($result->toArray(), JSON_THROW_ON_ERROR),
+        );
+    }
+
+    public function test_endpoint_uri_query_secrets_are_redacted_without_removing_safe_query_params(): void
+    {
+        $checker = new AiProviderReadinessChecker(
+            endpointRegistry: new FakeEndpointRegistry('provider', $this->endpointConfig(
+                endpointUri: 'https://provider.example.test/ai?api_key=secret-token&model=x',
+                timeoutSeconds: 10,
+                metadata: ['auth_token' => 'configured-token'],
+            )),
+            healthProbe: new FakeHealthProbe(AiHealth::HEALTHY),
+            runtimeStatus: FakeRuntimeStatus::withMode('provider'),
+            contractVerifier: new FailingContractVerifier,
+        );
+
+        $result = $checker->check(
+            endpointGroups: ['document'],
+            deep: false,
+            publishAlerts: false,
+            tenantId: 'plan6-tenant',
+            rfqId: 'plan6-rfq',
+        );
+
+        self::assertSame('https://provider.example.test/ai?api_key=[redacted]&model=x', $result->endpointGroups[0]->endpointUri);
+        self::assertStringNotContainsString(
+            'secret-token',
+            json_encode($result->toArray(), JSON_THROW_ON_ERROR),
+        );
+    }
+
+    public function test_endpoint_uri_fragments_are_dropped_without_leaking_fragment_secrets(): void
+    {
+        $checker = new AiProviderReadinessChecker(
+            endpointRegistry: new FakeEndpointRegistry('provider', $this->endpointConfig(
+                endpointUri: 'https://provider.example.test/callback#access_token=secret-token',
+                timeoutSeconds: 10,
+                metadata: ['auth_token' => 'configured-token'],
+            )),
+            healthProbe: new FakeHealthProbe(AiHealth::HEALTHY),
+            runtimeStatus: FakeRuntimeStatus::withMode('provider'),
+            contractVerifier: new FailingContractVerifier,
+        );
+
+        $result = $checker->check(
+            endpointGroups: ['document'],
+            deep: false,
+            publishAlerts: false,
+            tenantId: 'plan6-tenant',
+            rfqId: 'plan6-rfq',
+        );
+
+        self::assertSame('https://provider.example.test/callback', $result->endpointGroups[0]->endpointUri);
+        self::assertStringNotContainsString(
+            'secret-token',
+            json_encode($result->toArray(), JSON_THROW_ON_ERROR),
+        );
+    }
+
+    public function test_malformed_endpoint_uri_uses_placeholder_without_leaking_raw_token(): void
+    {
+        $checker = new AiProviderReadinessChecker(
+            endpointRegistry: new FakeEndpointRegistry('provider', $this->endpointConfig(
+                endpointUri: 'http:///path?token=secret-token',
+                timeoutSeconds: 10,
+                metadata: ['auth_token' => 'configured-token'],
+            )),
+            healthProbe: new FakeHealthProbe(AiHealth::HEALTHY),
+            runtimeStatus: FakeRuntimeStatus::withMode('provider'),
+            contractVerifier: new FailingContractVerifier,
+        );
+
+        $result = $checker->check(
+            endpointGroups: ['document'],
+            deep: false,
+            publishAlerts: false,
+            tenantId: 'plan6-tenant',
+            rfqId: 'plan6-rfq',
+        );
+
+        self::assertSame('[invalid-endpoint-uri]', $result->endpointGroups[0]->endpointUri);
+        self::assertStringNotContainsString(
+            'secret-token',
+            json_encode($result->toArray(), JSON_THROW_ON_ERROR),
+        );
+    }
+
+    public function test_safe_check_reports_missing_token_and_low_timeout_warnings(): void
+    {
+        $checker = new AiProviderReadinessChecker(
+            endpointRegistry: new FakeEndpointRegistry('provider', $this->endpointConfig(
+                endpointUri: 'https://provider.example.test/ai',
+                timeoutSeconds: 2,
+                metadata: [],
+            )),
+            healthProbe: new FakeHealthProbe(AiHealth::DEGRADED),
+            runtimeStatus: FakeRuntimeStatus::withMode('provider'),
+            contractVerifier: new FailingContractVerifier,
+        );
+
+        $result = $checker->check(
+            endpointGroups: ['document'],
+            deep: false,
+            publishAlerts: false,
+            tenantId: 'plan6-tenant',
+            rfqId: 'plan6-rfq',
+        );
+
+        self::assertSame(AiProviderCheckSeverity::WARNING, $result->endpointGroups[0]->severity);
+        self::assertSame(['missing_auth_token', 'low_timeout_seconds'], array_map(
+            static fn (AiProviderCheckFinding $finding): ?string => $finding->reasonCode,
+            $result->operatorFindings,
+        ));
+    }
+
+    public function test_deep_check_appends_verifier_findings(): void
+    {
+        $verifier = new RecordingContractVerifier([
+            new ProviderContractVerificationResult(
+                endpointGroup: 'document',
+                severity: AiProviderCheckSeverity::FAILED,
+                verified: false,
+                reasonCodes: ['provider_invalid_payload'],
+                message: 'Provider contract verification failed for document.',
+            ),
+        ]);
+        $checker = new AiProviderReadinessChecker(
+            endpointRegistry: new FakeEndpointRegistry('provider', $this->endpointConfig()),
+            healthProbe: new FakeHealthProbe(AiHealth::HEALTHY),
+            runtimeStatus: FakeRuntimeStatus::withMode('provider'),
+            contractVerifier: $verifier,
+        );
+
+        $result = $checker->check(
+            endpointGroups: ['document'],
+            deep: true,
+            publishAlerts: false,
+            tenantId: 'plan6-tenant',
+            rfqId: 'plan6-rfq',
+        );
+
+        self::assertSame([['document'], 'plan6-tenant', 'plan6-rfq'], $verifier->verifiedWith);
+        self::assertSame('deep_contract', $result->operatorFindings[0]->area);
+        self::assertSame('provider_invalid_payload', $result->operatorFindings[0]->reasonCode);
+    }
+
+    public function test_publish_alerts_includes_published_alerts_when_publisher_is_available(): void
+    {
+        $publisher = new FakeAlertPublisher([['type' => 'ai_provider_check', 'status' => 'published']]);
+        $checker = new AiProviderReadinessChecker(
+            endpointRegistry: new FakeEndpointRegistry('provider', $this->endpointConfig()),
+            healthProbe: new FakeHealthProbe(AiHealth::HEALTHY),
+            runtimeStatus: FakeRuntimeStatus::withMode('provider'),
+            contractVerifier: new FailingContractVerifier,
+            alertPublisher: $publisher,
+        );
+
+        $result = $checker->check(
+            endpointGroups: ['document'],
+            deep: false,
+            publishAlerts: true,
+            tenantId: 'plan6-tenant',
+            rfqId: 'plan6-rfq',
+        );
+
+        self::assertTrue($publisher->published);
+        self::assertSame([['type' => 'ai_provider_check', 'status' => 'published']], $result->publishedAlerts);
+    }
+
+    /**
+     * @param  array<string, scalar|null>  $metadata
+     */
+    private function endpointConfig(
+        string $endpointUri = 'https://provider.example.test/ai',
+        int $timeoutSeconds = 10,
+        array $metadata = ['auth_token' => 'secret-token'],
+    ): AiEndpointConfig {
+        return new AiEndpointConfig(
+            endpointGroup: AiEndpointGroup::DOCUMENT,
+            providerName: 'openrouter',
+            endpointUri: $endpointUri,
+            timeoutSeconds: $timeoutSeconds,
+            enabled: true,
+            metadata: $metadata,
+        );
+    }
+}
+
+final readonly class FakeEndpointRegistry implements AiEndpointRegistryInterface
+{
+    /**
+     * @param  list<string>  $endpointGroups
+     */
+    public function __construct(
+        private string $mode,
+        private ?AiEndpointConfig $config,
+        private array $endpointGroups = ['document'],
+    ) {}
+
+    public function mode(): string
+    {
+        return $this->mode;
+    }
+
+    public function providerName(): string
+    {
+        return 'openrouter';
+    }
+
+    public function endpointGroups(): array
+    {
+        return $this->endpointGroups;
+    }
+
+    public function endpointConfig(string $endpointGroup): ?AiEndpointConfig
+    {
+        return $endpointGroup === 'document' ? $this->config : null;
+    }
+}
+
+final readonly class FakeHealthProbe implements AiHealthProbeInterface
+{
+    public function __construct(private AiHealth $health = AiHealth::UNAVAILABLE) {}
+
+    public function probe(AiEndpointConfig $endpointConfig): AiEndpointHealthSnapshot
+    {
+        return new AiEndpointHealthSnapshot(
+            endpointGroup: $endpointConfig->endpointGroup,
+            health: $this->health,
+            checkedAt: new DateTimeImmutable('2026-05-02T00:00:00+00:00'),
+            reasonCodes: [$this->health === AiHealth::HEALTHY ? 'provider_available' : 'health_probe_failed'],
+            latencyMs: 25,
+            diagnostics: ['provider_name' => $endpointConfig->providerName],
+        );
+    }
+}
+
+final readonly class FakeRuntimeStatus implements AiRuntimeStatusInterface
+{
+    public function __construct(private AiStatusSnapshot $snapshot) {}
+
+    public static function withMode(string $mode): self
+    {
+        return new self(new AiStatusSnapshot(
+            mode: $mode,
+            globalHealth: $mode === AiStatusSchema::MODE_PROVIDER
+                ? AiStatusSchema::HEALTH_HEALTHY
+                : AiStatusSchema::HEALTH_DISABLED,
+            capabilityDefinitions: [],
+            capabilityStatuses: [],
+            endpointGroupHealthSnapshots: [],
+            reasonCodes: [],
+            generatedAt: new DateTimeImmutable('2026-05-02T00:00:00+00:00'),
+        ));
+    }
+
+    public function snapshot(): AiStatusSnapshot
+    {
+        return $this->snapshot;
+    }
+
+    public function capabilityStatus(string $featureKey): ?AiCapabilityStatus
+    {
+        return null;
+    }
+
+    public function providerName(): string
+    {
+        return 'openrouter';
+    }
+}
+
+final class FailingContractVerifier implements ProviderContractVerifierInterface
+{
+    public function assertEndpointGroups(array $endpointGroups): void {}
+
+    public function verify(array $endpointGroups, string $tenantId, string $rfqId): array
+    {
+        throw new RuntimeException('Deep verifier should not run during safe checks.');
+    }
+}
+
+final class RecordingContractVerifier implements ProviderContractVerifierInterface
+{
+    /**
+     * @var array{list<string>, string, string}|null
+     */
+    public ?array $verifiedWith = null;
+
+    /**
+     * @param  list<ProviderContractVerificationResult>  $results
+     */
+    public function __construct(private array $results) {}
+
+    public function assertEndpointGroups(array $endpointGroups): void {}
+
+    public function verify(array $endpointGroups, string $tenantId, string $rfqId): array
+    {
+        $this->verifiedWith = [$endpointGroups, $tenantId, $rfqId];
+
+        return $this->results;
+    }
+}
+
+final class FakeAlertPublisher implements AiOperationalAlertPublisherInterface
+{
+    public bool $published = false;
+
+    /**
+     * @param  list<array<string, mixed>>  $alerts
+     */
+    public function __construct(private array $alerts) {}
+
+    public function publishSnapshot(AiStatusSnapshot $snapshot): array
+    {
+        $this->published = true;
+
+        return $this->alerts;
     }
 }

--- a/apps/atomy-q/API/tests/Unit/Services/AiProviderReadinessCheckerTest.php
+++ b/apps/atomy-q/API/tests/Unit/Services/AiProviderReadinessCheckerTest.php
@@ -28,6 +28,12 @@ use Tests\TestCase;
 
 final class AiProviderReadinessCheckerTest extends TestCase
 {
+    public function test_unknown_provider_check_severity_ranks_as_unknown_instead_of_healthier_than_ok(): void
+    {
+        self::assertSame(30, AiProviderCheckSeverity::rank('unexpected'));
+        self::assertSame('unexpected', AiProviderCheckSeverity::worse('unexpected', AiProviderCheckSeverity::OK));
+    }
+
     public function test_readiness_result_rolls_up_failed_severity_and_serializes_payload(): void
     {
         $result = new AiProviderReadinessResult(
@@ -93,6 +99,28 @@ final class AiProviderReadinessCheckerTest extends TestCase
         self::assertSame(['ai_disabled_by_config'], $result->endpointGroups[0]->reasonCodes);
     }
 
+    public function test_safe_check_preserves_real_config_state_for_off_mode_endpoints(): void
+    {
+        $checker = new AiProviderReadinessChecker(
+            endpointRegistry: new FakeEndpointRegistry('off', $this->endpointConfig()),
+            healthProbe: new FakeHealthProbe,
+            runtimeStatus: FakeRuntimeStatus::withMode('off'),
+            contractVerifier: new FailingContractVerifier,
+        );
+
+        $result = $checker->check(
+            endpointGroups: ['document'],
+            deep: false,
+            publishAlerts: false,
+            tenantId: 'plan6-tenant',
+            rfqId: 'plan6-rfq',
+        );
+
+        self::assertTrue($result->endpointGroups[0]->configured);
+        self::assertTrue($result->endpointGroups[0]->enabled);
+        self::assertSame('https://provider.example.test/ai', $result->endpointGroups[0]->endpointUri);
+    }
+
     public function test_safe_check_marks_deterministic_mode_endpoints_as_skipped(): void
     {
         $checker = new AiProviderReadinessChecker(
@@ -112,6 +140,28 @@ final class AiProviderReadinessCheckerTest extends TestCase
 
         self::assertSame(AiProviderCheckSeverity::SKIPPED, $result->endpointGroups[0]->severity);
         self::assertSame(['deterministic_fallback_mode'], $result->endpointGroups[0]->reasonCodes);
+    }
+
+    public function test_safe_check_preserves_real_config_state_for_deterministic_mode_endpoints(): void
+    {
+        $checker = new AiProviderReadinessChecker(
+            endpointRegistry: new FakeEndpointRegistry('deterministic', $this->endpointConfig()),
+            healthProbe: new FakeHealthProbe,
+            runtimeStatus: FakeRuntimeStatus::withMode('deterministic'),
+            contractVerifier: new FailingContractVerifier,
+        );
+
+        $result = $checker->check(
+            endpointGroups: ['document'],
+            deep: false,
+            publishAlerts: false,
+            tenantId: 'plan6-tenant',
+            rfqId: 'plan6-rfq',
+        );
+
+        self::assertTrue($result->endpointGroups[0]->configured);
+        self::assertTrue($result->endpointGroups[0]->enabled);
+        self::assertSame('https://provider.example.test/ai', $result->endpointGroups[0]->endpointUri);
     }
 
     public function test_empty_endpoint_groups_default_to_registry_endpoint_groups(): void
@@ -333,6 +383,30 @@ final class AiProviderReadinessCheckerTest extends TestCase
         self::assertSame('provider_invalid_payload', $result->operatorFindings[0]->reasonCode);
     }
 
+    public function test_deep_check_converts_verifier_exception_into_failure_finding(): void
+    {
+        $checker = new AiProviderReadinessChecker(
+            endpointRegistry: new FakeEndpointRegistry('provider', $this->endpointConfig()),
+            healthProbe: new FakeHealthProbe(AiHealth::HEALTHY),
+            runtimeStatus: FakeRuntimeStatus::withMode('provider'),
+            contractVerifier: new ExplodingContractVerifier('Deep verification crashed.'),
+        );
+
+        $result = $checker->check(
+            endpointGroups: ['document'],
+            deep: true,
+            publishAlerts: false,
+            tenantId: 'plan6-tenant',
+            rfqId: 'plan6-rfq',
+        );
+
+        self::assertSame(AiProviderCheckSeverity::FAILED, $result->operatorFindings[0]->severity);
+        self::assertSame('deep_contract', $result->operatorFindings[0]->area);
+        self::assertSame('Deep verification crashed.', $result->operatorFindings[0]->message);
+        self::assertNull($result->operatorFindings[0]->endpointGroup);
+        self::assertNull($result->operatorFindings[0]->reasonCode);
+    }
+
     public function test_publish_alerts_includes_published_alerts_when_publisher_is_available(): void
     {
         $publisher = new FakeAlertPublisher([['type' => 'ai_provider_check', 'status' => 'published']]);
@@ -354,6 +428,32 @@ final class AiProviderReadinessCheckerTest extends TestCase
 
         self::assertTrue($publisher->published);
         self::assertSame([['type' => 'ai_provider_check', 'status' => 'published']], $result->publishedAlerts);
+    }
+
+    public function test_publish_alerts_converts_publisher_exception_into_failure_finding(): void
+    {
+        $checker = new AiProviderReadinessChecker(
+            endpointRegistry: new FakeEndpointRegistry('provider', $this->endpointConfig()),
+            healthProbe: new FakeHealthProbe(AiHealth::HEALTHY),
+            runtimeStatus: FakeRuntimeStatus::withMode('provider'),
+            contractVerifier: new RecordingContractVerifier([]),
+            alertPublisher: new ExplodingAlertPublisher('Alert publishing crashed.'),
+        );
+
+        $result = $checker->check(
+            endpointGroups: ['document'],
+            deep: false,
+            publishAlerts: true,
+            tenantId: 'plan6-tenant',
+            rfqId: 'plan6-rfq',
+        );
+
+        self::assertSame([], $result->publishedAlerts);
+        self::assertSame(AiProviderCheckSeverity::FAILED, $result->operatorFindings[0]->severity);
+        self::assertSame('alert_publish', $result->operatorFindings[0]->area);
+        self::assertSame('Alert publishing crashed.', $result->operatorFindings[0]->message);
+        self::assertNull($result->operatorFindings[0]->endpointGroup);
+        self::assertNull($result->operatorFindings[0]->reasonCode);
     }
 
     /**
@@ -501,6 +601,23 @@ final class RecordingContractVerifier implements ProviderContractVerifierInterfa
     }
 }
 
+final readonly class ExplodingContractVerifier implements ProviderContractVerifierInterface
+{
+    public function __construct(private string $message) {}
+
+    public function endpointGroups(): array
+    {
+        return AiStatusSchema::endpointGroups();
+    }
+
+    public function assertEndpointGroups(array $endpointGroups): void {}
+
+    public function verify(array $endpointGroups, string $tenantId, string $rfqId): array
+    {
+        throw new RuntimeException($this->message);
+    }
+}
+
 final class FakeAlertPublisher implements AiOperationalAlertPublisherInterface
 {
     public bool $published = false;
@@ -515,5 +632,15 @@ final class FakeAlertPublisher implements AiOperationalAlertPublisherInterface
         $this->published = true;
 
         return $this->alerts;
+    }
+}
+
+final readonly class ExplodingAlertPublisher implements AiOperationalAlertPublisherInterface
+{
+    public function __construct(private string $message) {}
+
+    public function publishSnapshot(AiStatusSnapshot $snapshot): array
+    {
+        throw new RuntimeException($this->message);
     }
 }

--- a/apps/atomy-q/API/tests/Unit/Services/AiProviderReadinessCheckerTest.php
+++ b/apps/atomy-q/API/tests/Unit/Services/AiProviderReadinessCheckerTest.php
@@ -461,6 +461,11 @@ final readonly class FakeRuntimeStatus implements AiRuntimeStatusInterface
 
 final class FailingContractVerifier implements ProviderContractVerifierInterface
 {
+    public function endpointGroups(): array
+    {
+        return AiStatusSchema::endpointGroups();
+    }
+
     public function assertEndpointGroups(array $endpointGroups): void {}
 
     public function verify(array $endpointGroups, string $tenantId, string $rfqId): array
@@ -480,6 +485,11 @@ final class RecordingContractVerifier implements ProviderContractVerifierInterfa
      * @param  list<ProviderContractVerificationResult>  $results
      */
     public function __construct(private array $results) {}
+
+    public function endpointGroups(): array
+    {
+        return AiStatusSchema::endpointGroups();
+    }
 
     public function assertEndpointGroups(array $endpointGroups): void {}
 

--- a/apps/atomy-q/API/tests/Unit/Services/AiProviderReadinessCheckerTest.php
+++ b/apps/atomy-q/API/tests/Unit/Services/AiProviderReadinessCheckerTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services;
+
+use App\Services\Ai\AiProviderCheckFinding;
+use App\Services\Ai\AiProviderCheckSeverity;
+use App\Services\Ai\AiProviderEndpointCheck;
+use App\Services\Ai\AiProviderReadinessResult;
+use Tests\TestCase;
+
+final class AiProviderReadinessCheckerTest extends TestCase
+{
+    public function testReadinessResultRollsUpFailedSeverityAndSerializesPayload(): void
+    {
+        $result = new AiProviderReadinessResult(
+            checkedAt: '2026-05-02T00:00:00+00:00',
+            mode: 'provider',
+            provider: 'openrouter',
+            deep: false,
+            endpointGroups: [
+                new AiProviderEndpointCheck(
+                    endpointGroup: 'document',
+                    configured: true,
+                    enabled: true,
+                    endpointUri: 'https://openrouter.ai/api/v1/chat/completions',
+                    probeHealth: 'unavailable',
+                    latencyMs: 120,
+                    severity: AiProviderCheckSeverity::FAILED,
+                    reasonCodes: ['health_probe_failed'],
+                    diagnostics: ['provider_name' => 'openrouter'],
+                ),
+            ],
+            operatorFindings: [
+                new AiProviderCheckFinding(
+                    severity: AiProviderCheckSeverity::WARNING,
+                    area: 'security',
+                    message: 'Endpoint [document] uses plain HTTP outside local development.',
+                    endpointGroup: 'document',
+                    reasonCode: 'plain_http_endpoint',
+                ),
+            ],
+            publishedAlerts: [],
+        );
+
+        self::assertSame(AiProviderCheckSeverity::FAILED, $result->exitSeverity());
+
+        $payload = $result->toArray();
+        self::assertSame('provider', $payload['mode']);
+        self::assertSame('openrouter', $payload['provider']);
+        self::assertFalse($payload['deep']);
+        self::assertSame(AiProviderCheckSeverity::FAILED, $payload['global_status']);
+        self::assertSame(AiProviderCheckSeverity::FAILED, $payload['exit_severity']);
+        self::assertSame('document', $payload['endpoint_groups'][0]['endpoint_group']);
+        self::assertSame('security', $payload['operator_findings'][0]['area']);
+    }
+}

--- a/orchestrators/SupplyChainOperations/phpstan.neon
+++ b/orchestrators/SupplyChainOperations/phpstan.neon
@@ -3,4 +3,4 @@ parameters:
     paths:
         - src
     bootstrapFiles:
-        - vendor/autoload.php
+        - ../../vendor/autoload.php

--- a/packages/Payment/phpstan.neon
+++ b/packages/Payment/phpstan.neon
@@ -2,34 +2,8 @@ parameters:
     level: 8
     paths:
         - src
-    
-    # Stub the Money class from Nexus\Common since it's not available in isolation
-    stubFiles:
-        - phpstan-stubs/Money.stub
-    
-    # Ignore errors for missing types from external dependencies (not real issues)
-    # These resolve when composer install is run with proper autoloading
-    ignoreErrors:
-        # Nexus\Common dependency
-        - '#has invalid (return )?type Nexus\\Common\\ValueObjects\\Money#'
-        - '#has unknown class Nexus\\Common\\ValueObjects\\Money#'
-        - '#Call to .* on an unknown class Nexus\\Common\\ValueObjects\\Money#'
-        - '#Parameter .* has invalid type Nexus\\Common\\ValueObjects\\Money#'
-        - '#Property .* has unknown class Nexus\\Common\\ValueObjects\\Money#'
-        
-        # PSR interfaces (installed via composer)
-        - '#has invalid type Psr\\Log\\LoggerInterface#'
-        - '#has unknown class Psr\\Log\\LoggerInterface#'
-        - '#on an unknown class Psr\\Log\\LoggerInterface#'
-        - '#has invalid type Psr\\EventDispatcher\\EventDispatcherInterface#'
-        - '#has unknown class Psr\\EventDispatcher\\EventDispatcherInterface#'
-        - '#on an unknown class Psr\\EventDispatcher\\EventDispatcherInterface#'
-        - '#Instantiated class Psr\\Log\\NullLogger not found#'
-        - '#Default value of the parameter .* \(Psr\\Log\\NullLogger\) .* is incompatible#'
-        
-        # PHPDoc @throws for exceptions (not actual code issues)
-        - '#PHPDoc tag @throws with type Nexus\\Payment\\Contracts\\InvalidDisbursementStatusException#'
-        - '#PHPDoc tag @throws with type Nexus\\Payment\\Exceptions\\PaymentStateException#'
-    
+    bootstrapFiles:
+        - ../../vendor/autoload.php
+
     # Report unmatched ignores so we know when issues are fixed
     reportUnmatchedIgnoredErrors: true

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,10 @@
+parameters:
+    level: 5
+    paths:
+        - packages
+        - orchestrators
+        - adapters
+    bootstrapFiles:
+        - vendor/autoload.php
+    checkMissingIterableValueType: false
+    checkGenericClassInNonGenericObjectType: false


### PR DESCRIPTION
## Summary
- Add `atomy:ai-provider-check` for safe-by-default AI provider readiness checks with JSON/human output, endpoint filtering, alert publishing, and `--fail-on=warning`.
- Extract reusable provider contract verification behind `ProviderContractVerifierInterface` while preserving `atomy:ai-verify-contracts`.
- Add focused console and readiness checker tests, including token redaction and JSON failure coverage.

## Validation
- `php artisan test tests/Feature/Console/AiConsoleCommandsTest.php tests/Unit/Services/AiProviderReadinessCheckerTest.php`
- `php artisan atomy:ai-provider-check --json`
- `php artisan atomy:ai-provider-check --endpoint-group=document`

## Notes
- PHPStan was not run because `apps/atomy-q/API/vendor/bin/phpstan` is not installed in this API app.
- Existing unrelated local changes under PHPStan config files were left out of this branch.