### PR TITLE
Add deterministic seed quotation fixtures

### DIFF
--- a/apps/atomy-q/API/IMPLEMENTATION_SUMMARY.md
+++ b/apps/atomy-q/API/IMPLEMENTATION_SUMMARY.md
@@ -1,5 +1,11 @@
 # Implementation Summary - Atomy-Q Backend API
 
+## 2026-05-03 Seed Quotation Fixture Pipeline
+
+- Added `php artisan atomy:generate-seed-quotation-fixtures` to generate a deterministic petrochemical quotation fixture set under `database/seed-data/quotations/`.
+- Added a committed `manifest.json` plus canonical text-bearing PDF fixtures keyed by stable business keys that mirror the seeded petrochemical RFQ/quote matrix.
+- `PetrochemicalTenantSeeder` now reuses those canonical fixtures, copies them into local `quote-submissions/...` storage during seeding, and persists manifest-derived file metadata instead of ad hoc `/uploads/quotes/...` paths.
+
 ## 2026-05-03 RFQ Evidence Vault
 
 - Removed the generic document API contract and replaced it with RFQ-scoped Evidence Vault endpoints for summary/readiness, supporting evidence upload, award-pack finalization, and award-pack export.

--- a/apps/atomy-q/API/app/Console/Commands/GenerateSeedQuotationFixturesCommand.php
+++ b/apps/atomy-q/API/app/Console/Commands/GenerateSeedQuotationFixturesCommand.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Support\SeedData\Quotations\PetrochemicalSeedQuotationCatalog;
+use App\Support\SeedData\Quotations\SeedQuotationManifest;
+use App\Support\SeedData\Quotations\SimplePdfWriter;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+
+final class GenerateSeedQuotationFixturesCommand extends Command
+{
+    protected $signature = 'atomy:generate-seed-quotation-fixtures';
+
+    protected $description = 'Generate canonical petrochemical seed quotation PDFs and manifest';
+
+    public function handle(SimplePdfWriter $pdfWriter): int
+    {
+        $fixtureRoot = base_path('database/seed-data/quotations');
+        $manifestPath = $fixtureRoot . '/manifest.json';
+        $entries = PetrochemicalSeedQuotationCatalog::entries();
+
+        File::ensureDirectoryExists($fixtureRoot . '/files');
+
+        foreach ($entries as $entry) {
+            $pdfWriter->write(
+                $fixtureRoot . '/' . $entry['pdf_path'],
+                $entry['document_lines'],
+            );
+        }
+
+        SeedQuotationManifest::write($manifestPath, $entries);
+
+        $this->info('Wrote manifest to ' . $manifestPath);
+
+        return self::SUCCESS;
+    }
+}

--- a/apps/atomy-q/API/app/Providers/AppServiceProvider.php
+++ b/apps/atomy-q/API/app/Providers/AppServiceProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Providers;
 
+use App\Console\Commands\GenerateSeedQuotationFixturesCommand;
 use App\Adapters\Ai\AiRuntimeStatusAdapter;
 use App\Adapters\Ai\AtomyAiCapabilityCatalog;
 use App\Adapters\Ai\ConfiguredAiEndpointRegistry;
@@ -1055,6 +1056,12 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
+        if ($this->app->runningInConsole()) {
+            $this->commands([
+                GenerateSeedQuotationFixturesCommand::class,
+            ]);
+        }
+
         Scramble::configure()->withDocumentTransformers([
             IdempotencyErrorCodesDocumentTransformer::class,
         ]);

--- a/apps/atomy-q/API/app/Support/SeedData/Quotations/PetrochemicalSeedQuotationCatalog.php
+++ b/apps/atomy-q/API/app/Support/SeedData/Quotations/PetrochemicalSeedQuotationCatalog.php
@@ -1,0 +1,276 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support\SeedData\Quotations;
+
+final class PetrochemicalSeedQuotationCatalog
+{
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    public static function entries(): array
+    {
+        $entries = [];
+
+        for ($rfqIndex = 0; $rfqIndex < self::rfqCount(); $rfqIndex++) {
+            $kind = self::rfqKind($rfqIndex);
+            $quoteTarget = self::quoteTarget($kind, $rfqIndex);
+
+            for ($quoteIndex = 0; $quoteIndex < $quoteTarget; $quoteIndex++) {
+                $businessKey = self::businessKey($rfqIndex, $quoteIndex);
+                $vendorName = self::vendorName($rfqIndex, $quoteIndex);
+
+                $entries[$businessKey] = [
+                    'business_key' => $businessKey,
+                    'rfq_key' => sprintf('rfq-%03d', $rfqIndex),
+                    'vendor_key' => sprintf('vendor-%02d', $quoteIndex),
+                    'rfq_index' => $rfqIndex,
+                    'quote_index' => $quoteIndex,
+                    'rfq_kind' => $kind,
+                    'rfq_title' => self::rfqTitle($rfqIndex),
+                    'vendor_name' => $vendorName,
+                    'quote_status' => self::quoteStatusFor($kind, $quoteIndex),
+                    'original_filename' => self::originalFilename($vendorName),
+                    'file_type' => 'application/pdf',
+                    'pdf_path' => self::pdfRelativePath($businessKey),
+                    'document_lines' => self::documentLines($rfqIndex, $quoteIndex, $vendorName),
+                    'line_seed_data' => self::lineSeedData($rfqIndex, $quoteIndex),
+                ];
+            }
+        }
+
+        ksort($entries);
+
+        return $entries;
+    }
+
+    public static function businessKey(int $rfqIndex, int $quoteIndex): string
+    {
+        return sprintf('rfq-%03d/vendor-%02d', $rfqIndex, $quoteIndex);
+    }
+
+    public static function pdfRelativePath(string $businessKey): string
+    {
+        return 'files/' . str_replace('/', '-', $businessKey) . '.pdf';
+    }
+
+    private static function rfqCount(): int
+    {
+        return 56;
+    }
+
+    private static function rfqKind(int $rfqIndex): string
+    {
+        if ($rfqIndex < 8) {
+            return 'draft';
+        }
+
+        if ($rfqIndex < 18) {
+            return 'published_intake';
+        }
+
+        if ($rfqIndex < 24) {
+            return 'published_stuck';
+        }
+
+        if ($rfqIndex < 32) {
+            return 'closed_pending';
+        }
+
+        if ($rfqIndex < 52) {
+            return 'awarded';
+        }
+
+        return 'cancelled';
+    }
+
+    private static function quoteTarget(string $kind, int $rfqIndex): int
+    {
+        return match ($kind) {
+            'published_intake' => 1 + ($rfqIndex % 4),
+            'published_stuck' => 3,
+            'closed_pending' => 3 + ($rfqIndex % 2),
+            'awarded' => 3 + ($rfqIndex % 3),
+            'cancelled' => $rfqIndex % 3,
+            default => 0,
+        };
+    }
+
+    private static function quoteStatusFor(string $kind, int $quoteIndex): string
+    {
+        return match ($kind) {
+            'published_intake' => match ($quoteIndex % 4) {
+                0 => 'uploaded',
+                1 => 'extracting',
+                2 => 'extracted',
+                default => 'normalizing',
+            },
+            'published_stuck' => 'needs_review',
+            'closed_pending', 'awarded' => 'ready',
+            'cancelled' => $quoteIndex === 0 ? 'normalizing' : 'failed',
+            default => 'ready',
+        };
+    }
+
+    private static function vendorName(int $rfqIndex, int $quoteIndex): string
+    {
+        $vendors = self::approvedVendors();
+        $vendorIndex = ($quoteIndex + ($rfqIndex * 7)) % count($vendors);
+
+        return $vendors[$vendorIndex];
+    }
+
+    private static function originalFilename(string $vendorName): string
+    {
+        $sanitized = preg_replace('/\W+/', '_', $vendorName) ?? 'Vendor';
+
+        return 'Quote_' . trim($sanitized, '_') . '.pdf';
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function documentLines(int $rfqIndex, int $quoteIndex, string $vendorName): array
+    {
+        $status = self::quoteStatusFor(self::rfqKind($rfqIndex), $quoteIndex);
+        $lineSeedData = self::lineSeedData($rfqIndex, $quoteIndex);
+
+        return [
+            'Atomy-Q seed quotation fixture',
+            'Business key: ' . self::businessKey($rfqIndex, $quoteIndex),
+            'RFQ: ' . self::rfqTitle($rfqIndex),
+            'Vendor: ' . $vendorName,
+            'Status profile: ' . $status,
+            'Commercial total (USD): ' . number_format(self::quoteTotal($lineSeedData), 2, '.', ''),
+            'Payment terms: ' . self::paymentTerms($rfqIndex),
+            'Delivery lead: ' . (6 + (($rfqIndex + $quoteIndex) % 9)) . ' weeks',
+        ];
+    }
+
+    /**
+     * @return list<array<string, int|float|string>>
+     */
+    private static function lineSeedData(int $rfqIndex, int $quoteIndex): array
+    {
+        $base = $rfqIndex + $quoteIndex + 1;
+
+        return [
+            [
+                'description' => sprintf('Line 1 - Tag NFC-%03d-A', $rfqIndex + 1),
+                'quantity' => 1 + ($base % 4),
+                'uom' => 'ea',
+                'unit_price' => 850.0 + ($base * 37.5),
+                'currency' => 'USD',
+            ],
+            [
+                'description' => sprintf('Line 2 - Tag NFC-%03d-B', $rfqIndex + 1),
+                'quantity' => 2 + ($base % 3),
+                'uom' => 'set',
+                'unit_price' => 425.0 + ($base * 21.25),
+                'currency' => 'USD',
+            ],
+            [
+                'description' => sprintf('Line 3 - Service bundle NFC-%03d', $rfqIndex + 1),
+                'quantity' => 1,
+                'uom' => 'lot',
+                'unit_price' => 1200.0 + ($base * 55.0),
+                'currency' => 'USD',
+            ],
+        ];
+    }
+
+    /**
+     * @param list<array<string, int|float|string>> $lineSeedData
+     */
+    private static function quoteTotal(array $lineSeedData): float
+    {
+        $total = 0.0;
+
+        foreach ($lineSeedData as $line) {
+            $total += (float) $line['quantity'] * (float) $line['unit_price'];
+        }
+
+        return $total;
+    }
+
+    private static function paymentTerms(int $rfqIndex): string
+    {
+        return $rfqIndex % 3 === 0 ? 'Net 45 EOM' : 'Net 30';
+    }
+
+    private static function rfqTitle(int $rfqIndex): string
+    {
+        $titles = [
+            'HP control valves Class 900 - ethylene rundown',
+            'Mechanical seal upgrade - cracked gas compressor',
+            'Sulfuric acid catalyst reload (Claus tail gas)',
+            'Demineralized water polisher resin',
+            'Thermal oxidizer burner management system',
+            'Stainless tank internals - agitator + baffles',
+            'Vapor recovery unit compressor package',
+            'Corrosion inhibitor injection skid',
+            'DCS I/O marshalling cabinets + IS barriers',
+            'Loading arm spare hydraulic power unit',
+            'Nitrogen generator membrane replacement',
+            'Flare pilot / igniter assembly',
+            'Heat exchanger bundle - lean amine',
+            'Emergency shower & eyewash stations (ATEX)',
+            'Chemical metering pumps - cooling tower',
+            'HVAC ATEX fan wall - analyzer shelter',
+            'Fixed gas detection - LEL / H2S',
+            'Firewater pump mechanical seal kit',
+            'Insulation & cladding - steam tracing package',
+            'Bolt tensioning service - turnaround',
+            'Temporary steam boiler rental (12 MW)',
+            'Scaffold & containment - sulfur pit',
+            'NDT phased-array - welds on HP piping',
+            'Relief valve recertification (in-situ)',
+            'Laser alignment - train B compressors',
+            'Catalyst sampling probes + quills',
+            'Sorbent media - mercury guard bed',
+            'Oxygen analyzer cells - reformer feed',
+            'Submersible sump pumps - containment sump',
+            'Gasket kit ANSI 900 - RF joint set',
+        ];
+
+        $title = $titles[$rfqIndex % count($titles)];
+
+        if ($rfqIndex + 1 > count($titles)) {
+            $title .= ' (lot ' . ($rfqIndex + 1) . ')';
+        }
+
+        return $title;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function approvedVendors(): array
+    {
+        return [
+            'FlowServe Nordics AS',
+            'Emerson Fisher Norway',
+            'Alfa Laval Aalborg',
+            'Sulzer Chemtech',
+            'John Zink Hamworthy Combustion',
+            'Donaldson Process Filtration',
+            'Grundfos Process Nordic',
+            'Atlas Copco Compressors',
+            'Linde Engineering',
+            'Air Liquide Advanced Separations',
+            'Technip Energies Norge',
+            'Wood PLC Norway',
+            'Worley Chemetics',
+            'Hayward Tyler (IMO) Pumps',
+            'SIHI Liquid Ring',
+            'Burkert Fluid Control',
+            'Swagelok Bergen',
+            'Parker Hannifin Scandinavia',
+            'Honeywell UOP',
+            'BASF Catalysts',
+            'Clariant Catalysts',
+            'Johnson Matthey NORAM',
+        ];
+    }
+}

--- a/apps/atomy-q/API/app/Support/SeedData/Quotations/SeedQuotationManifest.php
+++ b/apps/atomy-q/API/app/Support/SeedData/Quotations/SeedQuotationManifest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support\SeedData\Quotations;
+
+use Illuminate\Support\Facades\File;
+
+final class SeedQuotationManifest
+{
+    /**
+     * @param array<string, array<string, mixed>> $entries
+     */
+    public static function write(string $path, array $entries): void
+    {
+        ksort($entries);
+
+        File::ensureDirectoryExists(dirname($path));
+
+        $payload = [
+            'version' => 1,
+            'entries' => $entries,
+        ];
+
+        File::put(
+            $path,
+            json_encode(
+                $payload,
+                JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR,
+            ) . PHP_EOL,
+        );
+    }
+
+    /**
+     * @return array{version: int, entries: array<string, array<string, mixed>>}
+     */
+    public static function read(string $path): array
+    {
+        /** @var array{version: int, entries: array<string, array<string, mixed>>} $manifest */
+        $manifest = json_decode(
+            File::get($path),
+            true,
+            512,
+            JSON_THROW_ON_ERROR,
+        );
+
+        return $manifest;
+    }
+}

--- a/apps/atomy-q/API/app/Support/SeedData/Quotations/SimplePdfWriter.php
+++ b/apps/atomy-q/API/app/Support/SeedData/Quotations/SimplePdfWriter.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support\SeedData\Quotations;
+
+use Illuminate\Support\Facades\File;
+
+final class SimplePdfWriter
+{
+    /**
+     * @param list<string> $lines
+     */
+    public function write(string $path, array $lines): void
+    {
+        File::ensureDirectoryExists(dirname($path));
+
+        $content = "BT\n/F1 12 Tf\n50 760 Td\n";
+
+        foreach (array_values($lines) as $index => $line) {
+            $escaped = str_replace(['\\', '(', ')'], ['\\\\', '\\(', '\\)'], $line);
+
+            if ($index > 0) {
+                $content .= "0 -16 Td\n";
+            }
+
+            $content .= sprintf("(%s) Tj\n", $escaped);
+        }
+
+        $content .= "ET\n";
+
+        File::put($path, $this->wrapPdfObjects($content));
+    }
+
+    private function wrapPdfObjects(string $content): string
+    {
+        $objects = [
+            1 => "<< /Type /Catalog /Pages 2 0 R >>",
+            2 => "<< /Type /Pages /Count 1 /Kids [3 0 R] >>",
+            3 => "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>",
+            4 => "<< /Length " . strlen($content) . " >>\nstream\n" . $content . "endstream",
+            5 => "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+        ];
+
+        $pdf = "%PDF-1.4\n% seed quotation fixture\n";
+        $offsets = [0];
+
+        foreach ($objects as $objectNumber => $objectBody) {
+            $offsets[$objectNumber] = strlen($pdf);
+            $pdf .= $objectNumber . " 0 obj\n" . $objectBody . "\nendobj\n";
+        }
+
+        $xrefOffset = strlen($pdf);
+        $pdf .= "xref\n0 " . (count($objects) + 1) . "\n";
+        $pdf .= "0000000000 65535 f \n";
+
+        for ($objectNumber = 1; $objectNumber <= count($objects); $objectNumber++) {
+            $pdf .= sprintf('%010d 00000 n ', $offsets[$objectNumber]) . "\n";
+        }
+
+        $pdf .= "trailer\n<< /Size " . (count($objects) + 1) . " /Root 1 0 R >>\n";
+        $pdf .= "startxref\n" . $xrefOffset . "\n%%EOF\n";
+
+        return $pdf;
+    }
+}

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-008-vendor-00.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-008-vendor-00.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 370 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-008/vendor-00) Tj
+0 -16 Td
+(RFQ: DCS I/O marshalling cabinets + IS barriers) Tj
+0 -16 Td
+(Vendor: Worley Chemetics) Tj
+0 -16 Td
+(Status profile: uploaded) Tj
+0 -16 Td
+(Commercial total \(USD\): 5302.50) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 14 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000686 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+756
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-009-vendor-00.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-009-vendor-00.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 367 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-009/vendor-00) Tj
+0 -16 Td
+(RFQ: Loading arm spare hydraulic power unit) Tj
+0 -16 Td
+(Vendor: BASF Catalysts) Tj
+0 -16 Td
+(Status profile: uploaded) Tj
+0 -16 Td
+(Commercial total \(USD\): 7337.50) Tj
+0 -16 Td
+(Payment terms: Net 45 EOM) Tj
+0 -16 Td
+(Delivery lead: 6 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000683 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+753
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-009-vendor-01.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-009-vendor-01.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 373 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-009/vendor-01) Tj
+0 -16 Td
+(RFQ: Loading arm spare hydraulic power unit) Tj
+0 -16 Td
+(Vendor: Clariant Catalysts) Tj
+0 -16 Td
+(Status profile: extracting) Tj
+0 -16 Td
+(Commercial total \(USD\): 9490.00) Tj
+0 -16 Td
+(Payment terms: Net 45 EOM) Tj
+0 -16 Td
+(Delivery lead: 7 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000689 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+759
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-010-vendor-00.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-010-vendor-00.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 380 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-010/vendor-00) Tj
+0 -16 Td
+(RFQ: Nitrogen generator membrane replacement) Tj
+0 -16 Td
+(Vendor: John Zink Hamworthy Combustion) Tj
+0 -16 Td
+(Status profile: uploaded) Tj
+0 -16 Td
+(Commercial total \(USD\): 9490.00) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 7 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000696 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+766
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-010-vendor-01.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-010-vendor-01.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 380 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-010/vendor-01) Tj
+0 -16 Td
+(RFQ: Nitrogen generator membrane replacement) Tj
+0 -16 Td
+(Vendor: Donaldson Process Filtration) Tj
+0 -16 Td
+(Status profile: extracting) Tj
+0 -16 Td
+(Commercial total \(USD\): 4520.00) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 8 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000696 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+766
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-010-vendor-02.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-010-vendor-02.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 374 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-010/vendor-02) Tj
+0 -16 Td
+(RFQ: Nitrogen generator membrane replacement) Tj
+0 -16 Td
+(Vendor: Grundfos Process Nordic) Tj
+0 -16 Td
+(Status profile: extracted) Tj
+0 -16 Td
+(Commercial total \(USD\): 6693.75) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 9 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000690 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+760
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-011-vendor-00.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-011-vendor-00.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 356 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-011/vendor-00) Tj
+0 -16 Td
+(RFQ: Flare pilot / igniter assembly) Tj
+0 -16 Td
+(Vendor: Wood PLC Norway) Tj
+0 -16 Td
+(Status profile: uploaded) Tj
+0 -16 Td
+(Commercial total \(USD\): 4520.00) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 8 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000672 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+742
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-011-vendor-01.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-011-vendor-01.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 359 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-011/vendor-01) Tj
+0 -16 Td
+(RFQ: Flare pilot / igniter assembly) Tj
+0 -16 Td
+(Vendor: Worley Chemetics) Tj
+0 -16 Td
+(Status profile: extracting) Tj
+0 -16 Td
+(Commercial total \(USD\): 6693.75) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 9 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000675 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+745
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-011-vendor-02.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-011-vendor-02.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 370 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-011/vendor-02) Tj
+0 -16 Td
+(RFQ: Flare pilot / igniter assembly) Tj
+0 -16 Td
+(Vendor: Hayward Tyler \(IMO\) Pumps) Tj
+0 -16 Td
+(Status profile: extracted) Tj
+0 -16 Td
+(Commercial total \(USD\): 8985.00) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 10 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000686 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+756
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-011-vendor-03.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-011-vendor-03.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 361 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-011/vendor-03) Tj
+0 -16 Td
+(RFQ: Flare pilot / igniter assembly) Tj
+0 -16 Td
+(Vendor: SIHI Liquid Ring) Tj
+0 -16 Td
+(Status profile: normalizing) Tj
+0 -16 Td
+(Commercial total \(USD\): 9162.50) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 11 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000677 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+747
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-012-vendor-00.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-012-vendor-00.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 362 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-012/vendor-00) Tj
+0 -16 Td
+(RFQ: Heat exchanger bundle - lean amine) Tj
+0 -16 Td
+(Vendor: Honeywell UOP) Tj
+0 -16 Td
+(Status profile: uploaded) Tj
+0 -16 Td
+(Commercial total \(USD\): 6693.75) Tj
+0 -16 Td
+(Payment terms: Net 45 EOM) Tj
+0 -16 Td
+(Delivery lead: 9 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000678 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+748
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-013-vendor-00.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-013-vendor-00.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 371 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-013/vendor-00) Tj
+0 -16 Td
+(RFQ: Emergency shower & eyewash stations \(ATEX\)) Tj
+0 -16 Td
+(Vendor: Sulzer Chemtech) Tj
+0 -16 Td
+(Status profile: uploaded) Tj
+0 -16 Td
+(Commercial total \(USD\): 8985.00) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 10 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000687 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+757
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-013-vendor-01.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-013-vendor-01.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 388 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-013/vendor-01) Tj
+0 -16 Td
+(RFQ: Emergency shower & eyewash stations \(ATEX\)) Tj
+0 -16 Td
+(Vendor: John Zink Hamworthy Combustion) Tj
+0 -16 Td
+(Status profile: extracting) Tj
+0 -16 Td
+(Commercial total \(USD\): 9162.50) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 11 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000704 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+774
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-014-vendor-00.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-014-vendor-00.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 373 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-014/vendor-00) Tj
+0 -16 Td
+(RFQ: Chemical metering pumps - cooling tower) Tj
+0 -16 Td
+(Vendor: Technip Energies Norge) Tj
+0 -16 Td
+(Status profile: uploaded) Tj
+0 -16 Td
+(Commercial total \(USD\): 9162.50) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 11 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000689 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+759
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-014-vendor-01.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-014-vendor-01.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 368 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-014/vendor-01) Tj
+0 -16 Td
+(RFQ: Chemical metering pumps - cooling tower) Tj
+0 -16 Td
+(Vendor: Wood PLC Norway) Tj
+0 -16 Td
+(Status profile: extracting) Tj
+0 -16 Td
+(Commercial total \(USD\): 5825.00) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 12 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000684 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+754
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-014-vendor-02.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-014-vendor-02.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 368 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-014/vendor-02) Tj
+0 -16 Td
+(RFQ: Chemical metering pumps - cooling tower) Tj
+0 -16 Td
+(Vendor: Worley Chemetics) Tj
+0 -16 Td
+(Status profile: extracted) Tj
+0 -16 Td
+(Commercial total \(USD\): 8255.00) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 13 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000684 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+754
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-015-vendor-00.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-015-vendor-00.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 380 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-015/vendor-00) Tj
+0 -16 Td
+(RFQ: HVAC ATEX fan wall - analyzer shelter) Tj
+0 -16 Td
+(Vendor: Parker Hannifin Scandinavia) Tj
+0 -16 Td
+(Status profile: uploaded) Tj
+0 -16 Td
+(Commercial total \(USD\): 5825.00) Tj
+0 -16 Td
+(Payment terms: Net 45 EOM) Tj
+0 -16 Td
+(Delivery lead: 12 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000696 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+766
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-015-vendor-01.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-015-vendor-01.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 368 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-015/vendor-01) Tj
+0 -16 Td
+(RFQ: HVAC ATEX fan wall - analyzer shelter) Tj
+0 -16 Td
+(Vendor: Honeywell UOP) Tj
+0 -16 Td
+(Status profile: extracting) Tj
+0 -16 Td
+(Commercial total \(USD\): 8255.00) Tj
+0 -16 Td
+(Payment terms: Net 45 EOM) Tj
+0 -16 Td
+(Delivery lead: 13 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000684 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+754
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-015-vendor-02.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-015-vendor-02.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 368 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-015/vendor-02) Tj
+0 -16 Td
+(RFQ: HVAC ATEX fan wall - analyzer shelter) Tj
+0 -16 Td
+(Vendor: BASF Catalysts) Tj
+0 -16 Td
+(Status profile: extracted) Tj
+0 -16 Td
+(Commercial total \(USD\): 8380.00) Tj
+0 -16 Td
+(Payment terms: Net 45 EOM) Tj
+0 -16 Td
+(Delivery lead: 14 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000684 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+754
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-015-vendor-03.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-015-vendor-03.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 374 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-015/vendor-03) Tj
+0 -16 Td
+(RFQ: HVAC ATEX fan wall - analyzer shelter) Tj
+0 -16 Td
+(Vendor: Clariant Catalysts) Tj
+0 -16 Td
+(Status profile: normalizing) Tj
+0 -16 Td
+(Commercial total \(USD\): 10981.25) Tj
+0 -16 Td
+(Payment terms: Net 45 EOM) Tj
+0 -16 Td
+(Delivery lead: 6 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000690 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+760
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-016-vendor-00.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-016-vendor-00.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 361 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-016/vendor-00) Tj
+0 -16 Td
+(RFQ: Fixed gas detection - LEL / H2S) Tj
+0 -16 Td
+(Vendor: Alfa Laval Aalborg) Tj
+0 -16 Td
+(Status profile: uploaded) Tj
+0 -16 Td
+(Commercial total \(USD\): 8255.00) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 13 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000677 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+747
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-017-vendor-00.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-017-vendor-00.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 378 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-017/vendor-00) Tj
+0 -16 Td
+(RFQ: Firewater pump mechanical seal kit) Tj
+0 -16 Td
+(Vendor: Air Liquide Advanced Separations) Tj
+0 -16 Td
+(Status profile: uploaded) Tj
+0 -16 Td
+(Commercial total \(USD\): 8380.00) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 14 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000694 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+764
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-017-vendor-01.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-017-vendor-01.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 370 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-017/vendor-01) Tj
+0 -16 Td
+(RFQ: Firewater pump mechanical seal kit) Tj
+0 -16 Td
+(Vendor: Technip Energies Norge) Tj
+0 -16 Td
+(Status profile: extracting) Tj
+0 -16 Td
+(Commercial total \(USD\): 10981.25) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 6 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000686 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+756
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-018-vendor-00.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-018-vendor-00.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 380 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-018/vendor-00) Tj
+0 -16 Td
+(RFQ: Insulation & cladding - steam tracing package) Tj
+0 -16 Td
+(Vendor: Swagelok Bergen) Tj
+0 -16 Td
+(Status profile: needs_review) Tj
+0 -16 Td
+(Commercial total \(USD\): 10981.25) Tj
+0 -16 Td
+(Payment terms: Net 45 EOM) Tj
+0 -16 Td
+(Delivery lead: 6 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000696 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+766
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-018-vendor-01.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-018-vendor-01.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 391 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-018/vendor-01) Tj
+0 -16 Td
+(RFQ: Insulation & cladding - steam tracing package) Tj
+0 -16 Td
+(Vendor: Parker Hannifin Scandinavia) Tj
+0 -16 Td
+(Status profile: needs_review) Tj
+0 -16 Td
+(Commercial total \(USD\): 7300.00) Tj
+0 -16 Td
+(Payment terms: Net 45 EOM) Tj
+0 -16 Td
+(Delivery lead: 7 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000707 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+777
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-018-vendor-02.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-018-vendor-02.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 377 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-018/vendor-02) Tj
+0 -16 Td
+(RFQ: Insulation & cladding - steam tracing package) Tj
+0 -16 Td
+(Vendor: Honeywell UOP) Tj
+0 -16 Td
+(Status profile: needs_review) Tj
+0 -16 Td
+(Commercial total \(USD\): 7372.50) Tj
+0 -16 Td
+(Payment terms: Net 45 EOM) Tj
+0 -16 Td
+(Delivery lead: 8 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000693 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+763
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-019-vendor-00.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-019-vendor-00.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 372 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-019/vendor-00) Tj
+0 -16 Td
+(RFQ: Bolt tensioning service - turnaround) Tj
+0 -16 Td
+(Vendor: Emerson Fisher Norway) Tj
+0 -16 Td
+(Status profile: needs_review) Tj
+0 -16 Td
+(Commercial total \(USD\): 7300.00) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 7 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000688 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+758
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-019-vendor-01.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-019-vendor-01.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 369 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-019/vendor-01) Tj
+0 -16 Td
+(RFQ: Bolt tensioning service - turnaround) Tj
+0 -16 Td
+(Vendor: Alfa Laval Aalborg) Tj
+0 -16 Td
+(Status profile: needs_review) Tj
+0 -16 Td
+(Commercial total \(USD\): 7372.50) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 8 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000685 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+755
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-019-vendor-02.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-019-vendor-02.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 367 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-019/vendor-02) Tj
+0 -16 Td
+(RFQ: Bolt tensioning service - turnaround) Tj
+0 -16 Td
+(Vendor: Sulzer Chemtech) Tj
+0 -16 Td
+(Status profile: needs_review) Tj
+0 -16 Td
+(Commercial total \(USD\): 10112.50) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 9 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000683 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+753
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-020-vendor-00.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-020-vendor-00.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 371 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-020/vendor-00) Tj
+0 -16 Td
+(RFQ: Temporary steam boiler rental \(12 MW\)) Tj
+0 -16 Td
+(Vendor: Linde Engineering) Tj
+0 -16 Td
+(Status profile: needs_review) Tj
+0 -16 Td
+(Commercial total \(USD\): 7372.50) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 8 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000687 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+757
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-020-vendor-01.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-020-vendor-01.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 387 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-020/vendor-01) Tj
+0 -16 Td
+(RFQ: Temporary steam boiler rental \(12 MW\)) Tj
+0 -16 Td
+(Vendor: Air Liquide Advanced Separations) Tj
+0 -16 Td
+(Status profile: needs_review) Tj
+0 -16 Td
+(Commercial total \(USD\): 10112.50) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 9 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000703 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+773
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-020-vendor-02.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-020-vendor-02.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 378 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-020/vendor-02) Tj
+0 -16 Td
+(RFQ: Temporary steam boiler rental \(12 MW\)) Tj
+0 -16 Td
+(Vendor: Technip Energies Norge) Tj
+0 -16 Td
+(Status profile: needs_review) Tj
+0 -16 Td
+(Commercial total \(USD\): 12970.00) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 10 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000694 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+764
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-021-vendor-00.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-021-vendor-00.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 376 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-021/vendor-00) Tj
+0 -16 Td
+(RFQ: Scaffold & containment - sulfur pit) Tj
+0 -16 Td
+(Vendor: Burkert Fluid Control) Tj
+0 -16 Td
+(Status profile: needs_review) Tj
+0 -16 Td
+(Commercial total \(USD\): 10112.50) Tj
+0 -16 Td
+(Payment terms: Net 45 EOM) Tj
+0 -16 Td
+(Delivery lead: 9 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000692 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+762
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-021-vendor-01.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-021-vendor-01.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 371 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-021/vendor-01) Tj
+0 -16 Td
+(RFQ: Scaffold & containment - sulfur pit) Tj
+0 -16 Td
+(Vendor: Swagelok Bergen) Tj
+0 -16 Td
+(Status profile: needs_review) Tj
+0 -16 Td
+(Commercial total \(USD\): 12970.00) Tj
+0 -16 Td
+(Payment terms: Net 45 EOM) Tj
+0 -16 Td
+(Delivery lead: 10 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000687 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+757
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-021-vendor-02.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-021-vendor-02.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 382 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-021/vendor-02) Tj
+0 -16 Td
+(RFQ: Scaffold & containment - sulfur pit) Tj
+0 -16 Td
+(Vendor: Parker Hannifin Scandinavia) Tj
+0 -16 Td
+(Status profile: needs_review) Tj
+0 -16 Td
+(Commercial total \(USD\): 6140.00) Tj
+0 -16 Td
+(Payment terms: Net 45 EOM) Tj
+0 -16 Td
+(Delivery lead: 11 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000698 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+768
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-022-vendor-00.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-022-vendor-00.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 374 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-022/vendor-00) Tj
+0 -16 Td
+(RFQ: NDT phased-array - welds on HP piping) Tj
+0 -16 Td
+(Vendor: FlowServe Nordics AS) Tj
+0 -16 Td
+(Status profile: needs_review) Tj
+0 -16 Td
+(Commercial total \(USD\): 12970.00) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 10 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000690 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+760
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-022-vendor-01.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-022-vendor-01.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 374 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-022/vendor-01) Tj
+0 -16 Td
+(RFQ: NDT phased-array - welds on HP piping) Tj
+0 -16 Td
+(Vendor: Emerson Fisher Norway) Tj
+0 -16 Td
+(Status profile: needs_review) Tj
+0 -16 Td
+(Commercial total \(USD\): 6140.00) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 11 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000690 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+760
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-022-vendor-02.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-022-vendor-02.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 371 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-022/vendor-02) Tj
+0 -16 Td
+(RFQ: NDT phased-array - welds on HP piping) Tj
+0 -16 Td
+(Vendor: Alfa Laval Aalborg) Tj
+0 -16 Td
+(Status profile: needs_review) Tj
+0 -16 Td
+(Commercial total \(USD\): 9018.75) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 12 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000687 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+757
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-023-vendor-00.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-023-vendor-00.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 379 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-023/vendor-00) Tj
+0 -16 Td
+(RFQ: Relief valve recertification \(in-situ\)) Tj
+0 -16 Td
+(Vendor: Atlas Copco Compressors) Tj
+0 -16 Td
+(Status profile: needs_review) Tj
+0 -16 Td
+(Commercial total \(USD\): 6140.00) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 11 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000695 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+765
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-023-vendor-01.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-023-vendor-01.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 373 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-023/vendor-01) Tj
+0 -16 Td
+(RFQ: Relief valve recertification \(in-situ\)) Tj
+0 -16 Td
+(Vendor: Linde Engineering) Tj
+0 -16 Td
+(Status profile: needs_review) Tj
+0 -16 Td
+(Commercial total \(USD\): 9018.75) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 12 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000689 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+759
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-023-vendor-02.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-023-vendor-02.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 389 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-023/vendor-02) Tj
+0 -16 Td
+(RFQ: Relief valve recertification \(in-situ\)) Tj
+0 -16 Td
+(Vendor: Air Liquide Advanced Separations) Tj
+0 -16 Td
+(Status profile: needs_review) Tj
+0 -16 Td
+(Commercial total \(USD\): 12015.00) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 13 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000705 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+775
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-024-vendor-00.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-024-vendor-00.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 366 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-024/vendor-00) Tj
+0 -16 Td
+(RFQ: Laser alignment - train B compressors) Tj
+0 -16 Td
+(Vendor: SIHI Liquid Ring) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 9018.75) Tj
+0 -16 Td
+(Payment terms: Net 45 EOM) Tj
+0 -16 Td
+(Delivery lead: 12 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000682 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+752
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-024-vendor-01.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-024-vendor-01.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 372 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-024/vendor-01) Tj
+0 -16 Td
+(RFQ: Laser alignment - train B compressors) Tj
+0 -16 Td
+(Vendor: Burkert Fluid Control) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 12015.00) Tj
+0 -16 Td
+(Payment terms: Net 45 EOM) Tj
+0 -16 Td
+(Delivery lead: 13 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000688 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+758
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-024-vendor-02.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-024-vendor-02.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 366 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-024/vendor-02) Tj
+0 -16 Td
+(RFQ: Laser alignment - train B compressors) Tj
+0 -16 Td
+(Vendor: Swagelok Bergen) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 12132.50) Tj
+0 -16 Td
+(Payment terms: Net 45 EOM) Tj
+0 -16 Td
+(Delivery lead: 14 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000682 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+752
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-025-vendor-00.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-025-vendor-00.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 364 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-025/vendor-00) Tj
+0 -16 Td
+(RFQ: Catalyst sampling probes + quills) Tj
+0 -16 Td
+(Vendor: Johnson Matthey NORAM) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 12015.00) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 13 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000680 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+750
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-025-vendor-01.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-025-vendor-01.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 363 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-025/vendor-01) Tj
+0 -16 Td
+(RFQ: Catalyst sampling probes + quills) Tj
+0 -16 Td
+(Vendor: FlowServe Nordics AS) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 12132.50) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 14 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000679 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+749
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-025-vendor-02.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-025-vendor-02.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 362 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-025/vendor-02) Tj
+0 -16 Td
+(RFQ: Catalyst sampling probes + quills) Tj
+0 -16 Td
+(Vendor: Emerson Fisher Norway) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 7700.00) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 6 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000678 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+748
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-025-vendor-03.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-025-vendor-03.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 360 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-025/vendor-03) Tj
+0 -16 Td
+(RFQ: Catalyst sampling probes + quills) Tj
+0 -16 Td
+(Vendor: Alfa Laval Aalborg) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 10835.00) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 7 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000676 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+746
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-026-vendor-00.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-026-vendor-00.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 366 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-026/vendor-00) Tj
+0 -16 Td
+(RFQ: Sorbent media - mercury guard bed) Tj
+0 -16 Td
+(Vendor: Grundfos Process Nordic) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 12132.50) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 14 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000682 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+752
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-026-vendor-01.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-026-vendor-01.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 364 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-026/vendor-01) Tj
+0 -16 Td
+(RFQ: Sorbent media - mercury guard bed) Tj
+0 -16 Td
+(Vendor: Atlas Copco Compressors) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 7700.00) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 6 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000680 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+750
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-026-vendor-02.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-026-vendor-02.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 359 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-026/vendor-02) Tj
+0 -16 Td
+(RFQ: Sorbent media - mercury guard bed) Tj
+0 -16 Td
+(Vendor: Linde Engineering) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 10835.00) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 7 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000675 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+745
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-027-vendor-00.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-027-vendor-00.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 376 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-027/vendor-00) Tj
+0 -16 Td
+(RFQ: Oxygen analyzer cells - reformer feed) Tj
+0 -16 Td
+(Vendor: Hayward Tyler \(IMO\) Pumps) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 7700.00) Tj
+0 -16 Td
+(Payment terms: Net 45 EOM) Tj
+0 -16 Td
+(Delivery lead: 6 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000692 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+762
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-027-vendor-01.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-027-vendor-01.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 366 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-027/vendor-01) Tj
+0 -16 Td
+(RFQ: Oxygen analyzer cells - reformer feed) Tj
+0 -16 Td
+(Vendor: SIHI Liquid Ring) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 10835.00) Tj
+0 -16 Td
+(Payment terms: Net 45 EOM) Tj
+0 -16 Td
+(Delivery lead: 7 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000682 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+752
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-027-vendor-02.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-027-vendor-02.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 371 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-027/vendor-02) Tj
+0 -16 Td
+(RFQ: Oxygen analyzer cells - reformer feed) Tj
+0 -16 Td
+(Vendor: Burkert Fluid Control) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 10900.00) Tj
+0 -16 Td
+(Payment terms: Net 45 EOM) Tj
+0 -16 Td
+(Delivery lead: 8 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000687 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+757
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-027-vendor-03.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-027-vendor-03.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 365 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-027/vendor-03) Tj
+0 -16 Td
+(RFQ: Oxygen analyzer cells - reformer feed) Tj
+0 -16 Td
+(Vendor: Swagelok Bergen) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 14206.25) Tj
+0 -16 Td
+(Payment terms: Net 45 EOM) Tj
+0 -16 Td
+(Delivery lead: 9 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000681 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+751
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-028-vendor-00.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-028-vendor-00.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 368 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-028/vendor-00) Tj
+0 -16 Td
+(RFQ: Submersible sump pumps - containment sump) Tj
+0 -16 Td
+(Vendor: Clariant Catalysts) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 10835.00) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 7 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000684 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+754
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-028-vendor-01.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-028-vendor-01.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 371 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-028/vendor-01) Tj
+0 -16 Td
+(RFQ: Submersible sump pumps - containment sump) Tj
+0 -16 Td
+(Vendor: Johnson Matthey NORAM) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 10900.00) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 8 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000687 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+757
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-028-vendor-02.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-028-vendor-02.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 370 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-028/vendor-02) Tj
+0 -16 Td
+(RFQ: Submersible sump pumps - containment sump) Tj
+0 -16 Td
+(Vendor: FlowServe Nordics AS) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 14206.25) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 9 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000686 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+756
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-029-vendor-00.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-029-vendor-00.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 371 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-029/vendor-00) Tj
+0 -16 Td
+(RFQ: Gasket kit ANSI 900 - RF joint set) Tj
+0 -16 Td
+(Vendor: Donaldson Process Filtration) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 10900.00) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 8 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000687 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+757
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-029-vendor-01.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-029-vendor-01.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 366 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-029/vendor-01) Tj
+0 -16 Td
+(RFQ: Gasket kit ANSI 900 - RF joint set) Tj
+0 -16 Td
+(Vendor: Grundfos Process Nordic) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 14206.25) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 9 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000682 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+752
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-029-vendor-02.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-029-vendor-02.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 366 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-029/vendor-02) Tj
+0 -16 Td
+(RFQ: Gasket kit ANSI 900 - RF joint set) Tj
+0 -16 Td
+(Vendor: Atlas Copco Compressors) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 9430.00) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 10 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000682 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+752
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-029-vendor-03.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-029-vendor-03.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 360 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-029/vendor-03) Tj
+0 -16 Td
+(RFQ: Gasket kit ANSI 900 - RF joint set) Tj
+0 -16 Td
+(Vendor: Linde Engineering) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 9442.50) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 11 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000676 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+746
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-030-vendor-00.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-030-vendor-00.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 386 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-030/vendor-00) Tj
+0 -16 Td
+(RFQ: HP control valves Class 900 - ethylene rundown \(lot 31\)) Tj
+0 -16 Td
+(Vendor: Worley Chemetics) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 14206.25) Tj
+0 -16 Td
+(Payment terms: Net 45 EOM) Tj
+0 -16 Td
+(Delivery lead: 9 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000702 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+772
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-030-vendor-01.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-030-vendor-01.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 397 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-030/vendor-01) Tj
+0 -16 Td
+(RFQ: HP control valves Class 900 - ethylene rundown \(lot 31\)) Tj
+0 -16 Td
+(Vendor: Hayward Tyler \(IMO\) Pumps) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 9430.00) Tj
+0 -16 Td
+(Payment terms: Net 45 EOM) Tj
+0 -16 Td
+(Delivery lead: 10 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000713 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+783
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-030-vendor-02.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-030-vendor-02.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 386 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-030/vendor-02) Tj
+0 -16 Td
+(RFQ: HP control valves Class 900 - ethylene rundown \(lot 31\)) Tj
+0 -16 Td
+(Vendor: SIHI Liquid Ring) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 9442.50) Tj
+0 -16 Td
+(Payment terms: Net 45 EOM) Tj
+0 -16 Td
+(Delivery lead: 11 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000702 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+772
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-031-vendor-00.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-031-vendor-00.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 382 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-031/vendor-00) Tj
+0 -16 Td
+(RFQ: Mechanical seal upgrade - cracked gas compressor \(lot 32\)) Tj
+0 -16 Td
+(Vendor: BASF Catalysts) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 9430.00) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 10 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000698 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+768
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-031-vendor-01.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-031-vendor-01.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 386 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-031/vendor-01) Tj
+0 -16 Td
+(RFQ: Mechanical seal upgrade - cracked gas compressor \(lot 32\)) Tj
+0 -16 Td
+(Vendor: Clariant Catalysts) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 9442.50) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 11 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000702 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+772
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-031-vendor-02.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-031-vendor-02.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 390 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-031/vendor-02) Tj
+0 -16 Td
+(RFQ: Mechanical seal upgrade - cracked gas compressor \(lot 32\)) Tj
+0 -16 Td
+(Vendor: Johnson Matthey NORAM) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 12887.50) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 12 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000706 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+776
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-031-vendor-03.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-031-vendor-03.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 389 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-031/vendor-03) Tj
+0 -16 Td
+(RFQ: Mechanical seal upgrade - cracked gas compressor \(lot 32\)) Tj
+0 -16 Td
+(Vendor: FlowServe Nordics AS) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 16450.00) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 13 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000705 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+775
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-032-vendor-00.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-032-vendor-00.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 398 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-032/vendor-00) Tj
+0 -16 Td
+(RFQ: Sulfuric acid catalyst reload \(Claus tail gas\) \(lot 33\)) Tj
+0 -16 Td
+(Vendor: John Zink Hamworthy Combustion) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 9442.50) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 11 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000714 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+784
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-032-vendor-01.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-032-vendor-01.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 397 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-032/vendor-01) Tj
+0 -16 Td
+(RFQ: Sulfuric acid catalyst reload \(Claus tail gas\) \(lot 33\)) Tj
+0 -16 Td
+(Vendor: Donaldson Process Filtration) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 12887.50) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 12 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000713 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+783
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-032-vendor-02.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-032-vendor-02.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 392 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-032/vendor-02) Tj
+0 -16 Td
+(RFQ: Sulfuric acid catalyst reload \(Claus tail gas\) \(lot 33\)) Tj
+0 -16 Td
+(Vendor: Grundfos Process Nordic) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 16450.00) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 13 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000708 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+778
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-032-vendor-03.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-032-vendor-03.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 391 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-032/vendor-03) Tj
+0 -16 Td
+(RFQ: Sulfuric acid catalyst reload \(Claus tail gas\) \(lot 33\)) Tj
+0 -16 Td
+(Vendor: Atlas Copco Compressors) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 7760.00) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 14 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000707 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+777
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-032-vendor-04.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-032-vendor-04.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 385 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-032/vendor-04) Tj
+0 -16 Td
+(RFQ: Sulfuric acid catalyst reload \(Claus tail gas\) \(lot 33\)) Tj
+0 -16 Td
+(Vendor: Linde Engineering) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 11343.75) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 6 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000701 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+771
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-033-vendor-00.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-033-vendor-00.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 374 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-033/vendor-00) Tj
+0 -16 Td
+(RFQ: Demineralized water polisher resin \(lot 34\)) Tj
+0 -16 Td
+(Vendor: Wood PLC Norway) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 12887.50) Tj
+0 -16 Td
+(Payment terms: Net 45 EOM) Tj
+0 -16 Td
+(Delivery lead: 12 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000690 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+760
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-033-vendor-01.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-033-vendor-01.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 375 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-033/vendor-01) Tj
+0 -16 Td
+(RFQ: Demineralized water polisher resin \(lot 34\)) Tj
+0 -16 Td
+(Vendor: Worley Chemetics) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 16450.00) Tj
+0 -16 Td
+(Payment terms: Net 45 EOM) Tj
+0 -16 Td
+(Delivery lead: 13 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000691 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+761
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-033-vendor-02.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-033-vendor-02.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 385 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-033/vendor-02) Tj
+0 -16 Td
+(RFQ: Demineralized water polisher resin \(lot 34\)) Tj
+0 -16 Td
+(Vendor: Hayward Tyler \(IMO\) Pumps) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 7760.00) Tj
+0 -16 Td
+(Payment terms: Net 45 EOM) Tj
+0 -16 Td
+(Delivery lead: 14 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000701 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+771
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-034-vendor-00.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-034-vendor-00.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 375 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-034/vendor-00) Tj
+0 -16 Td
+(RFQ: Thermal oxidizer burner management system \(lot 35\)) Tj
+0 -16 Td
+(Vendor: Honeywell UOP) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 16450.00) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 13 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000691 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+761
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-034-vendor-01.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-034-vendor-01.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 375 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-034/vendor-01) Tj
+0 -16 Td
+(RFQ: Thermal oxidizer burner management system \(lot 35\)) Tj
+0 -16 Td
+(Vendor: BASF Catalysts) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 7760.00) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 14 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000691 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+761
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-034-vendor-02.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-034-vendor-02.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 379 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-034/vendor-02) Tj
+0 -16 Td
+(RFQ: Thermal oxidizer burner management system \(lot 35\)) Tj
+0 -16 Td
+(Vendor: Clariant Catalysts) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 11343.75) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 6 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000695 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+765
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-034-vendor-03.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-034-vendor-03.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 382 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-034/vendor-03) Tj
+0 -16 Td
+(RFQ: Thermal oxidizer burner management system \(lot 35\)) Tj
+0 -16 Td
+(Vendor: Johnson Matthey NORAM) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 15045.00) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 7 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000698 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+768
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-035-vendor-00.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-035-vendor-00.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 380 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-035/vendor-00) Tj
+0 -16 Td
+(RFQ: Stainless tank internals - agitator + baffles \(lot 36\)) Tj
+0 -16 Td
+(Vendor: Sulzer Chemtech) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 7760.00) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 14 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000696 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+766
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-035-vendor-01.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-035-vendor-01.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 395 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-035/vendor-01) Tj
+0 -16 Td
+(RFQ: Stainless tank internals - agitator + baffles \(lot 36\)) Tj
+0 -16 Td
+(Vendor: John Zink Hamworthy Combustion) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 11343.75) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 6 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000711 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+781
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-035-vendor-02.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-035-vendor-02.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 393 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-035/vendor-02) Tj
+0 -16 Td
+(RFQ: Stainless tank internals - agitator + baffles \(lot 36\)) Tj
+0 -16 Td
+(Vendor: Donaldson Process Filtration) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 15045.00) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 7 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000709 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+779
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-035-vendor-03.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-035-vendor-03.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 388 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-035/vendor-03) Tj
+0 -16 Td
+(RFQ: Stainless tank internals - agitator + baffles \(lot 36\)) Tj
+0 -16 Td
+(Vendor: Grundfos Process Nordic) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 15102.50) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 8 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000704 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+774
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-035-vendor-04.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-035-vendor-04.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 387 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-035/vendor-04) Tj
+0 -16 Td
+(RFQ: Stainless tank internals - agitator + baffles \(lot 36\)) Tj
+0 -16 Td
+(Vendor: Atlas Copco Compressors) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 9575.00) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 9 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000703 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+773
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-036-vendor-00.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-036-vendor-00.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 384 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-036/vendor-00) Tj
+0 -16 Td
+(RFQ: Vapor recovery unit compressor package \(lot 37\)) Tj
+0 -16 Td
+(Vendor: Technip Energies Norge) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 11343.75) Tj
+0 -16 Td
+(Payment terms: Net 45 EOM) Tj
+0 -16 Td
+(Delivery lead: 6 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000700 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+770
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-036-vendor-01.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-036-vendor-01.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 377 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-036/vendor-01) Tj
+0 -16 Td
+(RFQ: Vapor recovery unit compressor package \(lot 37\)) Tj
+0 -16 Td
+(Vendor: Wood PLC Norway) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 15045.00) Tj
+0 -16 Td
+(Payment terms: Net 45 EOM) Tj
+0 -16 Td
+(Delivery lead: 7 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000693 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+763
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-036-vendor-02.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-036-vendor-02.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 378 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-036/vendor-02) Tj
+0 -16 Td
+(RFQ: Vapor recovery unit compressor package \(lot 37\)) Tj
+0 -16 Td
+(Vendor: Worley Chemetics) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 15102.50) Tj
+0 -16 Td
+(Payment terms: Net 45 EOM) Tj
+0 -16 Td
+(Delivery lead: 8 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000694 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+764
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-037-vendor-00.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-037-vendor-00.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 381 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-037/vendor-00) Tj
+0 -16 Td
+(RFQ: Corrosion inhibitor injection skid \(lot 38\)) Tj
+0 -16 Td
+(Vendor: Parker Hannifin Scandinavia) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 15045.00) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 7 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000697 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+767
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-037-vendor-01.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-037-vendor-01.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 367 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-037/vendor-01) Tj
+0 -16 Td
+(RFQ: Corrosion inhibitor injection skid \(lot 38\)) Tj
+0 -16 Td
+(Vendor: Honeywell UOP) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 15102.50) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 8 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000683 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+753
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-037-vendor-02.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-037-vendor-02.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 367 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-037/vendor-02) Tj
+0 -16 Td
+(RFQ: Corrosion inhibitor injection skid \(lot 38\)) Tj
+0 -16 Td
+(Vendor: BASF Catalysts) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 9575.00) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 9 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000683 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+753
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-037-vendor-03.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-037-vendor-03.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 373 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-037/vendor-03) Tj
+0 -16 Td
+(RFQ: Corrosion inhibitor injection skid \(lot 38\)) Tj
+0 -16 Td
+(Vendor: Clariant Catalysts) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 13415.00) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 10 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000689 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+759
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-038-vendor-00.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-038-vendor-00.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 380 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-038/vendor-00) Tj
+0 -16 Td
+(RFQ: DCS I/O marshalling cabinets + IS barriers \(lot 39\)) Tj
+0 -16 Td
+(Vendor: Alfa Laval Aalborg) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 15102.50) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 8 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000696 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+766
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-038-vendor-01.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-038-vendor-01.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 376 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-038/vendor-01) Tj
+0 -16 Td
+(RFQ: DCS I/O marshalling cabinets + IS barriers \(lot 39\)) Tj
+0 -16 Td
+(Vendor: Sulzer Chemtech) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 9575.00) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 9 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000692 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+762
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-038-vendor-02.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-038-vendor-02.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 393 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-038/vendor-02) Tj
+0 -16 Td
+(RFQ: DCS I/O marshalling cabinets + IS barriers \(lot 39\)) Tj
+0 -16 Td
+(Vendor: John Zink Hamworthy Combustion) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 13415.00) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 10 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000709 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+779
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-038-vendor-03.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-038-vendor-03.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 391 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-038/vendor-03) Tj
+0 -16 Td
+(RFQ: DCS I/O marshalling cabinets + IS barriers \(lot 39\)) Tj
+0 -16 Td
+(Vendor: Donaldson Process Filtration) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 13420.00) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 11 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000707 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+777
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-038-vendor-04.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-038-vendor-04.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 386 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-038/vendor-04) Tj
+0 -16 Td
+(RFQ: DCS I/O marshalling cabinets + IS barriers \(lot 39\)) Tj
+0 -16 Td
+(Vendor: Grundfos Process Nordic) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 17431.25) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 12 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000702 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+772
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-039-vendor-00.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-039-vendor-00.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 393 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-039/vendor-00) Tj
+0 -16 Td
+(RFQ: Loading arm spare hydraulic power unit \(lot 40\)) Tj
+0 -16 Td
+(Vendor: Air Liquide Advanced Separations) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 9575.00) Tj
+0 -16 Td
+(Payment terms: Net 45 EOM) Tj
+0 -16 Td
+(Delivery lead: 9 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000709 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+779
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-039-vendor-01.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-039-vendor-01.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 385 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-039/vendor-01) Tj
+0 -16 Td
+(RFQ: Loading arm spare hydraulic power unit \(lot 40\)) Tj
+0 -16 Td
+(Vendor: Technip Energies Norge) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 13415.00) Tj
+0 -16 Td
+(Payment terms: Net 45 EOM) Tj
+0 -16 Td
+(Delivery lead: 10 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000701 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+771
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-039-vendor-02.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-039-vendor-02.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 378 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-039/vendor-02) Tj
+0 -16 Td
+(RFQ: Loading arm spare hydraulic power unit \(lot 40\)) Tj
+0 -16 Td
+(Vendor: Wood PLC Norway) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 13420.00) Tj
+0 -16 Td
+(Payment terms: Net 45 EOM) Tj
+0 -16 Td
+(Delivery lead: 11 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000694 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+764
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-040-vendor-00.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-040-vendor-00.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 375 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-040/vendor-00) Tj
+0 -16 Td
+(RFQ: Nitrogen generator membrane replacement \(lot 41\)) Tj
+0 -16 Td
+(Vendor: Swagelok Bergen) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 13415.00) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 10 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000691 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+761
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-040-vendor-01.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-040-vendor-01.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 387 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-040/vendor-01) Tj
+0 -16 Td
+(RFQ: Nitrogen generator membrane replacement \(lot 41\)) Tj
+0 -16 Td
+(Vendor: Parker Hannifin Scandinavia) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 13420.00) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 11 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000703 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+773
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-040-vendor-02.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-040-vendor-02.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 373 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-040/vendor-02) Tj
+0 -16 Td
+(RFQ: Nitrogen generator membrane replacement \(lot 41\)) Tj
+0 -16 Td
+(Vendor: Honeywell UOP) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 17431.25) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 12 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000689 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+759
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-040-vendor-03.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-040-vendor-03.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 374 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-040/vendor-03) Tj
+0 -16 Td
+(RFQ: Nitrogen generator membrane replacement \(lot 41\)) Tj
+0 -16 Td
+(Vendor: BASF Catalysts) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 11560.00) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 13 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000690 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+760
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-041-vendor-00.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-041-vendor-00.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 372 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-041/vendor-00) Tj
+0 -16 Td
+(RFQ: Flare pilot / igniter assembly \(lot 42\)) Tj
+0 -16 Td
+(Vendor: Emerson Fisher Norway) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 13420.00) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 11 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000688 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+758
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-041-vendor-01.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-041-vendor-01.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 369 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-041/vendor-01) Tj
+0 -16 Td
+(RFQ: Flare pilot / igniter assembly \(lot 42\)) Tj
+0 -16 Td
+(Vendor: Alfa Laval Aalborg) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 17431.25) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 12 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000685 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+755
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-041-vendor-02.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-041-vendor-02.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 366 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-041/vendor-02) Tj
+0 -16 Td
+(RFQ: Flare pilot / igniter assembly \(lot 42\)) Tj
+0 -16 Td
+(Vendor: Sulzer Chemtech) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 11560.00) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 13 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000682 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+752
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-041-vendor-03.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-041-vendor-03.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 381 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-041/vendor-03) Tj
+0 -16 Td
+(RFQ: Flare pilot / igniter assembly \(lot 42\)) Tj
+0 -16 Td
+(Vendor: John Zink Hamworthy Combustion) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 11512.50) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 14 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000697 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+767
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-041-vendor-04.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-041-vendor-04.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 378 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-041/vendor-04) Tj
+0 -16 Td
+(RFQ: Flare pilot / igniter assembly \(lot 42\)) Tj
+0 -16 Td
+(Vendor: Donaldson Process Filtration) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 15662.50) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 6 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000694 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+764
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-042-vendor-00.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-042-vendor-00.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 376 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-042/vendor-00) Tj
+0 -16 Td
+(RFQ: Heat exchanger bundle - lean amine \(lot 43\)) Tj
+0 -16 Td
+(Vendor: Linde Engineering) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 17431.25) Tj
+0 -16 Td
+(Payment terms: Net 45 EOM) Tj
+0 -16 Td
+(Delivery lead: 12 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000692 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+762
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-042-vendor-01.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-042-vendor-01.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 391 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-042/vendor-01) Tj
+0 -16 Td
+(RFQ: Heat exchanger bundle - lean amine \(lot 43\)) Tj
+0 -16 Td
+(Vendor: Air Liquide Advanced Separations) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 11560.00) Tj
+0 -16 Td
+(Payment terms: Net 45 EOM) Tj
+0 -16 Td
+(Delivery lead: 13 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000707 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+777
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-042-vendor-02.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-042-vendor-02.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 381 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-042/vendor-02) Tj
+0 -16 Td
+(RFQ: Heat exchanger bundle - lean amine \(lot 43\)) Tj
+0 -16 Td
+(Vendor: Technip Energies Norge) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 11512.50) Tj
+0 -16 Td
+(Payment terms: Net 45 EOM) Tj
+0 -16 Td
+(Delivery lead: 14 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000697 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+767
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-043-vendor-00.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-043-vendor-00.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 386 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-043/vendor-00) Tj
+0 -16 Td
+(RFQ: Emergency shower & eyewash stations \(ATEX\) \(lot 44\)) Tj
+0 -16 Td
+(Vendor: Burkert Fluid Control) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 11560.00) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 13 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000702 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+772
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-043-vendor-01.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-043-vendor-01.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 380 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-043/vendor-01) Tj
+0 -16 Td
+(RFQ: Emergency shower & eyewash stations \(ATEX\) \(lot 44\)) Tj
+0 -16 Td
+(Vendor: Swagelok Bergen) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 11512.50) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 14 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000696 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+766
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-043-vendor-02.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-043-vendor-02.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 391 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-043/vendor-02) Tj
+0 -16 Td
+(RFQ: Emergency shower & eyewash stations \(ATEX\) \(lot 44\)) Tj
+0 -16 Td
+(Vendor: Parker Hannifin Scandinavia) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 15662.50) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 6 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000707 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+777
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-043-vendor-03.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-043-vendor-03.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 377 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-043/vendor-03) Tj
+0 -16 Td
+(RFQ: Emergency shower & eyewash stations \(ATEX\) \(lot 44\)) Tj
+0 -16 Td
+(Vendor: Honeywell UOP) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 19930.00) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 7 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000693 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+763
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-044-vendor-00.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-044-vendor-00.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 380 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-044/vendor-00) Tj
+0 -16 Td
+(RFQ: Chemical metering pumps - cooling tower \(lot 45\)) Tj
+0 -16 Td
+(Vendor: FlowServe Nordics AS) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 11512.50) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 14 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000696 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+766
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-044-vendor-01.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-044-vendor-01.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 380 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-044/vendor-01) Tj
+0 -16 Td
+(RFQ: Chemical metering pumps - cooling tower \(lot 45\)) Tj
+0 -16 Td
+(Vendor: Emerson Fisher Norway) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 15662.50) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 6 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000696 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+766
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-044-vendor-02.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-044-vendor-02.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 377 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-044/vendor-02) Tj
+0 -16 Td
+(RFQ: Chemical metering pumps - cooling tower \(lot 45\)) Tj
+0 -16 Td
+(Vendor: Alfa Laval Aalborg) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 19930.00) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 7 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000693 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+763
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-044-vendor-03.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-044-vendor-03.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 373 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-044/vendor-03) Tj
+0 -16 Td
+(RFQ: Chemical metering pumps - cooling tower \(lot 45\)) Tj
+0 -16 Td
+(Vendor: Sulzer Chemtech) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 9380.00) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 8 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000689 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+759
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-044-vendor-04.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-044-vendor-04.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 389 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-044/vendor-04) Tj
+0 -16 Td
+(RFQ: Chemical metering pumps - cooling tower \(lot 45\)) Tj
+0 -16 Td
+(Vendor: John Zink Hamworthy Combustion) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 13668.75) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 9 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000705 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+775
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-045-vendor-00.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-045-vendor-00.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 384 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-045/vendor-00) Tj
+0 -16 Td
+(RFQ: HVAC ATEX fan wall - analyzer shelter \(lot 46\)) Tj
+0 -16 Td
+(Vendor: Atlas Copco Compressors) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 15662.50) Tj
+0 -16 Td
+(Payment terms: Net 45 EOM) Tj
+0 -16 Td
+(Delivery lead: 6 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000700 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+770
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-045-vendor-01.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-045-vendor-01.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 378 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-045/vendor-01) Tj
+0 -16 Td
+(RFQ: HVAC ATEX fan wall - analyzer shelter \(lot 46\)) Tj
+0 -16 Td
+(Vendor: Linde Engineering) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 19930.00) Tj
+0 -16 Td
+(Payment terms: Net 45 EOM) Tj
+0 -16 Td
+(Delivery lead: 7 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000694 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+764
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-045-vendor-02.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-045-vendor-02.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 392 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-045/vendor-02) Tj
+0 -16 Td
+(RFQ: HVAC ATEX fan wall - analyzer shelter \(lot 46\)) Tj
+0 -16 Td
+(Vendor: Air Liquide Advanced Separations) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 9380.00) Tj
+0 -16 Td
+(Payment terms: Net 45 EOM) Tj
+0 -16 Td
+(Delivery lead: 8 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000708 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+778
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-046-vendor-00.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-046-vendor-00.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 367 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-046/vendor-00) Tj
+0 -16 Td
+(RFQ: Fixed gas detection - LEL / H2S \(lot 47\)) Tj
+0 -16 Td
+(Vendor: SIHI Liquid Ring) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 19930.00) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 7 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000683 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+753
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-046-vendor-01.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-046-vendor-01.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 371 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-046/vendor-01) Tj
+0 -16 Td
+(RFQ: Fixed gas detection - LEL / H2S \(lot 47\)) Tj
+0 -16 Td
+(Vendor: Burkert Fluid Control) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 9380.00) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 8 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000687 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+757
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-046-vendor-02.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-046-vendor-02.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 366 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-046/vendor-02) Tj
+0 -16 Td
+(RFQ: Fixed gas detection - LEL / H2S \(lot 47\)) Tj
+0 -16 Td
+(Vendor: Swagelok Bergen) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 13668.75) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 9 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000682 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+752
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-046-vendor-03.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-046-vendor-03.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 379 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-046/vendor-03) Tj
+0 -16 Td
+(RFQ: Fixed gas detection - LEL / H2S \(lot 47\)) Tj
+0 -16 Td
+(Vendor: Parker Hannifin Scandinavia) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 18075.00) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 10 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000695 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+765
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-047-vendor-00.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-047-vendor-00.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 374 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-047/vendor-00) Tj
+0 -16 Td
+(RFQ: Firewater pump mechanical seal kit \(lot 48\)) Tj
+0 -16 Td
+(Vendor: Johnson Matthey NORAM) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 9380.00) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 8 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000690 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+760
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-047-vendor-01.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-047-vendor-01.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 374 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-047/vendor-01) Tj
+0 -16 Td
+(RFQ: Firewater pump mechanical seal kit \(lot 48\)) Tj
+0 -16 Td
+(Vendor: FlowServe Nordics AS) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 13668.75) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 9 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000690 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+760
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-047-vendor-02.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-047-vendor-02.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 376 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-047/vendor-02) Tj
+0 -16 Td
+(RFQ: Firewater pump mechanical seal kit \(lot 48\)) Tj
+0 -16 Td
+(Vendor: Emerson Fisher Norway) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 18075.00) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 10 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000692 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+762
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-047-vendor-03.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-047-vendor-03.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 373 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-047/vendor-03) Tj
+0 -16 Td
+(RFQ: Firewater pump mechanical seal kit \(lot 48\)) Tj
+0 -16 Td
+(Vendor: Alfa Laval Aalborg) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 18072.50) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 11 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000689 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+759
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-047-vendor-04.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-047-vendor-04.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 370 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-047/vendor-04) Tj
+0 -16 Td
+(RFQ: Firewater pump mechanical seal kit \(lot 48\)) Tj
+0 -16 Td
+(Vendor: Sulzer Chemtech) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 11450.00) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 12 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000686 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+756
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-048-vendor-00.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-048-vendor-00.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 392 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-048/vendor-00) Tj
+0 -16 Td
+(RFQ: Insulation & cladding - steam tracing package \(lot 49\)) Tj
+0 -16 Td
+(Vendor: Grundfos Process Nordic) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 13668.75) Tj
+0 -16 Td
+(Payment terms: Net 45 EOM) Tj
+0 -16 Td
+(Delivery lead: 9 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000708 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+778
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-048-vendor-01.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-048-vendor-01.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 393 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-048/vendor-01) Tj
+0 -16 Td
+(RFQ: Insulation & cladding - steam tracing package \(lot 49\)) Tj
+0 -16 Td
+(Vendor: Atlas Copco Compressors) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 18075.00) Tj
+0 -16 Td
+(Payment terms: Net 45 EOM) Tj
+0 -16 Td
+(Delivery lead: 10 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000709 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+779
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-048-vendor-02.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-048-vendor-02.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 387 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-048/vendor-02) Tj
+0 -16 Td
+(RFQ: Insulation & cladding - steam tracing package \(lot 49\)) Tj
+0 -16 Td
+(Vendor: Linde Engineering) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 18072.50) Tj
+0 -16 Td
+(Payment terms: Net 45 EOM) Tj
+0 -16 Td
+(Delivery lead: 11 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000703 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+773
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-049-vendor-00.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-049-vendor-00.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 384 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-049/vendor-00) Tj
+0 -16 Td
+(RFQ: Bolt tensioning service - turnaround \(lot 50\)) Tj
+0 -16 Td
+(Vendor: Hayward Tyler \(IMO\) Pumps) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 18075.00) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 10 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000700 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+770
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-049-vendor-01.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-049-vendor-01.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 373 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-049/vendor-01) Tj
+0 -16 Td
+(RFQ: Bolt tensioning service - turnaround \(lot 50\)) Tj
+0 -16 Td
+(Vendor: SIHI Liquid Ring) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 18072.50) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 11 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000689 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+759
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-049-vendor-02.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-049-vendor-02.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 378 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-049/vendor-02) Tj
+0 -16 Td
+(RFQ: Bolt tensioning service - turnaround \(lot 50\)) Tj
+0 -16 Td
+(Vendor: Burkert Fluid Control) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 11450.00) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 12 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000694 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+764
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-049-vendor-03.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-049-vendor-03.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 372 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-049/vendor-03) Tj
+0 -16 Td
+(RFQ: Bolt tensioning service - turnaround \(lot 50\)) Tj
+0 -16 Td
+(Vendor: Swagelok Bergen) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 15995.00) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 13 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000688 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+758
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-050-vendor-00.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-050-vendor-00.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 378 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-050/vendor-00) Tj
+0 -16 Td
+(RFQ: Temporary steam boiler rental \(12 MW\) \(lot 51\)) Tj
+0 -16 Td
+(Vendor: Clariant Catalysts) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 18072.50) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 11 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000694 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+764
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-050-vendor-01.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-050-vendor-01.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 381 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-050/vendor-01) Tj
+0 -16 Td
+(RFQ: Temporary steam boiler rental \(12 MW\) \(lot 51\)) Tj
+0 -16 Td
+(Vendor: Johnson Matthey NORAM) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 11450.00) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 12 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000697 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+767
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-050-vendor-02.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-050-vendor-02.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 380 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-050/vendor-02) Tj
+0 -16 Td
+(RFQ: Temporary steam boiler rental \(12 MW\) \(lot 51\)) Tj
+0 -16 Td
+(Vendor: FlowServe Nordics AS) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 15995.00) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 13 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000696 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+766
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-050-vendor-03.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-050-vendor-03.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 381 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-050/vendor-03) Tj
+0 -16 Td
+(RFQ: Temporary steam boiler rental \(12 MW\) \(lot 51\)) Tj
+0 -16 Td
+(Vendor: Emerson Fisher Norway) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 15940.00) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 14 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000697 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+767
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-050-vendor-04.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-050-vendor-04.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 377 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-050/vendor-04) Tj
+0 -16 Td
+(RFQ: Temporary steam boiler rental \(12 MW\) \(lot 51\)) Tj
+0 -16 Td
+(Vendor: Alfa Laval Aalborg) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 20656.25) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 6 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000693 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+763
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-051-vendor-00.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-051-vendor-00.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 388 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-051/vendor-00) Tj
+0 -16 Td
+(RFQ: Scaffold & containment - sulfur pit \(lot 52\)) Tj
+0 -16 Td
+(Vendor: Donaldson Process Filtration) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 11450.00) Tj
+0 -16 Td
+(Payment terms: Net 45 EOM) Tj
+0 -16 Td
+(Delivery lead: 12 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000704 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+774
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-051-vendor-01.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-051-vendor-01.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 383 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-051/vendor-01) Tj
+0 -16 Td
+(RFQ: Scaffold & containment - sulfur pit \(lot 52\)) Tj
+0 -16 Td
+(Vendor: Grundfos Process Nordic) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 15995.00) Tj
+0 -16 Td
+(Payment terms: Net 45 EOM) Tj
+0 -16 Td
+(Delivery lead: 13 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000699 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+769
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-051-vendor-02.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-051-vendor-02.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 383 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-051/vendor-02) Tj
+0 -16 Td
+(RFQ: Scaffold & containment - sulfur pit \(lot 52\)) Tj
+0 -16 Td
+(Vendor: Atlas Copco Compressors) Tj
+0 -16 Td
+(Status profile: ready) Tj
+0 -16 Td
+(Commercial total \(USD\): 15940.00) Tj
+0 -16 Td
+(Payment terms: Net 45 EOM) Tj
+0 -16 Td
+(Delivery lead: 14 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000699 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+769
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-052-vendor-00.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-052-vendor-00.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 380 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-052/vendor-00) Tj
+0 -16 Td
+(RFQ: NDT phased-array - welds on HP piping \(lot 53\)) Tj
+0 -16 Td
+(Vendor: Worley Chemetics) Tj
+0 -16 Td
+(Status profile: normalizing) Tj
+0 -16 Td
+(Commercial total \(USD\): 15995.00) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 13 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000696 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+766
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-053-vendor-00.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-053-vendor-00.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 381 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-053/vendor-00) Tj
+0 -16 Td
+(RFQ: Relief valve recertification \(in-situ\) \(lot 54\)) Tj
+0 -16 Td
+(Vendor: BASF Catalysts) Tj
+0 -16 Td
+(Status profile: normalizing) Tj
+0 -16 Td
+(Commercial total \(USD\): 15940.00) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 14 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000697 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+767
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-053-vendor-01.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-053-vendor-01.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 379 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-053/vendor-01) Tj
+0 -16 Td
+(RFQ: Relief valve recertification \(in-situ\) \(lot 54\)) Tj
+0 -16 Td
+(Vendor: Clariant Catalysts) Tj
+0 -16 Td
+(Status profile: failed) Tj
+0 -16 Td
+(Commercial total \(USD\): 20656.25) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 6 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000695 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+765
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/files/rfq-055-vendor-00.pdf
+++ b/apps/atomy-q/API/database/seed-data/quotations/files/rfq-055-vendor-00.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+% seed quotation fixture
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 374 >>
+stream
+BT
+/F1 12 Tf
+50 760 Td
+(Atomy-Q seed quotation fixture) Tj
+0 -16 Td
+(Business key: rfq-055/vendor-00) Tj
+0 -16 Td
+(RFQ: Catalyst sampling probes + quills \(lot 56\)) Tj
+0 -16 Td
+(Vendor: Wood PLC Norway) Tj
+0 -16 Td
+(Status profile: normalizing) Tj
+0 -16 Td
+(Commercial total \(USD\): 13690.00) Tj
+0 -16 Td
+(Payment terms: Net 30) Tj
+0 -16 Td
+(Delivery lead: 7 weeks) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000034 00000 n 
+0000000083 00000 n 
+0000000140 00000 n 
+0000000266 00000 n 
+0000000690 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+760
+%%EOF

--- a/apps/atomy-q/API/database/seed-data/quotations/manifest.json
+++ b/apps/atomy-q/API/database/seed-data/quotations/manifest.json
@@ -1,0 +1,7196 @@
+{
+    "version": 1,
+    "entries": {
+        "rfq-008/vendor-00": {
+            "business_key": "rfq-008/vendor-00",
+            "rfq_key": "rfq-008",
+            "vendor_key": "vendor-00",
+            "rfq_index": 8,
+            "quote_index": 0,
+            "rfq_kind": "published_intake",
+            "rfq_title": "DCS I/O marshalling cabinets + IS barriers",
+            "vendor_name": "Worley Chemetics",
+            "quote_status": "uploaded",
+            "original_filename": "Quote_Worley_Chemetics.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-008-vendor-00.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-008/vendor-00",
+                "RFQ: DCS I/O marshalling cabinets + IS barriers",
+                "Vendor: Worley Chemetics",
+                "Status profile: uploaded",
+                "Commercial total (USD): 5302.50",
+                "Payment terms: Net 30",
+                "Delivery lead: 14 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-009-A",
+                    "quantity": 2,
+                    "uom": "ea",
+                    "unit_price": 1187.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-009-B",
+                    "quantity": 2,
+                    "uom": "set",
+                    "unit_price": 616.25,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-009",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 1695,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-009/vendor-00": {
+            "business_key": "rfq-009/vendor-00",
+            "rfq_key": "rfq-009",
+            "vendor_key": "vendor-00",
+            "rfq_index": 9,
+            "quote_index": 0,
+            "rfq_kind": "published_intake",
+            "rfq_title": "Loading arm spare hydraulic power unit",
+            "vendor_name": "BASF Catalysts",
+            "quote_status": "uploaded",
+            "original_filename": "Quote_BASF_Catalysts.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-009-vendor-00.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-009/vendor-00",
+                "RFQ: Loading arm spare hydraulic power unit",
+                "Vendor: BASF Catalysts",
+                "Status profile: uploaded",
+                "Commercial total (USD): 7337.50",
+                "Payment terms: Net 45 EOM",
+                "Delivery lead: 6 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-010-A",
+                    "quantity": 3,
+                    "uom": "ea",
+                    "unit_price": 1225,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-010-B",
+                    "quantity": 3,
+                    "uom": "set",
+                    "unit_price": 637.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-010",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 1750,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-009/vendor-01": {
+            "business_key": "rfq-009/vendor-01",
+            "rfq_key": "rfq-009",
+            "vendor_key": "vendor-01",
+            "rfq_index": 9,
+            "quote_index": 1,
+            "rfq_kind": "published_intake",
+            "rfq_title": "Loading arm spare hydraulic power unit",
+            "vendor_name": "Clariant Catalysts",
+            "quote_status": "extracting",
+            "original_filename": "Quote_Clariant_Catalysts.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-009-vendor-01.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-009/vendor-01",
+                "RFQ: Loading arm spare hydraulic power unit",
+                "Vendor: Clariant Catalysts",
+                "Status profile: extracting",
+                "Commercial total (USD): 9490.00",
+                "Payment terms: Net 45 EOM",
+                "Delivery lead: 7 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-010-A",
+                    "quantity": 4,
+                    "uom": "ea",
+                    "unit_price": 1262.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-010-B",
+                    "quantity": 4,
+                    "uom": "set",
+                    "unit_price": 658.75,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-010",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 1805,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-010/vendor-00": {
+            "business_key": "rfq-010/vendor-00",
+            "rfq_key": "rfq-010",
+            "vendor_key": "vendor-00",
+            "rfq_index": 10,
+            "quote_index": 0,
+            "rfq_kind": "published_intake",
+            "rfq_title": "Nitrogen generator membrane replacement",
+            "vendor_name": "John Zink Hamworthy Combustion",
+            "quote_status": "uploaded",
+            "original_filename": "Quote_John_Zink_Hamworthy_Combustion.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-010-vendor-00.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-010/vendor-00",
+                "RFQ: Nitrogen generator membrane replacement",
+                "Vendor: John Zink Hamworthy Combustion",
+                "Status profile: uploaded",
+                "Commercial total (USD): 9490.00",
+                "Payment terms: Net 30",
+                "Delivery lead: 7 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-011-A",
+                    "quantity": 4,
+                    "uom": "ea",
+                    "unit_price": 1262.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-011-B",
+                    "quantity": 4,
+                    "uom": "set",
+                    "unit_price": 658.75,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-011",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 1805,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-010/vendor-01": {
+            "business_key": "rfq-010/vendor-01",
+            "rfq_key": "rfq-010",
+            "vendor_key": "vendor-01",
+            "rfq_index": 10,
+            "quote_index": 1,
+            "rfq_kind": "published_intake",
+            "rfq_title": "Nitrogen generator membrane replacement",
+            "vendor_name": "Donaldson Process Filtration",
+            "quote_status": "extracting",
+            "original_filename": "Quote_Donaldson_Process_Filtration.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-010-vendor-01.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-010/vendor-01",
+                "RFQ: Nitrogen generator membrane replacement",
+                "Vendor: Donaldson Process Filtration",
+                "Status profile: extracting",
+                "Commercial total (USD): 4520.00",
+                "Payment terms: Net 30",
+                "Delivery lead: 8 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-011-A",
+                    "quantity": 1,
+                    "uom": "ea",
+                    "unit_price": 1300,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-011-B",
+                    "quantity": 2,
+                    "uom": "set",
+                    "unit_price": 680,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-011",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 1860,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-010/vendor-02": {
+            "business_key": "rfq-010/vendor-02",
+            "rfq_key": "rfq-010",
+            "vendor_key": "vendor-02",
+            "rfq_index": 10,
+            "quote_index": 2,
+            "rfq_kind": "published_intake",
+            "rfq_title": "Nitrogen generator membrane replacement",
+            "vendor_name": "Grundfos Process Nordic",
+            "quote_status": "extracted",
+            "original_filename": "Quote_Grundfos_Process_Nordic.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-010-vendor-02.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-010/vendor-02",
+                "RFQ: Nitrogen generator membrane replacement",
+                "Vendor: Grundfos Process Nordic",
+                "Status profile: extracted",
+                "Commercial total (USD): 6693.75",
+                "Payment terms: Net 30",
+                "Delivery lead: 9 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-011-A",
+                    "quantity": 2,
+                    "uom": "ea",
+                    "unit_price": 1337.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-011-B",
+                    "quantity": 3,
+                    "uom": "set",
+                    "unit_price": 701.25,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-011",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 1915,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-011/vendor-00": {
+            "business_key": "rfq-011/vendor-00",
+            "rfq_key": "rfq-011",
+            "vendor_key": "vendor-00",
+            "rfq_index": 11,
+            "quote_index": 0,
+            "rfq_kind": "published_intake",
+            "rfq_title": "Flare pilot / igniter assembly",
+            "vendor_name": "Wood PLC Norway",
+            "quote_status": "uploaded",
+            "original_filename": "Quote_Wood_PLC_Norway.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-011-vendor-00.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-011/vendor-00",
+                "RFQ: Flare pilot / igniter assembly",
+                "Vendor: Wood PLC Norway",
+                "Status profile: uploaded",
+                "Commercial total (USD): 4520.00",
+                "Payment terms: Net 30",
+                "Delivery lead: 8 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-012-A",
+                    "quantity": 1,
+                    "uom": "ea",
+                    "unit_price": 1300,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-012-B",
+                    "quantity": 2,
+                    "uom": "set",
+                    "unit_price": 680,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-012",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 1860,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-011/vendor-01": {
+            "business_key": "rfq-011/vendor-01",
+            "rfq_key": "rfq-011",
+            "vendor_key": "vendor-01",
+            "rfq_index": 11,
+            "quote_index": 1,
+            "rfq_kind": "published_intake",
+            "rfq_title": "Flare pilot / igniter assembly",
+            "vendor_name": "Worley Chemetics",
+            "quote_status": "extracting",
+            "original_filename": "Quote_Worley_Chemetics.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-011-vendor-01.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-011/vendor-01",
+                "RFQ: Flare pilot / igniter assembly",
+                "Vendor: Worley Chemetics",
+                "Status profile: extracting",
+                "Commercial total (USD): 6693.75",
+                "Payment terms: Net 30",
+                "Delivery lead: 9 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-012-A",
+                    "quantity": 2,
+                    "uom": "ea",
+                    "unit_price": 1337.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-012-B",
+                    "quantity": 3,
+                    "uom": "set",
+                    "unit_price": 701.25,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-012",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 1915,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-011/vendor-02": {
+            "business_key": "rfq-011/vendor-02",
+            "rfq_key": "rfq-011",
+            "vendor_key": "vendor-02",
+            "rfq_index": 11,
+            "quote_index": 2,
+            "rfq_kind": "published_intake",
+            "rfq_title": "Flare pilot / igniter assembly",
+            "vendor_name": "Hayward Tyler (IMO) Pumps",
+            "quote_status": "extracted",
+            "original_filename": "Quote_Hayward_Tyler_IMO_Pumps.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-011-vendor-02.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-011/vendor-02",
+                "RFQ: Flare pilot / igniter assembly",
+                "Vendor: Hayward Tyler (IMO) Pumps",
+                "Status profile: extracted",
+                "Commercial total (USD): 8985.00",
+                "Payment terms: Net 30",
+                "Delivery lead: 10 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-012-A",
+                    "quantity": 3,
+                    "uom": "ea",
+                    "unit_price": 1375,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-012-B",
+                    "quantity": 4,
+                    "uom": "set",
+                    "unit_price": 722.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-012",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 1970,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-011/vendor-03": {
+            "business_key": "rfq-011/vendor-03",
+            "rfq_key": "rfq-011",
+            "vendor_key": "vendor-03",
+            "rfq_index": 11,
+            "quote_index": 3,
+            "rfq_kind": "published_intake",
+            "rfq_title": "Flare pilot / igniter assembly",
+            "vendor_name": "SIHI Liquid Ring",
+            "quote_status": "normalizing",
+            "original_filename": "Quote_SIHI_Liquid_Ring.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-011-vendor-03.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-011/vendor-03",
+                "RFQ: Flare pilot / igniter assembly",
+                "Vendor: SIHI Liquid Ring",
+                "Status profile: normalizing",
+                "Commercial total (USD): 9162.50",
+                "Payment terms: Net 30",
+                "Delivery lead: 11 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-012-A",
+                    "quantity": 4,
+                    "uom": "ea",
+                    "unit_price": 1412.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-012-B",
+                    "quantity": 2,
+                    "uom": "set",
+                    "unit_price": 743.75,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-012",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 2025,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-012/vendor-00": {
+            "business_key": "rfq-012/vendor-00",
+            "rfq_key": "rfq-012",
+            "vendor_key": "vendor-00",
+            "rfq_index": 12,
+            "quote_index": 0,
+            "rfq_kind": "published_intake",
+            "rfq_title": "Heat exchanger bundle - lean amine",
+            "vendor_name": "Honeywell UOP",
+            "quote_status": "uploaded",
+            "original_filename": "Quote_Honeywell_UOP.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-012-vendor-00.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-012/vendor-00",
+                "RFQ: Heat exchanger bundle - lean amine",
+                "Vendor: Honeywell UOP",
+                "Status profile: uploaded",
+                "Commercial total (USD): 6693.75",
+                "Payment terms: Net 45 EOM",
+                "Delivery lead: 9 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-013-A",
+                    "quantity": 2,
+                    "uom": "ea",
+                    "unit_price": 1337.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-013-B",
+                    "quantity": 3,
+                    "uom": "set",
+                    "unit_price": 701.25,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-013",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 1915,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-013/vendor-00": {
+            "business_key": "rfq-013/vendor-00",
+            "rfq_key": "rfq-013",
+            "vendor_key": "vendor-00",
+            "rfq_index": 13,
+            "quote_index": 0,
+            "rfq_kind": "published_intake",
+            "rfq_title": "Emergency shower & eyewash stations (ATEX)",
+            "vendor_name": "Sulzer Chemtech",
+            "quote_status": "uploaded",
+            "original_filename": "Quote_Sulzer_Chemtech.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-013-vendor-00.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-013/vendor-00",
+                "RFQ: Emergency shower & eyewash stations (ATEX)",
+                "Vendor: Sulzer Chemtech",
+                "Status profile: uploaded",
+                "Commercial total (USD): 8985.00",
+                "Payment terms: Net 30",
+                "Delivery lead: 10 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-014-A",
+                    "quantity": 3,
+                    "uom": "ea",
+                    "unit_price": 1375,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-014-B",
+                    "quantity": 4,
+                    "uom": "set",
+                    "unit_price": 722.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-014",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 1970,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-013/vendor-01": {
+            "business_key": "rfq-013/vendor-01",
+            "rfq_key": "rfq-013",
+            "vendor_key": "vendor-01",
+            "rfq_index": 13,
+            "quote_index": 1,
+            "rfq_kind": "published_intake",
+            "rfq_title": "Emergency shower & eyewash stations (ATEX)",
+            "vendor_name": "John Zink Hamworthy Combustion",
+            "quote_status": "extracting",
+            "original_filename": "Quote_John_Zink_Hamworthy_Combustion.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-013-vendor-01.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-013/vendor-01",
+                "RFQ: Emergency shower & eyewash stations (ATEX)",
+                "Vendor: John Zink Hamworthy Combustion",
+                "Status profile: extracting",
+                "Commercial total (USD): 9162.50",
+                "Payment terms: Net 30",
+                "Delivery lead: 11 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-014-A",
+                    "quantity": 4,
+                    "uom": "ea",
+                    "unit_price": 1412.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-014-B",
+                    "quantity": 2,
+                    "uom": "set",
+                    "unit_price": 743.75,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-014",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 2025,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-014/vendor-00": {
+            "business_key": "rfq-014/vendor-00",
+            "rfq_key": "rfq-014",
+            "vendor_key": "vendor-00",
+            "rfq_index": 14,
+            "quote_index": 0,
+            "rfq_kind": "published_intake",
+            "rfq_title": "Chemical metering pumps - cooling tower",
+            "vendor_name": "Technip Energies Norge",
+            "quote_status": "uploaded",
+            "original_filename": "Quote_Technip_Energies_Norge.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-014-vendor-00.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-014/vendor-00",
+                "RFQ: Chemical metering pumps - cooling tower",
+                "Vendor: Technip Energies Norge",
+                "Status profile: uploaded",
+                "Commercial total (USD): 9162.50",
+                "Payment terms: Net 30",
+                "Delivery lead: 11 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-015-A",
+                    "quantity": 4,
+                    "uom": "ea",
+                    "unit_price": 1412.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-015-B",
+                    "quantity": 2,
+                    "uom": "set",
+                    "unit_price": 743.75,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-015",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 2025,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-014/vendor-01": {
+            "business_key": "rfq-014/vendor-01",
+            "rfq_key": "rfq-014",
+            "vendor_key": "vendor-01",
+            "rfq_index": 14,
+            "quote_index": 1,
+            "rfq_kind": "published_intake",
+            "rfq_title": "Chemical metering pumps - cooling tower",
+            "vendor_name": "Wood PLC Norway",
+            "quote_status": "extracting",
+            "original_filename": "Quote_Wood_PLC_Norway.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-014-vendor-01.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-014/vendor-01",
+                "RFQ: Chemical metering pumps - cooling tower",
+                "Vendor: Wood PLC Norway",
+                "Status profile: extracting",
+                "Commercial total (USD): 5825.00",
+                "Payment terms: Net 30",
+                "Delivery lead: 12 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-015-A",
+                    "quantity": 1,
+                    "uom": "ea",
+                    "unit_price": 1450,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-015-B",
+                    "quantity": 3,
+                    "uom": "set",
+                    "unit_price": 765,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-015",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 2080,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-014/vendor-02": {
+            "business_key": "rfq-014/vendor-02",
+            "rfq_key": "rfq-014",
+            "vendor_key": "vendor-02",
+            "rfq_index": 14,
+            "quote_index": 2,
+            "rfq_kind": "published_intake",
+            "rfq_title": "Chemical metering pumps - cooling tower",
+            "vendor_name": "Worley Chemetics",
+            "quote_status": "extracted",
+            "original_filename": "Quote_Worley_Chemetics.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-014-vendor-02.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-014/vendor-02",
+                "RFQ: Chemical metering pumps - cooling tower",
+                "Vendor: Worley Chemetics",
+                "Status profile: extracted",
+                "Commercial total (USD): 8255.00",
+                "Payment terms: Net 30",
+                "Delivery lead: 13 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-015-A",
+                    "quantity": 2,
+                    "uom": "ea",
+                    "unit_price": 1487.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-015-B",
+                    "quantity": 4,
+                    "uom": "set",
+                    "unit_price": 786.25,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-015",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 2135,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-015/vendor-00": {
+            "business_key": "rfq-015/vendor-00",
+            "rfq_key": "rfq-015",
+            "vendor_key": "vendor-00",
+            "rfq_index": 15,
+            "quote_index": 0,
+            "rfq_kind": "published_intake",
+            "rfq_title": "HVAC ATEX fan wall - analyzer shelter",
+            "vendor_name": "Parker Hannifin Scandinavia",
+            "quote_status": "uploaded",
+            "original_filename": "Quote_Parker_Hannifin_Scandinavia.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-015-vendor-00.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-015/vendor-00",
+                "RFQ: HVAC ATEX fan wall - analyzer shelter",
+                "Vendor: Parker Hannifin Scandinavia",
+                "Status profile: uploaded",
+                "Commercial total (USD): 5825.00",
+                "Payment terms: Net 45 EOM",
+                "Delivery lead: 12 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-016-A",
+                    "quantity": 1,
+                    "uom": "ea",
+                    "unit_price": 1450,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-016-B",
+                    "quantity": 3,
+                    "uom": "set",
+                    "unit_price": 765,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-016",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 2080,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-015/vendor-01": {
+            "business_key": "rfq-015/vendor-01",
+            "rfq_key": "rfq-015",
+            "vendor_key": "vendor-01",
+            "rfq_index": 15,
+            "quote_index": 1,
+            "rfq_kind": "published_intake",
+            "rfq_title": "HVAC ATEX fan wall - analyzer shelter",
+            "vendor_name": "Honeywell UOP",
+            "quote_status": "extracting",
+            "original_filename": "Quote_Honeywell_UOP.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-015-vendor-01.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-015/vendor-01",
+                "RFQ: HVAC ATEX fan wall - analyzer shelter",
+                "Vendor: Honeywell UOP",
+                "Status profile: extracting",
+                "Commercial total (USD): 8255.00",
+                "Payment terms: Net 45 EOM",
+                "Delivery lead: 13 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-016-A",
+                    "quantity": 2,
+                    "uom": "ea",
+                    "unit_price": 1487.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-016-B",
+                    "quantity": 4,
+                    "uom": "set",
+                    "unit_price": 786.25,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-016",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 2135,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-015/vendor-02": {
+            "business_key": "rfq-015/vendor-02",
+            "rfq_key": "rfq-015",
+            "vendor_key": "vendor-02",
+            "rfq_index": 15,
+            "quote_index": 2,
+            "rfq_kind": "published_intake",
+            "rfq_title": "HVAC ATEX fan wall - analyzer shelter",
+            "vendor_name": "BASF Catalysts",
+            "quote_status": "extracted",
+            "original_filename": "Quote_BASF_Catalysts.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-015-vendor-02.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-015/vendor-02",
+                "RFQ: HVAC ATEX fan wall - analyzer shelter",
+                "Vendor: BASF Catalysts",
+                "Status profile: extracted",
+                "Commercial total (USD): 8380.00",
+                "Payment terms: Net 45 EOM",
+                "Delivery lead: 14 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-016-A",
+                    "quantity": 3,
+                    "uom": "ea",
+                    "unit_price": 1525,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-016-B",
+                    "quantity": 2,
+                    "uom": "set",
+                    "unit_price": 807.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-016",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 2190,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-015/vendor-03": {
+            "business_key": "rfq-015/vendor-03",
+            "rfq_key": "rfq-015",
+            "vendor_key": "vendor-03",
+            "rfq_index": 15,
+            "quote_index": 3,
+            "rfq_kind": "published_intake",
+            "rfq_title": "HVAC ATEX fan wall - analyzer shelter",
+            "vendor_name": "Clariant Catalysts",
+            "quote_status": "normalizing",
+            "original_filename": "Quote_Clariant_Catalysts.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-015-vendor-03.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-015/vendor-03",
+                "RFQ: HVAC ATEX fan wall - analyzer shelter",
+                "Vendor: Clariant Catalysts",
+                "Status profile: normalizing",
+                "Commercial total (USD): 10981.25",
+                "Payment terms: Net 45 EOM",
+                "Delivery lead: 6 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-016-A",
+                    "quantity": 4,
+                    "uom": "ea",
+                    "unit_price": 1562.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-016-B",
+                    "quantity": 3,
+                    "uom": "set",
+                    "unit_price": 828.75,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-016",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 2245,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-016/vendor-00": {
+            "business_key": "rfq-016/vendor-00",
+            "rfq_key": "rfq-016",
+            "vendor_key": "vendor-00",
+            "rfq_index": 16,
+            "quote_index": 0,
+            "rfq_kind": "published_intake",
+            "rfq_title": "Fixed gas detection - LEL / H2S",
+            "vendor_name": "Alfa Laval Aalborg",
+            "quote_status": "uploaded",
+            "original_filename": "Quote_Alfa_Laval_Aalborg.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-016-vendor-00.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-016/vendor-00",
+                "RFQ: Fixed gas detection - LEL / H2S",
+                "Vendor: Alfa Laval Aalborg",
+                "Status profile: uploaded",
+                "Commercial total (USD): 8255.00",
+                "Payment terms: Net 30",
+                "Delivery lead: 13 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-017-A",
+                    "quantity": 2,
+                    "uom": "ea",
+                    "unit_price": 1487.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-017-B",
+                    "quantity": 4,
+                    "uom": "set",
+                    "unit_price": 786.25,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-017",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 2135,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-017/vendor-00": {
+            "business_key": "rfq-017/vendor-00",
+            "rfq_key": "rfq-017",
+            "vendor_key": "vendor-00",
+            "rfq_index": 17,
+            "quote_index": 0,
+            "rfq_kind": "published_intake",
+            "rfq_title": "Firewater pump mechanical seal kit",
+            "vendor_name": "Air Liquide Advanced Separations",
+            "quote_status": "uploaded",
+            "original_filename": "Quote_Air_Liquide_Advanced_Separations.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-017-vendor-00.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-017/vendor-00",
+                "RFQ: Firewater pump mechanical seal kit",
+                "Vendor: Air Liquide Advanced Separations",
+                "Status profile: uploaded",
+                "Commercial total (USD): 8380.00",
+                "Payment terms: Net 30",
+                "Delivery lead: 14 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-018-A",
+                    "quantity": 3,
+                    "uom": "ea",
+                    "unit_price": 1525,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-018-B",
+                    "quantity": 2,
+                    "uom": "set",
+                    "unit_price": 807.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-018",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 2190,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-017/vendor-01": {
+            "business_key": "rfq-017/vendor-01",
+            "rfq_key": "rfq-017",
+            "vendor_key": "vendor-01",
+            "rfq_index": 17,
+            "quote_index": 1,
+            "rfq_kind": "published_intake",
+            "rfq_title": "Firewater pump mechanical seal kit",
+            "vendor_name": "Technip Energies Norge",
+            "quote_status": "extracting",
+            "original_filename": "Quote_Technip_Energies_Norge.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-017-vendor-01.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-017/vendor-01",
+                "RFQ: Firewater pump mechanical seal kit",
+                "Vendor: Technip Energies Norge",
+                "Status profile: extracting",
+                "Commercial total (USD): 10981.25",
+                "Payment terms: Net 30",
+                "Delivery lead: 6 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-018-A",
+                    "quantity": 4,
+                    "uom": "ea",
+                    "unit_price": 1562.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-018-B",
+                    "quantity": 3,
+                    "uom": "set",
+                    "unit_price": 828.75,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-018",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 2245,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-018/vendor-00": {
+            "business_key": "rfq-018/vendor-00",
+            "rfq_key": "rfq-018",
+            "vendor_key": "vendor-00",
+            "rfq_index": 18,
+            "quote_index": 0,
+            "rfq_kind": "published_stuck",
+            "rfq_title": "Insulation & cladding - steam tracing package",
+            "vendor_name": "Swagelok Bergen",
+            "quote_status": "needs_review",
+            "original_filename": "Quote_Swagelok_Bergen.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-018-vendor-00.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-018/vendor-00",
+                "RFQ: Insulation & cladding - steam tracing package",
+                "Vendor: Swagelok Bergen",
+                "Status profile: needs_review",
+                "Commercial total (USD): 10981.25",
+                "Payment terms: Net 45 EOM",
+                "Delivery lead: 6 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-019-A",
+                    "quantity": 4,
+                    "uom": "ea",
+                    "unit_price": 1562.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-019-B",
+                    "quantity": 3,
+                    "uom": "set",
+                    "unit_price": 828.75,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-019",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 2245,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-018/vendor-01": {
+            "business_key": "rfq-018/vendor-01",
+            "rfq_key": "rfq-018",
+            "vendor_key": "vendor-01",
+            "rfq_index": 18,
+            "quote_index": 1,
+            "rfq_kind": "published_stuck",
+            "rfq_title": "Insulation & cladding - steam tracing package",
+            "vendor_name": "Parker Hannifin Scandinavia",
+            "quote_status": "needs_review",
+            "original_filename": "Quote_Parker_Hannifin_Scandinavia.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-018-vendor-01.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-018/vendor-01",
+                "RFQ: Insulation & cladding - steam tracing package",
+                "Vendor: Parker Hannifin Scandinavia",
+                "Status profile: needs_review",
+                "Commercial total (USD): 7300.00",
+                "Payment terms: Net 45 EOM",
+                "Delivery lead: 7 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-019-A",
+                    "quantity": 1,
+                    "uom": "ea",
+                    "unit_price": 1600,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-019-B",
+                    "quantity": 4,
+                    "uom": "set",
+                    "unit_price": 850,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-019",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 2300,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-018/vendor-02": {
+            "business_key": "rfq-018/vendor-02",
+            "rfq_key": "rfq-018",
+            "vendor_key": "vendor-02",
+            "rfq_index": 18,
+            "quote_index": 2,
+            "rfq_kind": "published_stuck",
+            "rfq_title": "Insulation & cladding - steam tracing package",
+            "vendor_name": "Honeywell UOP",
+            "quote_status": "needs_review",
+            "original_filename": "Quote_Honeywell_UOP.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-018-vendor-02.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-018/vendor-02",
+                "RFQ: Insulation & cladding - steam tracing package",
+                "Vendor: Honeywell UOP",
+                "Status profile: needs_review",
+                "Commercial total (USD): 7372.50",
+                "Payment terms: Net 45 EOM",
+                "Delivery lead: 8 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-019-A",
+                    "quantity": 2,
+                    "uom": "ea",
+                    "unit_price": 1637.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-019-B",
+                    "quantity": 2,
+                    "uom": "set",
+                    "unit_price": 871.25,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-019",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 2355,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-019/vendor-00": {
+            "business_key": "rfq-019/vendor-00",
+            "rfq_key": "rfq-019",
+            "vendor_key": "vendor-00",
+            "rfq_index": 19,
+            "quote_index": 0,
+            "rfq_kind": "published_stuck",
+            "rfq_title": "Bolt tensioning service - turnaround",
+            "vendor_name": "Emerson Fisher Norway",
+            "quote_status": "needs_review",
+            "original_filename": "Quote_Emerson_Fisher_Norway.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-019-vendor-00.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-019/vendor-00",
+                "RFQ: Bolt tensioning service - turnaround",
+                "Vendor: Emerson Fisher Norway",
+                "Status profile: needs_review",
+                "Commercial total (USD): 7300.00",
+                "Payment terms: Net 30",
+                "Delivery lead: 7 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-020-A",
+                    "quantity": 1,
+                    "uom": "ea",
+                    "unit_price": 1600,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-020-B",
+                    "quantity": 4,
+                    "uom": "set",
+                    "unit_price": 850,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-020",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 2300,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-019/vendor-01": {
+            "business_key": "rfq-019/vendor-01",
+            "rfq_key": "rfq-019",
+            "vendor_key": "vendor-01",
+            "rfq_index": 19,
+            "quote_index": 1,
+            "rfq_kind": "published_stuck",
+            "rfq_title": "Bolt tensioning service - turnaround",
+            "vendor_name": "Alfa Laval Aalborg",
+            "quote_status": "needs_review",
+            "original_filename": "Quote_Alfa_Laval_Aalborg.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-019-vendor-01.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-019/vendor-01",
+                "RFQ: Bolt tensioning service - turnaround",
+                "Vendor: Alfa Laval Aalborg",
+                "Status profile: needs_review",
+                "Commercial total (USD): 7372.50",
+                "Payment terms: Net 30",
+                "Delivery lead: 8 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-020-A",
+                    "quantity": 2,
+                    "uom": "ea",
+                    "unit_price": 1637.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-020-B",
+                    "quantity": 2,
+                    "uom": "set",
+                    "unit_price": 871.25,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-020",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 2355,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-019/vendor-02": {
+            "business_key": "rfq-019/vendor-02",
+            "rfq_key": "rfq-019",
+            "vendor_key": "vendor-02",
+            "rfq_index": 19,
+            "quote_index": 2,
+            "rfq_kind": "published_stuck",
+            "rfq_title": "Bolt tensioning service - turnaround",
+            "vendor_name": "Sulzer Chemtech",
+            "quote_status": "needs_review",
+            "original_filename": "Quote_Sulzer_Chemtech.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-019-vendor-02.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-019/vendor-02",
+                "RFQ: Bolt tensioning service - turnaround",
+                "Vendor: Sulzer Chemtech",
+                "Status profile: needs_review",
+                "Commercial total (USD): 10112.50",
+                "Payment terms: Net 30",
+                "Delivery lead: 9 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-020-A",
+                    "quantity": 3,
+                    "uom": "ea",
+                    "unit_price": 1675,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-020-B",
+                    "quantity": 3,
+                    "uom": "set",
+                    "unit_price": 892.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-020",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 2410,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-020/vendor-00": {
+            "business_key": "rfq-020/vendor-00",
+            "rfq_key": "rfq-020",
+            "vendor_key": "vendor-00",
+            "rfq_index": 20,
+            "quote_index": 0,
+            "rfq_kind": "published_stuck",
+            "rfq_title": "Temporary steam boiler rental (12 MW)",
+            "vendor_name": "Linde Engineering",
+            "quote_status": "needs_review",
+            "original_filename": "Quote_Linde_Engineering.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-020-vendor-00.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-020/vendor-00",
+                "RFQ: Temporary steam boiler rental (12 MW)",
+                "Vendor: Linde Engineering",
+                "Status profile: needs_review",
+                "Commercial total (USD): 7372.50",
+                "Payment terms: Net 30",
+                "Delivery lead: 8 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-021-A",
+                    "quantity": 2,
+                    "uom": "ea",
+                    "unit_price": 1637.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-021-B",
+                    "quantity": 2,
+                    "uom": "set",
+                    "unit_price": 871.25,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-021",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 2355,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-020/vendor-01": {
+            "business_key": "rfq-020/vendor-01",
+            "rfq_key": "rfq-020",
+            "vendor_key": "vendor-01",
+            "rfq_index": 20,
+            "quote_index": 1,
+            "rfq_kind": "published_stuck",
+            "rfq_title": "Temporary steam boiler rental (12 MW)",
+            "vendor_name": "Air Liquide Advanced Separations",
+            "quote_status": "needs_review",
+            "original_filename": "Quote_Air_Liquide_Advanced_Separations.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-020-vendor-01.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-020/vendor-01",
+                "RFQ: Temporary steam boiler rental (12 MW)",
+                "Vendor: Air Liquide Advanced Separations",
+                "Status profile: needs_review",
+                "Commercial total (USD): 10112.50",
+                "Payment terms: Net 30",
+                "Delivery lead: 9 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-021-A",
+                    "quantity": 3,
+                    "uom": "ea",
+                    "unit_price": 1675,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-021-B",
+                    "quantity": 3,
+                    "uom": "set",
+                    "unit_price": 892.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-021",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 2410,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-020/vendor-02": {
+            "business_key": "rfq-020/vendor-02",
+            "rfq_key": "rfq-020",
+            "vendor_key": "vendor-02",
+            "rfq_index": 20,
+            "quote_index": 2,
+            "rfq_kind": "published_stuck",
+            "rfq_title": "Temporary steam boiler rental (12 MW)",
+            "vendor_name": "Technip Energies Norge",
+            "quote_status": "needs_review",
+            "original_filename": "Quote_Technip_Energies_Norge.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-020-vendor-02.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-020/vendor-02",
+                "RFQ: Temporary steam boiler rental (12 MW)",
+                "Vendor: Technip Energies Norge",
+                "Status profile: needs_review",
+                "Commercial total (USD): 12970.00",
+                "Payment terms: Net 30",
+                "Delivery lead: 10 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-021-A",
+                    "quantity": 4,
+                    "uom": "ea",
+                    "unit_price": 1712.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-021-B",
+                    "quantity": 4,
+                    "uom": "set",
+                    "unit_price": 913.75,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-021",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 2465,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-021/vendor-00": {
+            "business_key": "rfq-021/vendor-00",
+            "rfq_key": "rfq-021",
+            "vendor_key": "vendor-00",
+            "rfq_index": 21,
+            "quote_index": 0,
+            "rfq_kind": "published_stuck",
+            "rfq_title": "Scaffold & containment - sulfur pit",
+            "vendor_name": "Burkert Fluid Control",
+            "quote_status": "needs_review",
+            "original_filename": "Quote_Burkert_Fluid_Control.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-021-vendor-00.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-021/vendor-00",
+                "RFQ: Scaffold & containment - sulfur pit",
+                "Vendor: Burkert Fluid Control",
+                "Status profile: needs_review",
+                "Commercial total (USD): 10112.50",
+                "Payment terms: Net 45 EOM",
+                "Delivery lead: 9 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-022-A",
+                    "quantity": 3,
+                    "uom": "ea",
+                    "unit_price": 1675,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-022-B",
+                    "quantity": 3,
+                    "uom": "set",
+                    "unit_price": 892.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-022",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 2410,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-021/vendor-01": {
+            "business_key": "rfq-021/vendor-01",
+            "rfq_key": "rfq-021",
+            "vendor_key": "vendor-01",
+            "rfq_index": 21,
+            "quote_index": 1,
+            "rfq_kind": "published_stuck",
+            "rfq_title": "Scaffold & containment - sulfur pit",
+            "vendor_name": "Swagelok Bergen",
+            "quote_status": "needs_review",
+            "original_filename": "Quote_Swagelok_Bergen.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-021-vendor-01.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-021/vendor-01",
+                "RFQ: Scaffold & containment - sulfur pit",
+                "Vendor: Swagelok Bergen",
+                "Status profile: needs_review",
+                "Commercial total (USD): 12970.00",
+                "Payment terms: Net 45 EOM",
+                "Delivery lead: 10 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-022-A",
+                    "quantity": 4,
+                    "uom": "ea",
+                    "unit_price": 1712.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-022-B",
+                    "quantity": 4,
+                    "uom": "set",
+                    "unit_price": 913.75,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-022",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 2465,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-021/vendor-02": {
+            "business_key": "rfq-021/vendor-02",
+            "rfq_key": "rfq-021",
+            "vendor_key": "vendor-02",
+            "rfq_index": 21,
+            "quote_index": 2,
+            "rfq_kind": "published_stuck",
+            "rfq_title": "Scaffold & containment - sulfur pit",
+            "vendor_name": "Parker Hannifin Scandinavia",
+            "quote_status": "needs_review",
+            "original_filename": "Quote_Parker_Hannifin_Scandinavia.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-021-vendor-02.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-021/vendor-02",
+                "RFQ: Scaffold & containment - sulfur pit",
+                "Vendor: Parker Hannifin Scandinavia",
+                "Status profile: needs_review",
+                "Commercial total (USD): 6140.00",
+                "Payment terms: Net 45 EOM",
+                "Delivery lead: 11 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-022-A",
+                    "quantity": 1,
+                    "uom": "ea",
+                    "unit_price": 1750,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-022-B",
+                    "quantity": 2,
+                    "uom": "set",
+                    "unit_price": 935,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-022",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 2520,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-022/vendor-00": {
+            "business_key": "rfq-022/vendor-00",
+            "rfq_key": "rfq-022",
+            "vendor_key": "vendor-00",
+            "rfq_index": 22,
+            "quote_index": 0,
+            "rfq_kind": "published_stuck",
+            "rfq_title": "NDT phased-array - welds on HP piping",
+            "vendor_name": "FlowServe Nordics AS",
+            "quote_status": "needs_review",
+            "original_filename": "Quote_FlowServe_Nordics_AS.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-022-vendor-00.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-022/vendor-00",
+                "RFQ: NDT phased-array - welds on HP piping",
+                "Vendor: FlowServe Nordics AS",
+                "Status profile: needs_review",
+                "Commercial total (USD): 12970.00",
+                "Payment terms: Net 30",
+                "Delivery lead: 10 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-023-A",
+                    "quantity": 4,
+                    "uom": "ea",
+                    "unit_price": 1712.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-023-B",
+                    "quantity": 4,
+                    "uom": "set",
+                    "unit_price": 913.75,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-023",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 2465,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-022/vendor-01": {
+            "business_key": "rfq-022/vendor-01",
+            "rfq_key": "rfq-022",
+            "vendor_key": "vendor-01",
+            "rfq_index": 22,
+            "quote_index": 1,
+            "rfq_kind": "published_stuck",
+            "rfq_title": "NDT phased-array - welds on HP piping",
+            "vendor_name": "Emerson Fisher Norway",
+            "quote_status": "needs_review",
+            "original_filename": "Quote_Emerson_Fisher_Norway.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-022-vendor-01.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-022/vendor-01",
+                "RFQ: NDT phased-array - welds on HP piping",
+                "Vendor: Emerson Fisher Norway",
+                "Status profile: needs_review",
+                "Commercial total (USD): 6140.00",
+                "Payment terms: Net 30",
+                "Delivery lead: 11 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-023-A",
+                    "quantity": 1,
+                    "uom": "ea",
+                    "unit_price": 1750,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-023-B",
+                    "quantity": 2,
+                    "uom": "set",
+                    "unit_price": 935,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-023",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 2520,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-022/vendor-02": {
+            "business_key": "rfq-022/vendor-02",
+            "rfq_key": "rfq-022",
+            "vendor_key": "vendor-02",
+            "rfq_index": 22,
+            "quote_index": 2,
+            "rfq_kind": "published_stuck",
+            "rfq_title": "NDT phased-array - welds on HP piping",
+            "vendor_name": "Alfa Laval Aalborg",
+            "quote_status": "needs_review",
+            "original_filename": "Quote_Alfa_Laval_Aalborg.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-022-vendor-02.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-022/vendor-02",
+                "RFQ: NDT phased-array - welds on HP piping",
+                "Vendor: Alfa Laval Aalborg",
+                "Status profile: needs_review",
+                "Commercial total (USD): 9018.75",
+                "Payment terms: Net 30",
+                "Delivery lead: 12 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-023-A",
+                    "quantity": 2,
+                    "uom": "ea",
+                    "unit_price": 1787.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-023-B",
+                    "quantity": 3,
+                    "uom": "set",
+                    "unit_price": 956.25,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-023",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 2575,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-023/vendor-00": {
+            "business_key": "rfq-023/vendor-00",
+            "rfq_key": "rfq-023",
+            "vendor_key": "vendor-00",
+            "rfq_index": 23,
+            "quote_index": 0,
+            "rfq_kind": "published_stuck",
+            "rfq_title": "Relief valve recertification (in-situ)",
+            "vendor_name": "Atlas Copco Compressors",
+            "quote_status": "needs_review",
+            "original_filename": "Quote_Atlas_Copco_Compressors.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-023-vendor-00.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-023/vendor-00",
+                "RFQ: Relief valve recertification (in-situ)",
+                "Vendor: Atlas Copco Compressors",
+                "Status profile: needs_review",
+                "Commercial total (USD): 6140.00",
+                "Payment terms: Net 30",
+                "Delivery lead: 11 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-024-A",
+                    "quantity": 1,
+                    "uom": "ea",
+                    "unit_price": 1750,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-024-B",
+                    "quantity": 2,
+                    "uom": "set",
+                    "unit_price": 935,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-024",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 2520,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-023/vendor-01": {
+            "business_key": "rfq-023/vendor-01",
+            "rfq_key": "rfq-023",
+            "vendor_key": "vendor-01",
+            "rfq_index": 23,
+            "quote_index": 1,
+            "rfq_kind": "published_stuck",
+            "rfq_title": "Relief valve recertification (in-situ)",
+            "vendor_name": "Linde Engineering",
+            "quote_status": "needs_review",
+            "original_filename": "Quote_Linde_Engineering.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-023-vendor-01.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-023/vendor-01",
+                "RFQ: Relief valve recertification (in-situ)",
+                "Vendor: Linde Engineering",
+                "Status profile: needs_review",
+                "Commercial total (USD): 9018.75",
+                "Payment terms: Net 30",
+                "Delivery lead: 12 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-024-A",
+                    "quantity": 2,
+                    "uom": "ea",
+                    "unit_price": 1787.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-024-B",
+                    "quantity": 3,
+                    "uom": "set",
+                    "unit_price": 956.25,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-024",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 2575,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-023/vendor-02": {
+            "business_key": "rfq-023/vendor-02",
+            "rfq_key": "rfq-023",
+            "vendor_key": "vendor-02",
+            "rfq_index": 23,
+            "quote_index": 2,
+            "rfq_kind": "published_stuck",
+            "rfq_title": "Relief valve recertification (in-situ)",
+            "vendor_name": "Air Liquide Advanced Separations",
+            "quote_status": "needs_review",
+            "original_filename": "Quote_Air_Liquide_Advanced_Separations.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-023-vendor-02.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-023/vendor-02",
+                "RFQ: Relief valve recertification (in-situ)",
+                "Vendor: Air Liquide Advanced Separations",
+                "Status profile: needs_review",
+                "Commercial total (USD): 12015.00",
+                "Payment terms: Net 30",
+                "Delivery lead: 13 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-024-A",
+                    "quantity": 3,
+                    "uom": "ea",
+                    "unit_price": 1825,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-024-B",
+                    "quantity": 4,
+                    "uom": "set",
+                    "unit_price": 977.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-024",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 2630,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-024/vendor-00": {
+            "business_key": "rfq-024/vendor-00",
+            "rfq_key": "rfq-024",
+            "vendor_key": "vendor-00",
+            "rfq_index": 24,
+            "quote_index": 0,
+            "rfq_kind": "closed_pending",
+            "rfq_title": "Laser alignment - train B compressors",
+            "vendor_name": "SIHI Liquid Ring",
+            "quote_status": "ready",
+            "original_filename": "Quote_SIHI_Liquid_Ring.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-024-vendor-00.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-024/vendor-00",
+                "RFQ: Laser alignment - train B compressors",
+                "Vendor: SIHI Liquid Ring",
+                "Status profile: ready",
+                "Commercial total (USD): 9018.75",
+                "Payment terms: Net 45 EOM",
+                "Delivery lead: 12 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-025-A",
+                    "quantity": 2,
+                    "uom": "ea",
+                    "unit_price": 1787.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-025-B",
+                    "quantity": 3,
+                    "uom": "set",
+                    "unit_price": 956.25,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-025",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 2575,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-024/vendor-01": {
+            "business_key": "rfq-024/vendor-01",
+            "rfq_key": "rfq-024",
+            "vendor_key": "vendor-01",
+            "rfq_index": 24,
+            "quote_index": 1,
+            "rfq_kind": "closed_pending",
+            "rfq_title": "Laser alignment - train B compressors",
+            "vendor_name": "Burkert Fluid Control",
+            "quote_status": "ready",
+            "original_filename": "Quote_Burkert_Fluid_Control.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-024-vendor-01.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-024/vendor-01",
+                "RFQ: Laser alignment - train B compressors",
+                "Vendor: Burkert Fluid Control",
+                "Status profile: ready",
+                "Commercial total (USD): 12015.00",
+                "Payment terms: Net 45 EOM",
+                "Delivery lead: 13 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-025-A",
+                    "quantity": 3,
+                    "uom": "ea",
+                    "unit_price": 1825,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-025-B",
+                    "quantity": 4,
+                    "uom": "set",
+                    "unit_price": 977.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-025",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 2630,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-024/vendor-02": {
+            "business_key": "rfq-024/vendor-02",
+            "rfq_key": "rfq-024",
+            "vendor_key": "vendor-02",
+            "rfq_index": 24,
+            "quote_index": 2,
+            "rfq_kind": "closed_pending",
+            "rfq_title": "Laser alignment - train B compressors",
+            "vendor_name": "Swagelok Bergen",
+            "quote_status": "ready",
+            "original_filename": "Quote_Swagelok_Bergen.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-024-vendor-02.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-024/vendor-02",
+                "RFQ: Laser alignment - train B compressors",
+                "Vendor: Swagelok Bergen",
+                "Status profile: ready",
+                "Commercial total (USD): 12132.50",
+                "Payment terms: Net 45 EOM",
+                "Delivery lead: 14 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-025-A",
+                    "quantity": 4,
+                    "uom": "ea",
+                    "unit_price": 1862.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-025-B",
+                    "quantity": 2,
+                    "uom": "set",
+                    "unit_price": 998.75,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-025",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 2685,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-025/vendor-00": {
+            "business_key": "rfq-025/vendor-00",
+            "rfq_key": "rfq-025",
+            "vendor_key": "vendor-00",
+            "rfq_index": 25,
+            "quote_index": 0,
+            "rfq_kind": "closed_pending",
+            "rfq_title": "Catalyst sampling probes + quills",
+            "vendor_name": "Johnson Matthey NORAM",
+            "quote_status": "ready",
+            "original_filename": "Quote_Johnson_Matthey_NORAM.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-025-vendor-00.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-025/vendor-00",
+                "RFQ: Catalyst sampling probes + quills",
+                "Vendor: Johnson Matthey NORAM",
+                "Status profile: ready",
+                "Commercial total (USD): 12015.00",
+                "Payment terms: Net 30",
+                "Delivery lead: 13 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-026-A",
+                    "quantity": 3,
+                    "uom": "ea",
+                    "unit_price": 1825,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-026-B",
+                    "quantity": 4,
+                    "uom": "set",
+                    "unit_price": 977.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-026",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 2630,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-025/vendor-01": {
+            "business_key": "rfq-025/vendor-01",
+            "rfq_key": "rfq-025",
+            "vendor_key": "vendor-01",
+            "rfq_index": 25,
+            "quote_index": 1,
+            "rfq_kind": "closed_pending",
+            "rfq_title": "Catalyst sampling probes + quills",
+            "vendor_name": "FlowServe Nordics AS",
+            "quote_status": "ready",
+            "original_filename": "Quote_FlowServe_Nordics_AS.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-025-vendor-01.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-025/vendor-01",
+                "RFQ: Catalyst sampling probes + quills",
+                "Vendor: FlowServe Nordics AS",
+                "Status profile: ready",
+                "Commercial total (USD): 12132.50",
+                "Payment terms: Net 30",
+                "Delivery lead: 14 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-026-A",
+                    "quantity": 4,
+                    "uom": "ea",
+                    "unit_price": 1862.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-026-B",
+                    "quantity": 2,
+                    "uom": "set",
+                    "unit_price": 998.75,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-026",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 2685,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-025/vendor-02": {
+            "business_key": "rfq-025/vendor-02",
+            "rfq_key": "rfq-025",
+            "vendor_key": "vendor-02",
+            "rfq_index": 25,
+            "quote_index": 2,
+            "rfq_kind": "closed_pending",
+            "rfq_title": "Catalyst sampling probes + quills",
+            "vendor_name": "Emerson Fisher Norway",
+            "quote_status": "ready",
+            "original_filename": "Quote_Emerson_Fisher_Norway.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-025-vendor-02.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-025/vendor-02",
+                "RFQ: Catalyst sampling probes + quills",
+                "Vendor: Emerson Fisher Norway",
+                "Status profile: ready",
+                "Commercial total (USD): 7700.00",
+                "Payment terms: Net 30",
+                "Delivery lead: 6 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-026-A",
+                    "quantity": 1,
+                    "uom": "ea",
+                    "unit_price": 1900,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-026-B",
+                    "quantity": 3,
+                    "uom": "set",
+                    "unit_price": 1020,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-026",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 2740,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-025/vendor-03": {
+            "business_key": "rfq-025/vendor-03",
+            "rfq_key": "rfq-025",
+            "vendor_key": "vendor-03",
+            "rfq_index": 25,
+            "quote_index": 3,
+            "rfq_kind": "closed_pending",
+            "rfq_title": "Catalyst sampling probes + quills",
+            "vendor_name": "Alfa Laval Aalborg",
+            "quote_status": "ready",
+            "original_filename": "Quote_Alfa_Laval_Aalborg.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-025-vendor-03.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-025/vendor-03",
+                "RFQ: Catalyst sampling probes + quills",
+                "Vendor: Alfa Laval Aalborg",
+                "Status profile: ready",
+                "Commercial total (USD): 10835.00",
+                "Payment terms: Net 30",
+                "Delivery lead: 7 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-026-A",
+                    "quantity": 2,
+                    "uom": "ea",
+                    "unit_price": 1937.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-026-B",
+                    "quantity": 4,
+                    "uom": "set",
+                    "unit_price": 1041.25,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-026",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 2795,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-026/vendor-00": {
+            "business_key": "rfq-026/vendor-00",
+            "rfq_key": "rfq-026",
+            "vendor_key": "vendor-00",
+            "rfq_index": 26,
+            "quote_index": 0,
+            "rfq_kind": "closed_pending",
+            "rfq_title": "Sorbent media - mercury guard bed",
+            "vendor_name": "Grundfos Process Nordic",
+            "quote_status": "ready",
+            "original_filename": "Quote_Grundfos_Process_Nordic.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-026-vendor-00.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-026/vendor-00",
+                "RFQ: Sorbent media - mercury guard bed",
+                "Vendor: Grundfos Process Nordic",
+                "Status profile: ready",
+                "Commercial total (USD): 12132.50",
+                "Payment terms: Net 30",
+                "Delivery lead: 14 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-027-A",
+                    "quantity": 4,
+                    "uom": "ea",
+                    "unit_price": 1862.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-027-B",
+                    "quantity": 2,
+                    "uom": "set",
+                    "unit_price": 998.75,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-027",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 2685,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-026/vendor-01": {
+            "business_key": "rfq-026/vendor-01",
+            "rfq_key": "rfq-026",
+            "vendor_key": "vendor-01",
+            "rfq_index": 26,
+            "quote_index": 1,
+            "rfq_kind": "closed_pending",
+            "rfq_title": "Sorbent media - mercury guard bed",
+            "vendor_name": "Atlas Copco Compressors",
+            "quote_status": "ready",
+            "original_filename": "Quote_Atlas_Copco_Compressors.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-026-vendor-01.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-026/vendor-01",
+                "RFQ: Sorbent media - mercury guard bed",
+                "Vendor: Atlas Copco Compressors",
+                "Status profile: ready",
+                "Commercial total (USD): 7700.00",
+                "Payment terms: Net 30",
+                "Delivery lead: 6 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-027-A",
+                    "quantity": 1,
+                    "uom": "ea",
+                    "unit_price": 1900,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-027-B",
+                    "quantity": 3,
+                    "uom": "set",
+                    "unit_price": 1020,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-027",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 2740,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-026/vendor-02": {
+            "business_key": "rfq-026/vendor-02",
+            "rfq_key": "rfq-026",
+            "vendor_key": "vendor-02",
+            "rfq_index": 26,
+            "quote_index": 2,
+            "rfq_kind": "closed_pending",
+            "rfq_title": "Sorbent media - mercury guard bed",
+            "vendor_name": "Linde Engineering",
+            "quote_status": "ready",
+            "original_filename": "Quote_Linde_Engineering.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-026-vendor-02.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-026/vendor-02",
+                "RFQ: Sorbent media - mercury guard bed",
+                "Vendor: Linde Engineering",
+                "Status profile: ready",
+                "Commercial total (USD): 10835.00",
+                "Payment terms: Net 30",
+                "Delivery lead: 7 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-027-A",
+                    "quantity": 2,
+                    "uom": "ea",
+                    "unit_price": 1937.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-027-B",
+                    "quantity": 4,
+                    "uom": "set",
+                    "unit_price": 1041.25,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-027",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 2795,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-027/vendor-00": {
+            "business_key": "rfq-027/vendor-00",
+            "rfq_key": "rfq-027",
+            "vendor_key": "vendor-00",
+            "rfq_index": 27,
+            "quote_index": 0,
+            "rfq_kind": "closed_pending",
+            "rfq_title": "Oxygen analyzer cells - reformer feed",
+            "vendor_name": "Hayward Tyler (IMO) Pumps",
+            "quote_status": "ready",
+            "original_filename": "Quote_Hayward_Tyler_IMO_Pumps.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-027-vendor-00.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-027/vendor-00",
+                "RFQ: Oxygen analyzer cells - reformer feed",
+                "Vendor: Hayward Tyler (IMO) Pumps",
+                "Status profile: ready",
+                "Commercial total (USD): 7700.00",
+                "Payment terms: Net 45 EOM",
+                "Delivery lead: 6 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-028-A",
+                    "quantity": 1,
+                    "uom": "ea",
+                    "unit_price": 1900,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-028-B",
+                    "quantity": 3,
+                    "uom": "set",
+                    "unit_price": 1020,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-028",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 2740,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-027/vendor-01": {
+            "business_key": "rfq-027/vendor-01",
+            "rfq_key": "rfq-027",
+            "vendor_key": "vendor-01",
+            "rfq_index": 27,
+            "quote_index": 1,
+            "rfq_kind": "closed_pending",
+            "rfq_title": "Oxygen analyzer cells - reformer feed",
+            "vendor_name": "SIHI Liquid Ring",
+            "quote_status": "ready",
+            "original_filename": "Quote_SIHI_Liquid_Ring.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-027-vendor-01.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-027/vendor-01",
+                "RFQ: Oxygen analyzer cells - reformer feed",
+                "Vendor: SIHI Liquid Ring",
+                "Status profile: ready",
+                "Commercial total (USD): 10835.00",
+                "Payment terms: Net 45 EOM",
+                "Delivery lead: 7 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-028-A",
+                    "quantity": 2,
+                    "uom": "ea",
+                    "unit_price": 1937.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-028-B",
+                    "quantity": 4,
+                    "uom": "set",
+                    "unit_price": 1041.25,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-028",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 2795,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-027/vendor-02": {
+            "business_key": "rfq-027/vendor-02",
+            "rfq_key": "rfq-027",
+            "vendor_key": "vendor-02",
+            "rfq_index": 27,
+            "quote_index": 2,
+            "rfq_kind": "closed_pending",
+            "rfq_title": "Oxygen analyzer cells - reformer feed",
+            "vendor_name": "Burkert Fluid Control",
+            "quote_status": "ready",
+            "original_filename": "Quote_Burkert_Fluid_Control.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-027-vendor-02.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-027/vendor-02",
+                "RFQ: Oxygen analyzer cells - reformer feed",
+                "Vendor: Burkert Fluid Control",
+                "Status profile: ready",
+                "Commercial total (USD): 10900.00",
+                "Payment terms: Net 45 EOM",
+                "Delivery lead: 8 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-028-A",
+                    "quantity": 3,
+                    "uom": "ea",
+                    "unit_price": 1975,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-028-B",
+                    "quantity": 2,
+                    "uom": "set",
+                    "unit_price": 1062.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-028",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 2850,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-027/vendor-03": {
+            "business_key": "rfq-027/vendor-03",
+            "rfq_key": "rfq-027",
+            "vendor_key": "vendor-03",
+            "rfq_index": 27,
+            "quote_index": 3,
+            "rfq_kind": "closed_pending",
+            "rfq_title": "Oxygen analyzer cells - reformer feed",
+            "vendor_name": "Swagelok Bergen",
+            "quote_status": "ready",
+            "original_filename": "Quote_Swagelok_Bergen.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-027-vendor-03.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-027/vendor-03",
+                "RFQ: Oxygen analyzer cells - reformer feed",
+                "Vendor: Swagelok Bergen",
+                "Status profile: ready",
+                "Commercial total (USD): 14206.25",
+                "Payment terms: Net 45 EOM",
+                "Delivery lead: 9 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-028-A",
+                    "quantity": 4,
+                    "uom": "ea",
+                    "unit_price": 2012.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-028-B",
+                    "quantity": 3,
+                    "uom": "set",
+                    "unit_price": 1083.75,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-028",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 2905,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-028/vendor-00": {
+            "business_key": "rfq-028/vendor-00",
+            "rfq_key": "rfq-028",
+            "vendor_key": "vendor-00",
+            "rfq_index": 28,
+            "quote_index": 0,
+            "rfq_kind": "closed_pending",
+            "rfq_title": "Submersible sump pumps - containment sump",
+            "vendor_name": "Clariant Catalysts",
+            "quote_status": "ready",
+            "original_filename": "Quote_Clariant_Catalysts.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-028-vendor-00.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-028/vendor-00",
+                "RFQ: Submersible sump pumps - containment sump",
+                "Vendor: Clariant Catalysts",
+                "Status profile: ready",
+                "Commercial total (USD): 10835.00",
+                "Payment terms: Net 30",
+                "Delivery lead: 7 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-029-A",
+                    "quantity": 2,
+                    "uom": "ea",
+                    "unit_price": 1937.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-029-B",
+                    "quantity": 4,
+                    "uom": "set",
+                    "unit_price": 1041.25,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-029",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 2795,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-028/vendor-01": {
+            "business_key": "rfq-028/vendor-01",
+            "rfq_key": "rfq-028",
+            "vendor_key": "vendor-01",
+            "rfq_index": 28,
+            "quote_index": 1,
+            "rfq_kind": "closed_pending",
+            "rfq_title": "Submersible sump pumps - containment sump",
+            "vendor_name": "Johnson Matthey NORAM",
+            "quote_status": "ready",
+            "original_filename": "Quote_Johnson_Matthey_NORAM.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-028-vendor-01.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-028/vendor-01",
+                "RFQ: Submersible sump pumps - containment sump",
+                "Vendor: Johnson Matthey NORAM",
+                "Status profile: ready",
+                "Commercial total (USD): 10900.00",
+                "Payment terms: Net 30",
+                "Delivery lead: 8 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-029-A",
+                    "quantity": 3,
+                    "uom": "ea",
+                    "unit_price": 1975,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-029-B",
+                    "quantity": 2,
+                    "uom": "set",
+                    "unit_price": 1062.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-029",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 2850,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-028/vendor-02": {
+            "business_key": "rfq-028/vendor-02",
+            "rfq_key": "rfq-028",
+            "vendor_key": "vendor-02",
+            "rfq_index": 28,
+            "quote_index": 2,
+            "rfq_kind": "closed_pending",
+            "rfq_title": "Submersible sump pumps - containment sump",
+            "vendor_name": "FlowServe Nordics AS",
+            "quote_status": "ready",
+            "original_filename": "Quote_FlowServe_Nordics_AS.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-028-vendor-02.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-028/vendor-02",
+                "RFQ: Submersible sump pumps - containment sump",
+                "Vendor: FlowServe Nordics AS",
+                "Status profile: ready",
+                "Commercial total (USD): 14206.25",
+                "Payment terms: Net 30",
+                "Delivery lead: 9 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-029-A",
+                    "quantity": 4,
+                    "uom": "ea",
+                    "unit_price": 2012.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-029-B",
+                    "quantity": 3,
+                    "uom": "set",
+                    "unit_price": 1083.75,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-029",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 2905,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-029/vendor-00": {
+            "business_key": "rfq-029/vendor-00",
+            "rfq_key": "rfq-029",
+            "vendor_key": "vendor-00",
+            "rfq_index": 29,
+            "quote_index": 0,
+            "rfq_kind": "closed_pending",
+            "rfq_title": "Gasket kit ANSI 900 - RF joint set",
+            "vendor_name": "Donaldson Process Filtration",
+            "quote_status": "ready",
+            "original_filename": "Quote_Donaldson_Process_Filtration.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-029-vendor-00.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-029/vendor-00",
+                "RFQ: Gasket kit ANSI 900 - RF joint set",
+                "Vendor: Donaldson Process Filtration",
+                "Status profile: ready",
+                "Commercial total (USD): 10900.00",
+                "Payment terms: Net 30",
+                "Delivery lead: 8 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-030-A",
+                    "quantity": 3,
+                    "uom": "ea",
+                    "unit_price": 1975,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-030-B",
+                    "quantity": 2,
+                    "uom": "set",
+                    "unit_price": 1062.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-030",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 2850,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-029/vendor-01": {
+            "business_key": "rfq-029/vendor-01",
+            "rfq_key": "rfq-029",
+            "vendor_key": "vendor-01",
+            "rfq_index": 29,
+            "quote_index": 1,
+            "rfq_kind": "closed_pending",
+            "rfq_title": "Gasket kit ANSI 900 - RF joint set",
+            "vendor_name": "Grundfos Process Nordic",
+            "quote_status": "ready",
+            "original_filename": "Quote_Grundfos_Process_Nordic.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-029-vendor-01.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-029/vendor-01",
+                "RFQ: Gasket kit ANSI 900 - RF joint set",
+                "Vendor: Grundfos Process Nordic",
+                "Status profile: ready",
+                "Commercial total (USD): 14206.25",
+                "Payment terms: Net 30",
+                "Delivery lead: 9 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-030-A",
+                    "quantity": 4,
+                    "uom": "ea",
+                    "unit_price": 2012.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-030-B",
+                    "quantity": 3,
+                    "uom": "set",
+                    "unit_price": 1083.75,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-030",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 2905,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-029/vendor-02": {
+            "business_key": "rfq-029/vendor-02",
+            "rfq_key": "rfq-029",
+            "vendor_key": "vendor-02",
+            "rfq_index": 29,
+            "quote_index": 2,
+            "rfq_kind": "closed_pending",
+            "rfq_title": "Gasket kit ANSI 900 - RF joint set",
+            "vendor_name": "Atlas Copco Compressors",
+            "quote_status": "ready",
+            "original_filename": "Quote_Atlas_Copco_Compressors.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-029-vendor-02.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-029/vendor-02",
+                "RFQ: Gasket kit ANSI 900 - RF joint set",
+                "Vendor: Atlas Copco Compressors",
+                "Status profile: ready",
+                "Commercial total (USD): 9430.00",
+                "Payment terms: Net 30",
+                "Delivery lead: 10 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-030-A",
+                    "quantity": 1,
+                    "uom": "ea",
+                    "unit_price": 2050,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-030-B",
+                    "quantity": 4,
+                    "uom": "set",
+                    "unit_price": 1105,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-030",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 2960,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-029/vendor-03": {
+            "business_key": "rfq-029/vendor-03",
+            "rfq_key": "rfq-029",
+            "vendor_key": "vendor-03",
+            "rfq_index": 29,
+            "quote_index": 3,
+            "rfq_kind": "closed_pending",
+            "rfq_title": "Gasket kit ANSI 900 - RF joint set",
+            "vendor_name": "Linde Engineering",
+            "quote_status": "ready",
+            "original_filename": "Quote_Linde_Engineering.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-029-vendor-03.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-029/vendor-03",
+                "RFQ: Gasket kit ANSI 900 - RF joint set",
+                "Vendor: Linde Engineering",
+                "Status profile: ready",
+                "Commercial total (USD): 9442.50",
+                "Payment terms: Net 30",
+                "Delivery lead: 11 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-030-A",
+                    "quantity": 2,
+                    "uom": "ea",
+                    "unit_price": 2087.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-030-B",
+                    "quantity": 2,
+                    "uom": "set",
+                    "unit_price": 1126.25,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-030",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 3015,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-030/vendor-00": {
+            "business_key": "rfq-030/vendor-00",
+            "rfq_key": "rfq-030",
+            "vendor_key": "vendor-00",
+            "rfq_index": 30,
+            "quote_index": 0,
+            "rfq_kind": "closed_pending",
+            "rfq_title": "HP control valves Class 900 - ethylene rundown (lot 31)",
+            "vendor_name": "Worley Chemetics",
+            "quote_status": "ready",
+            "original_filename": "Quote_Worley_Chemetics.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-030-vendor-00.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-030/vendor-00",
+                "RFQ: HP control valves Class 900 - ethylene rundown (lot 31)",
+                "Vendor: Worley Chemetics",
+                "Status profile: ready",
+                "Commercial total (USD): 14206.25",
+                "Payment terms: Net 45 EOM",
+                "Delivery lead: 9 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-031-A",
+                    "quantity": 4,
+                    "uom": "ea",
+                    "unit_price": 2012.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-031-B",
+                    "quantity": 3,
+                    "uom": "set",
+                    "unit_price": 1083.75,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-031",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 2905,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-030/vendor-01": {
+            "business_key": "rfq-030/vendor-01",
+            "rfq_key": "rfq-030",
+            "vendor_key": "vendor-01",
+            "rfq_index": 30,
+            "quote_index": 1,
+            "rfq_kind": "closed_pending",
+            "rfq_title": "HP control valves Class 900 - ethylene rundown (lot 31)",
+            "vendor_name": "Hayward Tyler (IMO) Pumps",
+            "quote_status": "ready",
+            "original_filename": "Quote_Hayward_Tyler_IMO_Pumps.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-030-vendor-01.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-030/vendor-01",
+                "RFQ: HP control valves Class 900 - ethylene rundown (lot 31)",
+                "Vendor: Hayward Tyler (IMO) Pumps",
+                "Status profile: ready",
+                "Commercial total (USD): 9430.00",
+                "Payment terms: Net 45 EOM",
+                "Delivery lead: 10 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-031-A",
+                    "quantity": 1,
+                    "uom": "ea",
+                    "unit_price": 2050,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-031-B",
+                    "quantity": 4,
+                    "uom": "set",
+                    "unit_price": 1105,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-031",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 2960,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-030/vendor-02": {
+            "business_key": "rfq-030/vendor-02",
+            "rfq_key": "rfq-030",
+            "vendor_key": "vendor-02",
+            "rfq_index": 30,
+            "quote_index": 2,
+            "rfq_kind": "closed_pending",
+            "rfq_title": "HP control valves Class 900 - ethylene rundown (lot 31)",
+            "vendor_name": "SIHI Liquid Ring",
+            "quote_status": "ready",
+            "original_filename": "Quote_SIHI_Liquid_Ring.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-030-vendor-02.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-030/vendor-02",
+                "RFQ: HP control valves Class 900 - ethylene rundown (lot 31)",
+                "Vendor: SIHI Liquid Ring",
+                "Status profile: ready",
+                "Commercial total (USD): 9442.50",
+                "Payment terms: Net 45 EOM",
+                "Delivery lead: 11 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-031-A",
+                    "quantity": 2,
+                    "uom": "ea",
+                    "unit_price": 2087.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-031-B",
+                    "quantity": 2,
+                    "uom": "set",
+                    "unit_price": 1126.25,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-031",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 3015,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-031/vendor-00": {
+            "business_key": "rfq-031/vendor-00",
+            "rfq_key": "rfq-031",
+            "vendor_key": "vendor-00",
+            "rfq_index": 31,
+            "quote_index": 0,
+            "rfq_kind": "closed_pending",
+            "rfq_title": "Mechanical seal upgrade - cracked gas compressor (lot 32)",
+            "vendor_name": "BASF Catalysts",
+            "quote_status": "ready",
+            "original_filename": "Quote_BASF_Catalysts.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-031-vendor-00.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-031/vendor-00",
+                "RFQ: Mechanical seal upgrade - cracked gas compressor (lot 32)",
+                "Vendor: BASF Catalysts",
+                "Status profile: ready",
+                "Commercial total (USD): 9430.00",
+                "Payment terms: Net 30",
+                "Delivery lead: 10 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-032-A",
+                    "quantity": 1,
+                    "uom": "ea",
+                    "unit_price": 2050,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-032-B",
+                    "quantity": 4,
+                    "uom": "set",
+                    "unit_price": 1105,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-032",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 2960,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-031/vendor-01": {
+            "business_key": "rfq-031/vendor-01",
+            "rfq_key": "rfq-031",
+            "vendor_key": "vendor-01",
+            "rfq_index": 31,
+            "quote_index": 1,
+            "rfq_kind": "closed_pending",
+            "rfq_title": "Mechanical seal upgrade - cracked gas compressor (lot 32)",
+            "vendor_name": "Clariant Catalysts",
+            "quote_status": "ready",
+            "original_filename": "Quote_Clariant_Catalysts.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-031-vendor-01.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-031/vendor-01",
+                "RFQ: Mechanical seal upgrade - cracked gas compressor (lot 32)",
+                "Vendor: Clariant Catalysts",
+                "Status profile: ready",
+                "Commercial total (USD): 9442.50",
+                "Payment terms: Net 30",
+                "Delivery lead: 11 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-032-A",
+                    "quantity": 2,
+                    "uom": "ea",
+                    "unit_price": 2087.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-032-B",
+                    "quantity": 2,
+                    "uom": "set",
+                    "unit_price": 1126.25,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-032",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 3015,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-031/vendor-02": {
+            "business_key": "rfq-031/vendor-02",
+            "rfq_key": "rfq-031",
+            "vendor_key": "vendor-02",
+            "rfq_index": 31,
+            "quote_index": 2,
+            "rfq_kind": "closed_pending",
+            "rfq_title": "Mechanical seal upgrade - cracked gas compressor (lot 32)",
+            "vendor_name": "Johnson Matthey NORAM",
+            "quote_status": "ready",
+            "original_filename": "Quote_Johnson_Matthey_NORAM.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-031-vendor-02.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-031/vendor-02",
+                "RFQ: Mechanical seal upgrade - cracked gas compressor (lot 32)",
+                "Vendor: Johnson Matthey NORAM",
+                "Status profile: ready",
+                "Commercial total (USD): 12887.50",
+                "Payment terms: Net 30",
+                "Delivery lead: 12 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-032-A",
+                    "quantity": 3,
+                    "uom": "ea",
+                    "unit_price": 2125,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-032-B",
+                    "quantity": 3,
+                    "uom": "set",
+                    "unit_price": 1147.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-032",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 3070,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-031/vendor-03": {
+            "business_key": "rfq-031/vendor-03",
+            "rfq_key": "rfq-031",
+            "vendor_key": "vendor-03",
+            "rfq_index": 31,
+            "quote_index": 3,
+            "rfq_kind": "closed_pending",
+            "rfq_title": "Mechanical seal upgrade - cracked gas compressor (lot 32)",
+            "vendor_name": "FlowServe Nordics AS",
+            "quote_status": "ready",
+            "original_filename": "Quote_FlowServe_Nordics_AS.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-031-vendor-03.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-031/vendor-03",
+                "RFQ: Mechanical seal upgrade - cracked gas compressor (lot 32)",
+                "Vendor: FlowServe Nordics AS",
+                "Status profile: ready",
+                "Commercial total (USD): 16450.00",
+                "Payment terms: Net 30",
+                "Delivery lead: 13 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-032-A",
+                    "quantity": 4,
+                    "uom": "ea",
+                    "unit_price": 2162.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-032-B",
+                    "quantity": 4,
+                    "uom": "set",
+                    "unit_price": 1168.75,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-032",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 3125,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-032/vendor-00": {
+            "business_key": "rfq-032/vendor-00",
+            "rfq_key": "rfq-032",
+            "vendor_key": "vendor-00",
+            "rfq_index": 32,
+            "quote_index": 0,
+            "rfq_kind": "awarded",
+            "rfq_title": "Sulfuric acid catalyst reload (Claus tail gas) (lot 33)",
+            "vendor_name": "John Zink Hamworthy Combustion",
+            "quote_status": "ready",
+            "original_filename": "Quote_John_Zink_Hamworthy_Combustion.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-032-vendor-00.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-032/vendor-00",
+                "RFQ: Sulfuric acid catalyst reload (Claus tail gas) (lot 33)",
+                "Vendor: John Zink Hamworthy Combustion",
+                "Status profile: ready",
+                "Commercial total (USD): 9442.50",
+                "Payment terms: Net 30",
+                "Delivery lead: 11 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-033-A",
+                    "quantity": 2,
+                    "uom": "ea",
+                    "unit_price": 2087.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-033-B",
+                    "quantity": 2,
+                    "uom": "set",
+                    "unit_price": 1126.25,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-033",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 3015,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-032/vendor-01": {
+            "business_key": "rfq-032/vendor-01",
+            "rfq_key": "rfq-032",
+            "vendor_key": "vendor-01",
+            "rfq_index": 32,
+            "quote_index": 1,
+            "rfq_kind": "awarded",
+            "rfq_title": "Sulfuric acid catalyst reload (Claus tail gas) (lot 33)",
+            "vendor_name": "Donaldson Process Filtration",
+            "quote_status": "ready",
+            "original_filename": "Quote_Donaldson_Process_Filtration.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-032-vendor-01.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-032/vendor-01",
+                "RFQ: Sulfuric acid catalyst reload (Claus tail gas) (lot 33)",
+                "Vendor: Donaldson Process Filtration",
+                "Status profile: ready",
+                "Commercial total (USD): 12887.50",
+                "Payment terms: Net 30",
+                "Delivery lead: 12 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-033-A",
+                    "quantity": 3,
+                    "uom": "ea",
+                    "unit_price": 2125,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-033-B",
+                    "quantity": 3,
+                    "uom": "set",
+                    "unit_price": 1147.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-033",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 3070,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-032/vendor-02": {
+            "business_key": "rfq-032/vendor-02",
+            "rfq_key": "rfq-032",
+            "vendor_key": "vendor-02",
+            "rfq_index": 32,
+            "quote_index": 2,
+            "rfq_kind": "awarded",
+            "rfq_title": "Sulfuric acid catalyst reload (Claus tail gas) (lot 33)",
+            "vendor_name": "Grundfos Process Nordic",
+            "quote_status": "ready",
+            "original_filename": "Quote_Grundfos_Process_Nordic.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-032-vendor-02.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-032/vendor-02",
+                "RFQ: Sulfuric acid catalyst reload (Claus tail gas) (lot 33)",
+                "Vendor: Grundfos Process Nordic",
+                "Status profile: ready",
+                "Commercial total (USD): 16450.00",
+                "Payment terms: Net 30",
+                "Delivery lead: 13 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-033-A",
+                    "quantity": 4,
+                    "uom": "ea",
+                    "unit_price": 2162.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-033-B",
+                    "quantity": 4,
+                    "uom": "set",
+                    "unit_price": 1168.75,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-033",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 3125,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-032/vendor-03": {
+            "business_key": "rfq-032/vendor-03",
+            "rfq_key": "rfq-032",
+            "vendor_key": "vendor-03",
+            "rfq_index": 32,
+            "quote_index": 3,
+            "rfq_kind": "awarded",
+            "rfq_title": "Sulfuric acid catalyst reload (Claus tail gas) (lot 33)",
+            "vendor_name": "Atlas Copco Compressors",
+            "quote_status": "ready",
+            "original_filename": "Quote_Atlas_Copco_Compressors.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-032-vendor-03.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-032/vendor-03",
+                "RFQ: Sulfuric acid catalyst reload (Claus tail gas) (lot 33)",
+                "Vendor: Atlas Copco Compressors",
+                "Status profile: ready",
+                "Commercial total (USD): 7760.00",
+                "Payment terms: Net 30",
+                "Delivery lead: 14 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-033-A",
+                    "quantity": 1,
+                    "uom": "ea",
+                    "unit_price": 2200,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-033-B",
+                    "quantity": 2,
+                    "uom": "set",
+                    "unit_price": 1190,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-033",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 3180,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-032/vendor-04": {
+            "business_key": "rfq-032/vendor-04",
+            "rfq_key": "rfq-032",
+            "vendor_key": "vendor-04",
+            "rfq_index": 32,
+            "quote_index": 4,
+            "rfq_kind": "awarded",
+            "rfq_title": "Sulfuric acid catalyst reload (Claus tail gas) (lot 33)",
+            "vendor_name": "Linde Engineering",
+            "quote_status": "ready",
+            "original_filename": "Quote_Linde_Engineering.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-032-vendor-04.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-032/vendor-04",
+                "RFQ: Sulfuric acid catalyst reload (Claus tail gas) (lot 33)",
+                "Vendor: Linde Engineering",
+                "Status profile: ready",
+                "Commercial total (USD): 11343.75",
+                "Payment terms: Net 30",
+                "Delivery lead: 6 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-033-A",
+                    "quantity": 2,
+                    "uom": "ea",
+                    "unit_price": 2237.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-033-B",
+                    "quantity": 3,
+                    "uom": "set",
+                    "unit_price": 1211.25,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-033",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 3235,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-033/vendor-00": {
+            "business_key": "rfq-033/vendor-00",
+            "rfq_key": "rfq-033",
+            "vendor_key": "vendor-00",
+            "rfq_index": 33,
+            "quote_index": 0,
+            "rfq_kind": "awarded",
+            "rfq_title": "Demineralized water polisher resin (lot 34)",
+            "vendor_name": "Wood PLC Norway",
+            "quote_status": "ready",
+            "original_filename": "Quote_Wood_PLC_Norway.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-033-vendor-00.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-033/vendor-00",
+                "RFQ: Demineralized water polisher resin (lot 34)",
+                "Vendor: Wood PLC Norway",
+                "Status profile: ready",
+                "Commercial total (USD): 12887.50",
+                "Payment terms: Net 45 EOM",
+                "Delivery lead: 12 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-034-A",
+                    "quantity": 3,
+                    "uom": "ea",
+                    "unit_price": 2125,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-034-B",
+                    "quantity": 3,
+                    "uom": "set",
+                    "unit_price": 1147.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-034",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 3070,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-033/vendor-01": {
+            "business_key": "rfq-033/vendor-01",
+            "rfq_key": "rfq-033",
+            "vendor_key": "vendor-01",
+            "rfq_index": 33,
+            "quote_index": 1,
+            "rfq_kind": "awarded",
+            "rfq_title": "Demineralized water polisher resin (lot 34)",
+            "vendor_name": "Worley Chemetics",
+            "quote_status": "ready",
+            "original_filename": "Quote_Worley_Chemetics.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-033-vendor-01.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-033/vendor-01",
+                "RFQ: Demineralized water polisher resin (lot 34)",
+                "Vendor: Worley Chemetics",
+                "Status profile: ready",
+                "Commercial total (USD): 16450.00",
+                "Payment terms: Net 45 EOM",
+                "Delivery lead: 13 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-034-A",
+                    "quantity": 4,
+                    "uom": "ea",
+                    "unit_price": 2162.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-034-B",
+                    "quantity": 4,
+                    "uom": "set",
+                    "unit_price": 1168.75,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-034",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 3125,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-033/vendor-02": {
+            "business_key": "rfq-033/vendor-02",
+            "rfq_key": "rfq-033",
+            "vendor_key": "vendor-02",
+            "rfq_index": 33,
+            "quote_index": 2,
+            "rfq_kind": "awarded",
+            "rfq_title": "Demineralized water polisher resin (lot 34)",
+            "vendor_name": "Hayward Tyler (IMO) Pumps",
+            "quote_status": "ready",
+            "original_filename": "Quote_Hayward_Tyler_IMO_Pumps.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-033-vendor-02.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-033/vendor-02",
+                "RFQ: Demineralized water polisher resin (lot 34)",
+                "Vendor: Hayward Tyler (IMO) Pumps",
+                "Status profile: ready",
+                "Commercial total (USD): 7760.00",
+                "Payment terms: Net 45 EOM",
+                "Delivery lead: 14 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-034-A",
+                    "quantity": 1,
+                    "uom": "ea",
+                    "unit_price": 2200,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-034-B",
+                    "quantity": 2,
+                    "uom": "set",
+                    "unit_price": 1190,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-034",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 3180,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-034/vendor-00": {
+            "business_key": "rfq-034/vendor-00",
+            "rfq_key": "rfq-034",
+            "vendor_key": "vendor-00",
+            "rfq_index": 34,
+            "quote_index": 0,
+            "rfq_kind": "awarded",
+            "rfq_title": "Thermal oxidizer burner management system (lot 35)",
+            "vendor_name": "Honeywell UOP",
+            "quote_status": "ready",
+            "original_filename": "Quote_Honeywell_UOP.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-034-vendor-00.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-034/vendor-00",
+                "RFQ: Thermal oxidizer burner management system (lot 35)",
+                "Vendor: Honeywell UOP",
+                "Status profile: ready",
+                "Commercial total (USD): 16450.00",
+                "Payment terms: Net 30",
+                "Delivery lead: 13 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-035-A",
+                    "quantity": 4,
+                    "uom": "ea",
+                    "unit_price": 2162.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-035-B",
+                    "quantity": 4,
+                    "uom": "set",
+                    "unit_price": 1168.75,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-035",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 3125,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-034/vendor-01": {
+            "business_key": "rfq-034/vendor-01",
+            "rfq_key": "rfq-034",
+            "vendor_key": "vendor-01",
+            "rfq_index": 34,
+            "quote_index": 1,
+            "rfq_kind": "awarded",
+            "rfq_title": "Thermal oxidizer burner management system (lot 35)",
+            "vendor_name": "BASF Catalysts",
+            "quote_status": "ready",
+            "original_filename": "Quote_BASF_Catalysts.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-034-vendor-01.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-034/vendor-01",
+                "RFQ: Thermal oxidizer burner management system (lot 35)",
+                "Vendor: BASF Catalysts",
+                "Status profile: ready",
+                "Commercial total (USD): 7760.00",
+                "Payment terms: Net 30",
+                "Delivery lead: 14 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-035-A",
+                    "quantity": 1,
+                    "uom": "ea",
+                    "unit_price": 2200,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-035-B",
+                    "quantity": 2,
+                    "uom": "set",
+                    "unit_price": 1190,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-035",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 3180,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-034/vendor-02": {
+            "business_key": "rfq-034/vendor-02",
+            "rfq_key": "rfq-034",
+            "vendor_key": "vendor-02",
+            "rfq_index": 34,
+            "quote_index": 2,
+            "rfq_kind": "awarded",
+            "rfq_title": "Thermal oxidizer burner management system (lot 35)",
+            "vendor_name": "Clariant Catalysts",
+            "quote_status": "ready",
+            "original_filename": "Quote_Clariant_Catalysts.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-034-vendor-02.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-034/vendor-02",
+                "RFQ: Thermal oxidizer burner management system (lot 35)",
+                "Vendor: Clariant Catalysts",
+                "Status profile: ready",
+                "Commercial total (USD): 11343.75",
+                "Payment terms: Net 30",
+                "Delivery lead: 6 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-035-A",
+                    "quantity": 2,
+                    "uom": "ea",
+                    "unit_price": 2237.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-035-B",
+                    "quantity": 3,
+                    "uom": "set",
+                    "unit_price": 1211.25,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-035",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 3235,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-034/vendor-03": {
+            "business_key": "rfq-034/vendor-03",
+            "rfq_key": "rfq-034",
+            "vendor_key": "vendor-03",
+            "rfq_index": 34,
+            "quote_index": 3,
+            "rfq_kind": "awarded",
+            "rfq_title": "Thermal oxidizer burner management system (lot 35)",
+            "vendor_name": "Johnson Matthey NORAM",
+            "quote_status": "ready",
+            "original_filename": "Quote_Johnson_Matthey_NORAM.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-034-vendor-03.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-034/vendor-03",
+                "RFQ: Thermal oxidizer burner management system (lot 35)",
+                "Vendor: Johnson Matthey NORAM",
+                "Status profile: ready",
+                "Commercial total (USD): 15045.00",
+                "Payment terms: Net 30",
+                "Delivery lead: 7 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-035-A",
+                    "quantity": 3,
+                    "uom": "ea",
+                    "unit_price": 2275,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-035-B",
+                    "quantity": 4,
+                    "uom": "set",
+                    "unit_price": 1232.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-035",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 3290,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-035/vendor-00": {
+            "business_key": "rfq-035/vendor-00",
+            "rfq_key": "rfq-035",
+            "vendor_key": "vendor-00",
+            "rfq_index": 35,
+            "quote_index": 0,
+            "rfq_kind": "awarded",
+            "rfq_title": "Stainless tank internals - agitator + baffles (lot 36)",
+            "vendor_name": "Sulzer Chemtech",
+            "quote_status": "ready",
+            "original_filename": "Quote_Sulzer_Chemtech.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-035-vendor-00.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-035/vendor-00",
+                "RFQ: Stainless tank internals - agitator + baffles (lot 36)",
+                "Vendor: Sulzer Chemtech",
+                "Status profile: ready",
+                "Commercial total (USD): 7760.00",
+                "Payment terms: Net 30",
+                "Delivery lead: 14 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-036-A",
+                    "quantity": 1,
+                    "uom": "ea",
+                    "unit_price": 2200,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-036-B",
+                    "quantity": 2,
+                    "uom": "set",
+                    "unit_price": 1190,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-036",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 3180,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-035/vendor-01": {
+            "business_key": "rfq-035/vendor-01",
+            "rfq_key": "rfq-035",
+            "vendor_key": "vendor-01",
+            "rfq_index": 35,
+            "quote_index": 1,
+            "rfq_kind": "awarded",
+            "rfq_title": "Stainless tank internals - agitator + baffles (lot 36)",
+            "vendor_name": "John Zink Hamworthy Combustion",
+            "quote_status": "ready",
+            "original_filename": "Quote_John_Zink_Hamworthy_Combustion.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-035-vendor-01.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-035/vendor-01",
+                "RFQ: Stainless tank internals - agitator + baffles (lot 36)",
+                "Vendor: John Zink Hamworthy Combustion",
+                "Status profile: ready",
+                "Commercial total (USD): 11343.75",
+                "Payment terms: Net 30",
+                "Delivery lead: 6 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-036-A",
+                    "quantity": 2,
+                    "uom": "ea",
+                    "unit_price": 2237.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-036-B",
+                    "quantity": 3,
+                    "uom": "set",
+                    "unit_price": 1211.25,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-036",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 3235,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-035/vendor-02": {
+            "business_key": "rfq-035/vendor-02",
+            "rfq_key": "rfq-035",
+            "vendor_key": "vendor-02",
+            "rfq_index": 35,
+            "quote_index": 2,
+            "rfq_kind": "awarded",
+            "rfq_title": "Stainless tank internals - agitator + baffles (lot 36)",
+            "vendor_name": "Donaldson Process Filtration",
+            "quote_status": "ready",
+            "original_filename": "Quote_Donaldson_Process_Filtration.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-035-vendor-02.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-035/vendor-02",
+                "RFQ: Stainless tank internals - agitator + baffles (lot 36)",
+                "Vendor: Donaldson Process Filtration",
+                "Status profile: ready",
+                "Commercial total (USD): 15045.00",
+                "Payment terms: Net 30",
+                "Delivery lead: 7 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-036-A",
+                    "quantity": 3,
+                    "uom": "ea",
+                    "unit_price": 2275,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-036-B",
+                    "quantity": 4,
+                    "uom": "set",
+                    "unit_price": 1232.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-036",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 3290,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-035/vendor-03": {
+            "business_key": "rfq-035/vendor-03",
+            "rfq_key": "rfq-035",
+            "vendor_key": "vendor-03",
+            "rfq_index": 35,
+            "quote_index": 3,
+            "rfq_kind": "awarded",
+            "rfq_title": "Stainless tank internals - agitator + baffles (lot 36)",
+            "vendor_name": "Grundfos Process Nordic",
+            "quote_status": "ready",
+            "original_filename": "Quote_Grundfos_Process_Nordic.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-035-vendor-03.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-035/vendor-03",
+                "RFQ: Stainless tank internals - agitator + baffles (lot 36)",
+                "Vendor: Grundfos Process Nordic",
+                "Status profile: ready",
+                "Commercial total (USD): 15102.50",
+                "Payment terms: Net 30",
+                "Delivery lead: 8 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-036-A",
+                    "quantity": 4,
+                    "uom": "ea",
+                    "unit_price": 2312.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-036-B",
+                    "quantity": 2,
+                    "uom": "set",
+                    "unit_price": 1253.75,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-036",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 3345,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-035/vendor-04": {
+            "business_key": "rfq-035/vendor-04",
+            "rfq_key": "rfq-035",
+            "vendor_key": "vendor-04",
+            "rfq_index": 35,
+            "quote_index": 4,
+            "rfq_kind": "awarded",
+            "rfq_title": "Stainless tank internals - agitator + baffles (lot 36)",
+            "vendor_name": "Atlas Copco Compressors",
+            "quote_status": "ready",
+            "original_filename": "Quote_Atlas_Copco_Compressors.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-035-vendor-04.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-035/vendor-04",
+                "RFQ: Stainless tank internals - agitator + baffles (lot 36)",
+                "Vendor: Atlas Copco Compressors",
+                "Status profile: ready",
+                "Commercial total (USD): 9575.00",
+                "Payment terms: Net 30",
+                "Delivery lead: 9 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-036-A",
+                    "quantity": 1,
+                    "uom": "ea",
+                    "unit_price": 2350,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-036-B",
+                    "quantity": 3,
+                    "uom": "set",
+                    "unit_price": 1275,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-036",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 3400,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-036/vendor-00": {
+            "business_key": "rfq-036/vendor-00",
+            "rfq_key": "rfq-036",
+            "vendor_key": "vendor-00",
+            "rfq_index": 36,
+            "quote_index": 0,
+            "rfq_kind": "awarded",
+            "rfq_title": "Vapor recovery unit compressor package (lot 37)",
+            "vendor_name": "Technip Energies Norge",
+            "quote_status": "ready",
+            "original_filename": "Quote_Technip_Energies_Norge.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-036-vendor-00.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-036/vendor-00",
+                "RFQ: Vapor recovery unit compressor package (lot 37)",
+                "Vendor: Technip Energies Norge",
+                "Status profile: ready",
+                "Commercial total (USD): 11343.75",
+                "Payment terms: Net 45 EOM",
+                "Delivery lead: 6 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-037-A",
+                    "quantity": 2,
+                    "uom": "ea",
+                    "unit_price": 2237.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-037-B",
+                    "quantity": 3,
+                    "uom": "set",
+                    "unit_price": 1211.25,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-037",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 3235,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-036/vendor-01": {
+            "business_key": "rfq-036/vendor-01",
+            "rfq_key": "rfq-036",
+            "vendor_key": "vendor-01",
+            "rfq_index": 36,
+            "quote_index": 1,
+            "rfq_kind": "awarded",
+            "rfq_title": "Vapor recovery unit compressor package (lot 37)",
+            "vendor_name": "Wood PLC Norway",
+            "quote_status": "ready",
+            "original_filename": "Quote_Wood_PLC_Norway.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-036-vendor-01.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-036/vendor-01",
+                "RFQ: Vapor recovery unit compressor package (lot 37)",
+                "Vendor: Wood PLC Norway",
+                "Status profile: ready",
+                "Commercial total (USD): 15045.00",
+                "Payment terms: Net 45 EOM",
+                "Delivery lead: 7 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-037-A",
+                    "quantity": 3,
+                    "uom": "ea",
+                    "unit_price": 2275,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-037-B",
+                    "quantity": 4,
+                    "uom": "set",
+                    "unit_price": 1232.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-037",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 3290,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-036/vendor-02": {
+            "business_key": "rfq-036/vendor-02",
+            "rfq_key": "rfq-036",
+            "vendor_key": "vendor-02",
+            "rfq_index": 36,
+            "quote_index": 2,
+            "rfq_kind": "awarded",
+            "rfq_title": "Vapor recovery unit compressor package (lot 37)",
+            "vendor_name": "Worley Chemetics",
+            "quote_status": "ready",
+            "original_filename": "Quote_Worley_Chemetics.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-036-vendor-02.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-036/vendor-02",
+                "RFQ: Vapor recovery unit compressor package (lot 37)",
+                "Vendor: Worley Chemetics",
+                "Status profile: ready",
+                "Commercial total (USD): 15102.50",
+                "Payment terms: Net 45 EOM",
+                "Delivery lead: 8 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-037-A",
+                    "quantity": 4,
+                    "uom": "ea",
+                    "unit_price": 2312.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-037-B",
+                    "quantity": 2,
+                    "uom": "set",
+                    "unit_price": 1253.75,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-037",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 3345,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-037/vendor-00": {
+            "business_key": "rfq-037/vendor-00",
+            "rfq_key": "rfq-037",
+            "vendor_key": "vendor-00",
+            "rfq_index": 37,
+            "quote_index": 0,
+            "rfq_kind": "awarded",
+            "rfq_title": "Corrosion inhibitor injection skid (lot 38)",
+            "vendor_name": "Parker Hannifin Scandinavia",
+            "quote_status": "ready",
+            "original_filename": "Quote_Parker_Hannifin_Scandinavia.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-037-vendor-00.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-037/vendor-00",
+                "RFQ: Corrosion inhibitor injection skid (lot 38)",
+                "Vendor: Parker Hannifin Scandinavia",
+                "Status profile: ready",
+                "Commercial total (USD): 15045.00",
+                "Payment terms: Net 30",
+                "Delivery lead: 7 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-038-A",
+                    "quantity": 3,
+                    "uom": "ea",
+                    "unit_price": 2275,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-038-B",
+                    "quantity": 4,
+                    "uom": "set",
+                    "unit_price": 1232.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-038",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 3290,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-037/vendor-01": {
+            "business_key": "rfq-037/vendor-01",
+            "rfq_key": "rfq-037",
+            "vendor_key": "vendor-01",
+            "rfq_index": 37,
+            "quote_index": 1,
+            "rfq_kind": "awarded",
+            "rfq_title": "Corrosion inhibitor injection skid (lot 38)",
+            "vendor_name": "Honeywell UOP",
+            "quote_status": "ready",
+            "original_filename": "Quote_Honeywell_UOP.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-037-vendor-01.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-037/vendor-01",
+                "RFQ: Corrosion inhibitor injection skid (lot 38)",
+                "Vendor: Honeywell UOP",
+                "Status profile: ready",
+                "Commercial total (USD): 15102.50",
+                "Payment terms: Net 30",
+                "Delivery lead: 8 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-038-A",
+                    "quantity": 4,
+                    "uom": "ea",
+                    "unit_price": 2312.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-038-B",
+                    "quantity": 2,
+                    "uom": "set",
+                    "unit_price": 1253.75,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-038",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 3345,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-037/vendor-02": {
+            "business_key": "rfq-037/vendor-02",
+            "rfq_key": "rfq-037",
+            "vendor_key": "vendor-02",
+            "rfq_index": 37,
+            "quote_index": 2,
+            "rfq_kind": "awarded",
+            "rfq_title": "Corrosion inhibitor injection skid (lot 38)",
+            "vendor_name": "BASF Catalysts",
+            "quote_status": "ready",
+            "original_filename": "Quote_BASF_Catalysts.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-037-vendor-02.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-037/vendor-02",
+                "RFQ: Corrosion inhibitor injection skid (lot 38)",
+                "Vendor: BASF Catalysts",
+                "Status profile: ready",
+                "Commercial total (USD): 9575.00",
+                "Payment terms: Net 30",
+                "Delivery lead: 9 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-038-A",
+                    "quantity": 1,
+                    "uom": "ea",
+                    "unit_price": 2350,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-038-B",
+                    "quantity": 3,
+                    "uom": "set",
+                    "unit_price": 1275,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-038",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 3400,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-037/vendor-03": {
+            "business_key": "rfq-037/vendor-03",
+            "rfq_key": "rfq-037",
+            "vendor_key": "vendor-03",
+            "rfq_index": 37,
+            "quote_index": 3,
+            "rfq_kind": "awarded",
+            "rfq_title": "Corrosion inhibitor injection skid (lot 38)",
+            "vendor_name": "Clariant Catalysts",
+            "quote_status": "ready",
+            "original_filename": "Quote_Clariant_Catalysts.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-037-vendor-03.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-037/vendor-03",
+                "RFQ: Corrosion inhibitor injection skid (lot 38)",
+                "Vendor: Clariant Catalysts",
+                "Status profile: ready",
+                "Commercial total (USD): 13415.00",
+                "Payment terms: Net 30",
+                "Delivery lead: 10 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-038-A",
+                    "quantity": 2,
+                    "uom": "ea",
+                    "unit_price": 2387.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-038-B",
+                    "quantity": 4,
+                    "uom": "set",
+                    "unit_price": 1296.25,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-038",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 3455,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-038/vendor-00": {
+            "business_key": "rfq-038/vendor-00",
+            "rfq_key": "rfq-038",
+            "vendor_key": "vendor-00",
+            "rfq_index": 38,
+            "quote_index": 0,
+            "rfq_kind": "awarded",
+            "rfq_title": "DCS I/O marshalling cabinets + IS barriers (lot 39)",
+            "vendor_name": "Alfa Laval Aalborg",
+            "quote_status": "ready",
+            "original_filename": "Quote_Alfa_Laval_Aalborg.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-038-vendor-00.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-038/vendor-00",
+                "RFQ: DCS I/O marshalling cabinets + IS barriers (lot 39)",
+                "Vendor: Alfa Laval Aalborg",
+                "Status profile: ready",
+                "Commercial total (USD): 15102.50",
+                "Payment terms: Net 30",
+                "Delivery lead: 8 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-039-A",
+                    "quantity": 4,
+                    "uom": "ea",
+                    "unit_price": 2312.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-039-B",
+                    "quantity": 2,
+                    "uom": "set",
+                    "unit_price": 1253.75,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-039",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 3345,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-038/vendor-01": {
+            "business_key": "rfq-038/vendor-01",
+            "rfq_key": "rfq-038",
+            "vendor_key": "vendor-01",
+            "rfq_index": 38,
+            "quote_index": 1,
+            "rfq_kind": "awarded",
+            "rfq_title": "DCS I/O marshalling cabinets + IS barriers (lot 39)",
+            "vendor_name": "Sulzer Chemtech",
+            "quote_status": "ready",
+            "original_filename": "Quote_Sulzer_Chemtech.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-038-vendor-01.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-038/vendor-01",
+                "RFQ: DCS I/O marshalling cabinets + IS barriers (lot 39)",
+                "Vendor: Sulzer Chemtech",
+                "Status profile: ready",
+                "Commercial total (USD): 9575.00",
+                "Payment terms: Net 30",
+                "Delivery lead: 9 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-039-A",
+                    "quantity": 1,
+                    "uom": "ea",
+                    "unit_price": 2350,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-039-B",
+                    "quantity": 3,
+                    "uom": "set",
+                    "unit_price": 1275,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-039",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 3400,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-038/vendor-02": {
+            "business_key": "rfq-038/vendor-02",
+            "rfq_key": "rfq-038",
+            "vendor_key": "vendor-02",
+            "rfq_index": 38,
+            "quote_index": 2,
+            "rfq_kind": "awarded",
+            "rfq_title": "DCS I/O marshalling cabinets + IS barriers (lot 39)",
+            "vendor_name": "John Zink Hamworthy Combustion",
+            "quote_status": "ready",
+            "original_filename": "Quote_John_Zink_Hamworthy_Combustion.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-038-vendor-02.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-038/vendor-02",
+                "RFQ: DCS I/O marshalling cabinets + IS barriers (lot 39)",
+                "Vendor: John Zink Hamworthy Combustion",
+                "Status profile: ready",
+                "Commercial total (USD): 13415.00",
+                "Payment terms: Net 30",
+                "Delivery lead: 10 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-039-A",
+                    "quantity": 2,
+                    "uom": "ea",
+                    "unit_price": 2387.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-039-B",
+                    "quantity": 4,
+                    "uom": "set",
+                    "unit_price": 1296.25,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-039",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 3455,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-038/vendor-03": {
+            "business_key": "rfq-038/vendor-03",
+            "rfq_key": "rfq-038",
+            "vendor_key": "vendor-03",
+            "rfq_index": 38,
+            "quote_index": 3,
+            "rfq_kind": "awarded",
+            "rfq_title": "DCS I/O marshalling cabinets + IS barriers (lot 39)",
+            "vendor_name": "Donaldson Process Filtration",
+            "quote_status": "ready",
+            "original_filename": "Quote_Donaldson_Process_Filtration.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-038-vendor-03.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-038/vendor-03",
+                "RFQ: DCS I/O marshalling cabinets + IS barriers (lot 39)",
+                "Vendor: Donaldson Process Filtration",
+                "Status profile: ready",
+                "Commercial total (USD): 13420.00",
+                "Payment terms: Net 30",
+                "Delivery lead: 11 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-039-A",
+                    "quantity": 3,
+                    "uom": "ea",
+                    "unit_price": 2425,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-039-B",
+                    "quantity": 2,
+                    "uom": "set",
+                    "unit_price": 1317.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-039",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 3510,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-038/vendor-04": {
+            "business_key": "rfq-038/vendor-04",
+            "rfq_key": "rfq-038",
+            "vendor_key": "vendor-04",
+            "rfq_index": 38,
+            "quote_index": 4,
+            "rfq_kind": "awarded",
+            "rfq_title": "DCS I/O marshalling cabinets + IS barriers (lot 39)",
+            "vendor_name": "Grundfos Process Nordic",
+            "quote_status": "ready",
+            "original_filename": "Quote_Grundfos_Process_Nordic.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-038-vendor-04.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-038/vendor-04",
+                "RFQ: DCS I/O marshalling cabinets + IS barriers (lot 39)",
+                "Vendor: Grundfos Process Nordic",
+                "Status profile: ready",
+                "Commercial total (USD): 17431.25",
+                "Payment terms: Net 30",
+                "Delivery lead: 12 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-039-A",
+                    "quantity": 4,
+                    "uom": "ea",
+                    "unit_price": 2462.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-039-B",
+                    "quantity": 3,
+                    "uom": "set",
+                    "unit_price": 1338.75,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-039",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 3565,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-039/vendor-00": {
+            "business_key": "rfq-039/vendor-00",
+            "rfq_key": "rfq-039",
+            "vendor_key": "vendor-00",
+            "rfq_index": 39,
+            "quote_index": 0,
+            "rfq_kind": "awarded",
+            "rfq_title": "Loading arm spare hydraulic power unit (lot 40)",
+            "vendor_name": "Air Liquide Advanced Separations",
+            "quote_status": "ready",
+            "original_filename": "Quote_Air_Liquide_Advanced_Separations.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-039-vendor-00.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-039/vendor-00",
+                "RFQ: Loading arm spare hydraulic power unit (lot 40)",
+                "Vendor: Air Liquide Advanced Separations",
+                "Status profile: ready",
+                "Commercial total (USD): 9575.00",
+                "Payment terms: Net 45 EOM",
+                "Delivery lead: 9 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-040-A",
+                    "quantity": 1,
+                    "uom": "ea",
+                    "unit_price": 2350,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-040-B",
+                    "quantity": 3,
+                    "uom": "set",
+                    "unit_price": 1275,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-040",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 3400,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-039/vendor-01": {
+            "business_key": "rfq-039/vendor-01",
+            "rfq_key": "rfq-039",
+            "vendor_key": "vendor-01",
+            "rfq_index": 39,
+            "quote_index": 1,
+            "rfq_kind": "awarded",
+            "rfq_title": "Loading arm spare hydraulic power unit (lot 40)",
+            "vendor_name": "Technip Energies Norge",
+            "quote_status": "ready",
+            "original_filename": "Quote_Technip_Energies_Norge.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-039-vendor-01.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-039/vendor-01",
+                "RFQ: Loading arm spare hydraulic power unit (lot 40)",
+                "Vendor: Technip Energies Norge",
+                "Status profile: ready",
+                "Commercial total (USD): 13415.00",
+                "Payment terms: Net 45 EOM",
+                "Delivery lead: 10 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-040-A",
+                    "quantity": 2,
+                    "uom": "ea",
+                    "unit_price": 2387.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-040-B",
+                    "quantity": 4,
+                    "uom": "set",
+                    "unit_price": 1296.25,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-040",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 3455,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-039/vendor-02": {
+            "business_key": "rfq-039/vendor-02",
+            "rfq_key": "rfq-039",
+            "vendor_key": "vendor-02",
+            "rfq_index": 39,
+            "quote_index": 2,
+            "rfq_kind": "awarded",
+            "rfq_title": "Loading arm spare hydraulic power unit (lot 40)",
+            "vendor_name": "Wood PLC Norway",
+            "quote_status": "ready",
+            "original_filename": "Quote_Wood_PLC_Norway.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-039-vendor-02.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-039/vendor-02",
+                "RFQ: Loading arm spare hydraulic power unit (lot 40)",
+                "Vendor: Wood PLC Norway",
+                "Status profile: ready",
+                "Commercial total (USD): 13420.00",
+                "Payment terms: Net 45 EOM",
+                "Delivery lead: 11 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-040-A",
+                    "quantity": 3,
+                    "uom": "ea",
+                    "unit_price": 2425,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-040-B",
+                    "quantity": 2,
+                    "uom": "set",
+                    "unit_price": 1317.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-040",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 3510,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-040/vendor-00": {
+            "business_key": "rfq-040/vendor-00",
+            "rfq_key": "rfq-040",
+            "vendor_key": "vendor-00",
+            "rfq_index": 40,
+            "quote_index": 0,
+            "rfq_kind": "awarded",
+            "rfq_title": "Nitrogen generator membrane replacement (lot 41)",
+            "vendor_name": "Swagelok Bergen",
+            "quote_status": "ready",
+            "original_filename": "Quote_Swagelok_Bergen.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-040-vendor-00.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-040/vendor-00",
+                "RFQ: Nitrogen generator membrane replacement (lot 41)",
+                "Vendor: Swagelok Bergen",
+                "Status profile: ready",
+                "Commercial total (USD): 13415.00",
+                "Payment terms: Net 30",
+                "Delivery lead: 10 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-041-A",
+                    "quantity": 2,
+                    "uom": "ea",
+                    "unit_price": 2387.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-041-B",
+                    "quantity": 4,
+                    "uom": "set",
+                    "unit_price": 1296.25,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-041",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 3455,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-040/vendor-01": {
+            "business_key": "rfq-040/vendor-01",
+            "rfq_key": "rfq-040",
+            "vendor_key": "vendor-01",
+            "rfq_index": 40,
+            "quote_index": 1,
+            "rfq_kind": "awarded",
+            "rfq_title": "Nitrogen generator membrane replacement (lot 41)",
+            "vendor_name": "Parker Hannifin Scandinavia",
+            "quote_status": "ready",
+            "original_filename": "Quote_Parker_Hannifin_Scandinavia.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-040-vendor-01.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-040/vendor-01",
+                "RFQ: Nitrogen generator membrane replacement (lot 41)",
+                "Vendor: Parker Hannifin Scandinavia",
+                "Status profile: ready",
+                "Commercial total (USD): 13420.00",
+                "Payment terms: Net 30",
+                "Delivery lead: 11 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-041-A",
+                    "quantity": 3,
+                    "uom": "ea",
+                    "unit_price": 2425,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-041-B",
+                    "quantity": 2,
+                    "uom": "set",
+                    "unit_price": 1317.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-041",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 3510,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-040/vendor-02": {
+            "business_key": "rfq-040/vendor-02",
+            "rfq_key": "rfq-040",
+            "vendor_key": "vendor-02",
+            "rfq_index": 40,
+            "quote_index": 2,
+            "rfq_kind": "awarded",
+            "rfq_title": "Nitrogen generator membrane replacement (lot 41)",
+            "vendor_name": "Honeywell UOP",
+            "quote_status": "ready",
+            "original_filename": "Quote_Honeywell_UOP.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-040-vendor-02.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-040/vendor-02",
+                "RFQ: Nitrogen generator membrane replacement (lot 41)",
+                "Vendor: Honeywell UOP",
+                "Status profile: ready",
+                "Commercial total (USD): 17431.25",
+                "Payment terms: Net 30",
+                "Delivery lead: 12 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-041-A",
+                    "quantity": 4,
+                    "uom": "ea",
+                    "unit_price": 2462.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-041-B",
+                    "quantity": 3,
+                    "uom": "set",
+                    "unit_price": 1338.75,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-041",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 3565,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-040/vendor-03": {
+            "business_key": "rfq-040/vendor-03",
+            "rfq_key": "rfq-040",
+            "vendor_key": "vendor-03",
+            "rfq_index": 40,
+            "quote_index": 3,
+            "rfq_kind": "awarded",
+            "rfq_title": "Nitrogen generator membrane replacement (lot 41)",
+            "vendor_name": "BASF Catalysts",
+            "quote_status": "ready",
+            "original_filename": "Quote_BASF_Catalysts.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-040-vendor-03.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-040/vendor-03",
+                "RFQ: Nitrogen generator membrane replacement (lot 41)",
+                "Vendor: BASF Catalysts",
+                "Status profile: ready",
+                "Commercial total (USD): 11560.00",
+                "Payment terms: Net 30",
+                "Delivery lead: 13 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-041-A",
+                    "quantity": 1,
+                    "uom": "ea",
+                    "unit_price": 2500,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-041-B",
+                    "quantity": 4,
+                    "uom": "set",
+                    "unit_price": 1360,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-041",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 3620,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-041/vendor-00": {
+            "business_key": "rfq-041/vendor-00",
+            "rfq_key": "rfq-041",
+            "vendor_key": "vendor-00",
+            "rfq_index": 41,
+            "quote_index": 0,
+            "rfq_kind": "awarded",
+            "rfq_title": "Flare pilot / igniter assembly (lot 42)",
+            "vendor_name": "Emerson Fisher Norway",
+            "quote_status": "ready",
+            "original_filename": "Quote_Emerson_Fisher_Norway.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-041-vendor-00.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-041/vendor-00",
+                "RFQ: Flare pilot / igniter assembly (lot 42)",
+                "Vendor: Emerson Fisher Norway",
+                "Status profile: ready",
+                "Commercial total (USD): 13420.00",
+                "Payment terms: Net 30",
+                "Delivery lead: 11 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-042-A",
+                    "quantity": 3,
+                    "uom": "ea",
+                    "unit_price": 2425,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-042-B",
+                    "quantity": 2,
+                    "uom": "set",
+                    "unit_price": 1317.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-042",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 3510,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-041/vendor-01": {
+            "business_key": "rfq-041/vendor-01",
+            "rfq_key": "rfq-041",
+            "vendor_key": "vendor-01",
+            "rfq_index": 41,
+            "quote_index": 1,
+            "rfq_kind": "awarded",
+            "rfq_title": "Flare pilot / igniter assembly (lot 42)",
+            "vendor_name": "Alfa Laval Aalborg",
+            "quote_status": "ready",
+            "original_filename": "Quote_Alfa_Laval_Aalborg.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-041-vendor-01.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-041/vendor-01",
+                "RFQ: Flare pilot / igniter assembly (lot 42)",
+                "Vendor: Alfa Laval Aalborg",
+                "Status profile: ready",
+                "Commercial total (USD): 17431.25",
+                "Payment terms: Net 30",
+                "Delivery lead: 12 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-042-A",
+                    "quantity": 4,
+                    "uom": "ea",
+                    "unit_price": 2462.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-042-B",
+                    "quantity": 3,
+                    "uom": "set",
+                    "unit_price": 1338.75,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-042",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 3565,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-041/vendor-02": {
+            "business_key": "rfq-041/vendor-02",
+            "rfq_key": "rfq-041",
+            "vendor_key": "vendor-02",
+            "rfq_index": 41,
+            "quote_index": 2,
+            "rfq_kind": "awarded",
+            "rfq_title": "Flare pilot / igniter assembly (lot 42)",
+            "vendor_name": "Sulzer Chemtech",
+            "quote_status": "ready",
+            "original_filename": "Quote_Sulzer_Chemtech.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-041-vendor-02.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-041/vendor-02",
+                "RFQ: Flare pilot / igniter assembly (lot 42)",
+                "Vendor: Sulzer Chemtech",
+                "Status profile: ready",
+                "Commercial total (USD): 11560.00",
+                "Payment terms: Net 30",
+                "Delivery lead: 13 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-042-A",
+                    "quantity": 1,
+                    "uom": "ea",
+                    "unit_price": 2500,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-042-B",
+                    "quantity": 4,
+                    "uom": "set",
+                    "unit_price": 1360,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-042",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 3620,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-041/vendor-03": {
+            "business_key": "rfq-041/vendor-03",
+            "rfq_key": "rfq-041",
+            "vendor_key": "vendor-03",
+            "rfq_index": 41,
+            "quote_index": 3,
+            "rfq_kind": "awarded",
+            "rfq_title": "Flare pilot / igniter assembly (lot 42)",
+            "vendor_name": "John Zink Hamworthy Combustion",
+            "quote_status": "ready",
+            "original_filename": "Quote_John_Zink_Hamworthy_Combustion.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-041-vendor-03.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-041/vendor-03",
+                "RFQ: Flare pilot / igniter assembly (lot 42)",
+                "Vendor: John Zink Hamworthy Combustion",
+                "Status profile: ready",
+                "Commercial total (USD): 11512.50",
+                "Payment terms: Net 30",
+                "Delivery lead: 14 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-042-A",
+                    "quantity": 2,
+                    "uom": "ea",
+                    "unit_price": 2537.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-042-B",
+                    "quantity": 2,
+                    "uom": "set",
+                    "unit_price": 1381.25,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-042",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 3675,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-041/vendor-04": {
+            "business_key": "rfq-041/vendor-04",
+            "rfq_key": "rfq-041",
+            "vendor_key": "vendor-04",
+            "rfq_index": 41,
+            "quote_index": 4,
+            "rfq_kind": "awarded",
+            "rfq_title": "Flare pilot / igniter assembly (lot 42)",
+            "vendor_name": "Donaldson Process Filtration",
+            "quote_status": "ready",
+            "original_filename": "Quote_Donaldson_Process_Filtration.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-041-vendor-04.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-041/vendor-04",
+                "RFQ: Flare pilot / igniter assembly (lot 42)",
+                "Vendor: Donaldson Process Filtration",
+                "Status profile: ready",
+                "Commercial total (USD): 15662.50",
+                "Payment terms: Net 30",
+                "Delivery lead: 6 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-042-A",
+                    "quantity": 3,
+                    "uom": "ea",
+                    "unit_price": 2575,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-042-B",
+                    "quantity": 3,
+                    "uom": "set",
+                    "unit_price": 1402.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-042",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 3730,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-042/vendor-00": {
+            "business_key": "rfq-042/vendor-00",
+            "rfq_key": "rfq-042",
+            "vendor_key": "vendor-00",
+            "rfq_index": 42,
+            "quote_index": 0,
+            "rfq_kind": "awarded",
+            "rfq_title": "Heat exchanger bundle - lean amine (lot 43)",
+            "vendor_name": "Linde Engineering",
+            "quote_status": "ready",
+            "original_filename": "Quote_Linde_Engineering.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-042-vendor-00.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-042/vendor-00",
+                "RFQ: Heat exchanger bundle - lean amine (lot 43)",
+                "Vendor: Linde Engineering",
+                "Status profile: ready",
+                "Commercial total (USD): 17431.25",
+                "Payment terms: Net 45 EOM",
+                "Delivery lead: 12 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-043-A",
+                    "quantity": 4,
+                    "uom": "ea",
+                    "unit_price": 2462.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-043-B",
+                    "quantity": 3,
+                    "uom": "set",
+                    "unit_price": 1338.75,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-043",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 3565,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-042/vendor-01": {
+            "business_key": "rfq-042/vendor-01",
+            "rfq_key": "rfq-042",
+            "vendor_key": "vendor-01",
+            "rfq_index": 42,
+            "quote_index": 1,
+            "rfq_kind": "awarded",
+            "rfq_title": "Heat exchanger bundle - lean amine (lot 43)",
+            "vendor_name": "Air Liquide Advanced Separations",
+            "quote_status": "ready",
+            "original_filename": "Quote_Air_Liquide_Advanced_Separations.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-042-vendor-01.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-042/vendor-01",
+                "RFQ: Heat exchanger bundle - lean amine (lot 43)",
+                "Vendor: Air Liquide Advanced Separations",
+                "Status profile: ready",
+                "Commercial total (USD): 11560.00",
+                "Payment terms: Net 45 EOM",
+                "Delivery lead: 13 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-043-A",
+                    "quantity": 1,
+                    "uom": "ea",
+                    "unit_price": 2500,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-043-B",
+                    "quantity": 4,
+                    "uom": "set",
+                    "unit_price": 1360,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-043",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 3620,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-042/vendor-02": {
+            "business_key": "rfq-042/vendor-02",
+            "rfq_key": "rfq-042",
+            "vendor_key": "vendor-02",
+            "rfq_index": 42,
+            "quote_index": 2,
+            "rfq_kind": "awarded",
+            "rfq_title": "Heat exchanger bundle - lean amine (lot 43)",
+            "vendor_name": "Technip Energies Norge",
+            "quote_status": "ready",
+            "original_filename": "Quote_Technip_Energies_Norge.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-042-vendor-02.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-042/vendor-02",
+                "RFQ: Heat exchanger bundle - lean amine (lot 43)",
+                "Vendor: Technip Energies Norge",
+                "Status profile: ready",
+                "Commercial total (USD): 11512.50",
+                "Payment terms: Net 45 EOM",
+                "Delivery lead: 14 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-043-A",
+                    "quantity": 2,
+                    "uom": "ea",
+                    "unit_price": 2537.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-043-B",
+                    "quantity": 2,
+                    "uom": "set",
+                    "unit_price": 1381.25,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-043",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 3675,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-043/vendor-00": {
+            "business_key": "rfq-043/vendor-00",
+            "rfq_key": "rfq-043",
+            "vendor_key": "vendor-00",
+            "rfq_index": 43,
+            "quote_index": 0,
+            "rfq_kind": "awarded",
+            "rfq_title": "Emergency shower & eyewash stations (ATEX) (lot 44)",
+            "vendor_name": "Burkert Fluid Control",
+            "quote_status": "ready",
+            "original_filename": "Quote_Burkert_Fluid_Control.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-043-vendor-00.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-043/vendor-00",
+                "RFQ: Emergency shower & eyewash stations (ATEX) (lot 44)",
+                "Vendor: Burkert Fluid Control",
+                "Status profile: ready",
+                "Commercial total (USD): 11560.00",
+                "Payment terms: Net 30",
+                "Delivery lead: 13 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-044-A",
+                    "quantity": 1,
+                    "uom": "ea",
+                    "unit_price": 2500,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-044-B",
+                    "quantity": 4,
+                    "uom": "set",
+                    "unit_price": 1360,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-044",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 3620,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-043/vendor-01": {
+            "business_key": "rfq-043/vendor-01",
+            "rfq_key": "rfq-043",
+            "vendor_key": "vendor-01",
+            "rfq_index": 43,
+            "quote_index": 1,
+            "rfq_kind": "awarded",
+            "rfq_title": "Emergency shower & eyewash stations (ATEX) (lot 44)",
+            "vendor_name": "Swagelok Bergen",
+            "quote_status": "ready",
+            "original_filename": "Quote_Swagelok_Bergen.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-043-vendor-01.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-043/vendor-01",
+                "RFQ: Emergency shower & eyewash stations (ATEX) (lot 44)",
+                "Vendor: Swagelok Bergen",
+                "Status profile: ready",
+                "Commercial total (USD): 11512.50",
+                "Payment terms: Net 30",
+                "Delivery lead: 14 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-044-A",
+                    "quantity": 2,
+                    "uom": "ea",
+                    "unit_price": 2537.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-044-B",
+                    "quantity": 2,
+                    "uom": "set",
+                    "unit_price": 1381.25,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-044",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 3675,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-043/vendor-02": {
+            "business_key": "rfq-043/vendor-02",
+            "rfq_key": "rfq-043",
+            "vendor_key": "vendor-02",
+            "rfq_index": 43,
+            "quote_index": 2,
+            "rfq_kind": "awarded",
+            "rfq_title": "Emergency shower & eyewash stations (ATEX) (lot 44)",
+            "vendor_name": "Parker Hannifin Scandinavia",
+            "quote_status": "ready",
+            "original_filename": "Quote_Parker_Hannifin_Scandinavia.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-043-vendor-02.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-043/vendor-02",
+                "RFQ: Emergency shower & eyewash stations (ATEX) (lot 44)",
+                "Vendor: Parker Hannifin Scandinavia",
+                "Status profile: ready",
+                "Commercial total (USD): 15662.50",
+                "Payment terms: Net 30",
+                "Delivery lead: 6 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-044-A",
+                    "quantity": 3,
+                    "uom": "ea",
+                    "unit_price": 2575,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-044-B",
+                    "quantity": 3,
+                    "uom": "set",
+                    "unit_price": 1402.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-044",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 3730,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-043/vendor-03": {
+            "business_key": "rfq-043/vendor-03",
+            "rfq_key": "rfq-043",
+            "vendor_key": "vendor-03",
+            "rfq_index": 43,
+            "quote_index": 3,
+            "rfq_kind": "awarded",
+            "rfq_title": "Emergency shower & eyewash stations (ATEX) (lot 44)",
+            "vendor_name": "Honeywell UOP",
+            "quote_status": "ready",
+            "original_filename": "Quote_Honeywell_UOP.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-043-vendor-03.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-043/vendor-03",
+                "RFQ: Emergency shower & eyewash stations (ATEX) (lot 44)",
+                "Vendor: Honeywell UOP",
+                "Status profile: ready",
+                "Commercial total (USD): 19930.00",
+                "Payment terms: Net 30",
+                "Delivery lead: 7 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-044-A",
+                    "quantity": 4,
+                    "uom": "ea",
+                    "unit_price": 2612.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-044-B",
+                    "quantity": 4,
+                    "uom": "set",
+                    "unit_price": 1423.75,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-044",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 3785,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-044/vendor-00": {
+            "business_key": "rfq-044/vendor-00",
+            "rfq_key": "rfq-044",
+            "vendor_key": "vendor-00",
+            "rfq_index": 44,
+            "quote_index": 0,
+            "rfq_kind": "awarded",
+            "rfq_title": "Chemical metering pumps - cooling tower (lot 45)",
+            "vendor_name": "FlowServe Nordics AS",
+            "quote_status": "ready",
+            "original_filename": "Quote_FlowServe_Nordics_AS.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-044-vendor-00.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-044/vendor-00",
+                "RFQ: Chemical metering pumps - cooling tower (lot 45)",
+                "Vendor: FlowServe Nordics AS",
+                "Status profile: ready",
+                "Commercial total (USD): 11512.50",
+                "Payment terms: Net 30",
+                "Delivery lead: 14 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-045-A",
+                    "quantity": 2,
+                    "uom": "ea",
+                    "unit_price": 2537.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-045-B",
+                    "quantity": 2,
+                    "uom": "set",
+                    "unit_price": 1381.25,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-045",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 3675,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-044/vendor-01": {
+            "business_key": "rfq-044/vendor-01",
+            "rfq_key": "rfq-044",
+            "vendor_key": "vendor-01",
+            "rfq_index": 44,
+            "quote_index": 1,
+            "rfq_kind": "awarded",
+            "rfq_title": "Chemical metering pumps - cooling tower (lot 45)",
+            "vendor_name": "Emerson Fisher Norway",
+            "quote_status": "ready",
+            "original_filename": "Quote_Emerson_Fisher_Norway.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-044-vendor-01.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-044/vendor-01",
+                "RFQ: Chemical metering pumps - cooling tower (lot 45)",
+                "Vendor: Emerson Fisher Norway",
+                "Status profile: ready",
+                "Commercial total (USD): 15662.50",
+                "Payment terms: Net 30",
+                "Delivery lead: 6 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-045-A",
+                    "quantity": 3,
+                    "uom": "ea",
+                    "unit_price": 2575,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-045-B",
+                    "quantity": 3,
+                    "uom": "set",
+                    "unit_price": 1402.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-045",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 3730,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-044/vendor-02": {
+            "business_key": "rfq-044/vendor-02",
+            "rfq_key": "rfq-044",
+            "vendor_key": "vendor-02",
+            "rfq_index": 44,
+            "quote_index": 2,
+            "rfq_kind": "awarded",
+            "rfq_title": "Chemical metering pumps - cooling tower (lot 45)",
+            "vendor_name": "Alfa Laval Aalborg",
+            "quote_status": "ready",
+            "original_filename": "Quote_Alfa_Laval_Aalborg.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-044-vendor-02.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-044/vendor-02",
+                "RFQ: Chemical metering pumps - cooling tower (lot 45)",
+                "Vendor: Alfa Laval Aalborg",
+                "Status profile: ready",
+                "Commercial total (USD): 19930.00",
+                "Payment terms: Net 30",
+                "Delivery lead: 7 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-045-A",
+                    "quantity": 4,
+                    "uom": "ea",
+                    "unit_price": 2612.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-045-B",
+                    "quantity": 4,
+                    "uom": "set",
+                    "unit_price": 1423.75,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-045",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 3785,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-044/vendor-03": {
+            "business_key": "rfq-044/vendor-03",
+            "rfq_key": "rfq-044",
+            "vendor_key": "vendor-03",
+            "rfq_index": 44,
+            "quote_index": 3,
+            "rfq_kind": "awarded",
+            "rfq_title": "Chemical metering pumps - cooling tower (lot 45)",
+            "vendor_name": "Sulzer Chemtech",
+            "quote_status": "ready",
+            "original_filename": "Quote_Sulzer_Chemtech.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-044-vendor-03.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-044/vendor-03",
+                "RFQ: Chemical metering pumps - cooling tower (lot 45)",
+                "Vendor: Sulzer Chemtech",
+                "Status profile: ready",
+                "Commercial total (USD): 9380.00",
+                "Payment terms: Net 30",
+                "Delivery lead: 8 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-045-A",
+                    "quantity": 1,
+                    "uom": "ea",
+                    "unit_price": 2650,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-045-B",
+                    "quantity": 2,
+                    "uom": "set",
+                    "unit_price": 1445,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-045",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 3840,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-044/vendor-04": {
+            "business_key": "rfq-044/vendor-04",
+            "rfq_key": "rfq-044",
+            "vendor_key": "vendor-04",
+            "rfq_index": 44,
+            "quote_index": 4,
+            "rfq_kind": "awarded",
+            "rfq_title": "Chemical metering pumps - cooling tower (lot 45)",
+            "vendor_name": "John Zink Hamworthy Combustion",
+            "quote_status": "ready",
+            "original_filename": "Quote_John_Zink_Hamworthy_Combustion.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-044-vendor-04.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-044/vendor-04",
+                "RFQ: Chemical metering pumps - cooling tower (lot 45)",
+                "Vendor: John Zink Hamworthy Combustion",
+                "Status profile: ready",
+                "Commercial total (USD): 13668.75",
+                "Payment terms: Net 30",
+                "Delivery lead: 9 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-045-A",
+                    "quantity": 2,
+                    "uom": "ea",
+                    "unit_price": 2687.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-045-B",
+                    "quantity": 3,
+                    "uom": "set",
+                    "unit_price": 1466.25,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-045",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 3895,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-045/vendor-00": {
+            "business_key": "rfq-045/vendor-00",
+            "rfq_key": "rfq-045",
+            "vendor_key": "vendor-00",
+            "rfq_index": 45,
+            "quote_index": 0,
+            "rfq_kind": "awarded",
+            "rfq_title": "HVAC ATEX fan wall - analyzer shelter (lot 46)",
+            "vendor_name": "Atlas Copco Compressors",
+            "quote_status": "ready",
+            "original_filename": "Quote_Atlas_Copco_Compressors.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-045-vendor-00.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-045/vendor-00",
+                "RFQ: HVAC ATEX fan wall - analyzer shelter (lot 46)",
+                "Vendor: Atlas Copco Compressors",
+                "Status profile: ready",
+                "Commercial total (USD): 15662.50",
+                "Payment terms: Net 45 EOM",
+                "Delivery lead: 6 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-046-A",
+                    "quantity": 3,
+                    "uom": "ea",
+                    "unit_price": 2575,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-046-B",
+                    "quantity": 3,
+                    "uom": "set",
+                    "unit_price": 1402.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-046",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 3730,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-045/vendor-01": {
+            "business_key": "rfq-045/vendor-01",
+            "rfq_key": "rfq-045",
+            "vendor_key": "vendor-01",
+            "rfq_index": 45,
+            "quote_index": 1,
+            "rfq_kind": "awarded",
+            "rfq_title": "HVAC ATEX fan wall - analyzer shelter (lot 46)",
+            "vendor_name": "Linde Engineering",
+            "quote_status": "ready",
+            "original_filename": "Quote_Linde_Engineering.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-045-vendor-01.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-045/vendor-01",
+                "RFQ: HVAC ATEX fan wall - analyzer shelter (lot 46)",
+                "Vendor: Linde Engineering",
+                "Status profile: ready",
+                "Commercial total (USD): 19930.00",
+                "Payment terms: Net 45 EOM",
+                "Delivery lead: 7 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-046-A",
+                    "quantity": 4,
+                    "uom": "ea",
+                    "unit_price": 2612.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-046-B",
+                    "quantity": 4,
+                    "uom": "set",
+                    "unit_price": 1423.75,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-046",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 3785,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-045/vendor-02": {
+            "business_key": "rfq-045/vendor-02",
+            "rfq_key": "rfq-045",
+            "vendor_key": "vendor-02",
+            "rfq_index": 45,
+            "quote_index": 2,
+            "rfq_kind": "awarded",
+            "rfq_title": "HVAC ATEX fan wall - analyzer shelter (lot 46)",
+            "vendor_name": "Air Liquide Advanced Separations",
+            "quote_status": "ready",
+            "original_filename": "Quote_Air_Liquide_Advanced_Separations.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-045-vendor-02.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-045/vendor-02",
+                "RFQ: HVAC ATEX fan wall - analyzer shelter (lot 46)",
+                "Vendor: Air Liquide Advanced Separations",
+                "Status profile: ready",
+                "Commercial total (USD): 9380.00",
+                "Payment terms: Net 45 EOM",
+                "Delivery lead: 8 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-046-A",
+                    "quantity": 1,
+                    "uom": "ea",
+                    "unit_price": 2650,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-046-B",
+                    "quantity": 2,
+                    "uom": "set",
+                    "unit_price": 1445,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-046",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 3840,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-046/vendor-00": {
+            "business_key": "rfq-046/vendor-00",
+            "rfq_key": "rfq-046",
+            "vendor_key": "vendor-00",
+            "rfq_index": 46,
+            "quote_index": 0,
+            "rfq_kind": "awarded",
+            "rfq_title": "Fixed gas detection - LEL / H2S (lot 47)",
+            "vendor_name": "SIHI Liquid Ring",
+            "quote_status": "ready",
+            "original_filename": "Quote_SIHI_Liquid_Ring.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-046-vendor-00.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-046/vendor-00",
+                "RFQ: Fixed gas detection - LEL / H2S (lot 47)",
+                "Vendor: SIHI Liquid Ring",
+                "Status profile: ready",
+                "Commercial total (USD): 19930.00",
+                "Payment terms: Net 30",
+                "Delivery lead: 7 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-047-A",
+                    "quantity": 4,
+                    "uom": "ea",
+                    "unit_price": 2612.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-047-B",
+                    "quantity": 4,
+                    "uom": "set",
+                    "unit_price": 1423.75,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-047",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 3785,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-046/vendor-01": {
+            "business_key": "rfq-046/vendor-01",
+            "rfq_key": "rfq-046",
+            "vendor_key": "vendor-01",
+            "rfq_index": 46,
+            "quote_index": 1,
+            "rfq_kind": "awarded",
+            "rfq_title": "Fixed gas detection - LEL / H2S (lot 47)",
+            "vendor_name": "Burkert Fluid Control",
+            "quote_status": "ready",
+            "original_filename": "Quote_Burkert_Fluid_Control.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-046-vendor-01.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-046/vendor-01",
+                "RFQ: Fixed gas detection - LEL / H2S (lot 47)",
+                "Vendor: Burkert Fluid Control",
+                "Status profile: ready",
+                "Commercial total (USD): 9380.00",
+                "Payment terms: Net 30",
+                "Delivery lead: 8 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-047-A",
+                    "quantity": 1,
+                    "uom": "ea",
+                    "unit_price": 2650,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-047-B",
+                    "quantity": 2,
+                    "uom": "set",
+                    "unit_price": 1445,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-047",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 3840,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-046/vendor-02": {
+            "business_key": "rfq-046/vendor-02",
+            "rfq_key": "rfq-046",
+            "vendor_key": "vendor-02",
+            "rfq_index": 46,
+            "quote_index": 2,
+            "rfq_kind": "awarded",
+            "rfq_title": "Fixed gas detection - LEL / H2S (lot 47)",
+            "vendor_name": "Swagelok Bergen",
+            "quote_status": "ready",
+            "original_filename": "Quote_Swagelok_Bergen.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-046-vendor-02.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-046/vendor-02",
+                "RFQ: Fixed gas detection - LEL / H2S (lot 47)",
+                "Vendor: Swagelok Bergen",
+                "Status profile: ready",
+                "Commercial total (USD): 13668.75",
+                "Payment terms: Net 30",
+                "Delivery lead: 9 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-047-A",
+                    "quantity": 2,
+                    "uom": "ea",
+                    "unit_price": 2687.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-047-B",
+                    "quantity": 3,
+                    "uom": "set",
+                    "unit_price": 1466.25,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-047",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 3895,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-046/vendor-03": {
+            "business_key": "rfq-046/vendor-03",
+            "rfq_key": "rfq-046",
+            "vendor_key": "vendor-03",
+            "rfq_index": 46,
+            "quote_index": 3,
+            "rfq_kind": "awarded",
+            "rfq_title": "Fixed gas detection - LEL / H2S (lot 47)",
+            "vendor_name": "Parker Hannifin Scandinavia",
+            "quote_status": "ready",
+            "original_filename": "Quote_Parker_Hannifin_Scandinavia.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-046-vendor-03.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-046/vendor-03",
+                "RFQ: Fixed gas detection - LEL / H2S (lot 47)",
+                "Vendor: Parker Hannifin Scandinavia",
+                "Status profile: ready",
+                "Commercial total (USD): 18075.00",
+                "Payment terms: Net 30",
+                "Delivery lead: 10 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-047-A",
+                    "quantity": 3,
+                    "uom": "ea",
+                    "unit_price": 2725,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-047-B",
+                    "quantity": 4,
+                    "uom": "set",
+                    "unit_price": 1487.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-047",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 3950,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-047/vendor-00": {
+            "business_key": "rfq-047/vendor-00",
+            "rfq_key": "rfq-047",
+            "vendor_key": "vendor-00",
+            "rfq_index": 47,
+            "quote_index": 0,
+            "rfq_kind": "awarded",
+            "rfq_title": "Firewater pump mechanical seal kit (lot 48)",
+            "vendor_name": "Johnson Matthey NORAM",
+            "quote_status": "ready",
+            "original_filename": "Quote_Johnson_Matthey_NORAM.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-047-vendor-00.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-047/vendor-00",
+                "RFQ: Firewater pump mechanical seal kit (lot 48)",
+                "Vendor: Johnson Matthey NORAM",
+                "Status profile: ready",
+                "Commercial total (USD): 9380.00",
+                "Payment terms: Net 30",
+                "Delivery lead: 8 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-048-A",
+                    "quantity": 1,
+                    "uom": "ea",
+                    "unit_price": 2650,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-048-B",
+                    "quantity": 2,
+                    "uom": "set",
+                    "unit_price": 1445,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-048",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 3840,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-047/vendor-01": {
+            "business_key": "rfq-047/vendor-01",
+            "rfq_key": "rfq-047",
+            "vendor_key": "vendor-01",
+            "rfq_index": 47,
+            "quote_index": 1,
+            "rfq_kind": "awarded",
+            "rfq_title": "Firewater pump mechanical seal kit (lot 48)",
+            "vendor_name": "FlowServe Nordics AS",
+            "quote_status": "ready",
+            "original_filename": "Quote_FlowServe_Nordics_AS.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-047-vendor-01.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-047/vendor-01",
+                "RFQ: Firewater pump mechanical seal kit (lot 48)",
+                "Vendor: FlowServe Nordics AS",
+                "Status profile: ready",
+                "Commercial total (USD): 13668.75",
+                "Payment terms: Net 30",
+                "Delivery lead: 9 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-048-A",
+                    "quantity": 2,
+                    "uom": "ea",
+                    "unit_price": 2687.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-048-B",
+                    "quantity": 3,
+                    "uom": "set",
+                    "unit_price": 1466.25,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-048",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 3895,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-047/vendor-02": {
+            "business_key": "rfq-047/vendor-02",
+            "rfq_key": "rfq-047",
+            "vendor_key": "vendor-02",
+            "rfq_index": 47,
+            "quote_index": 2,
+            "rfq_kind": "awarded",
+            "rfq_title": "Firewater pump mechanical seal kit (lot 48)",
+            "vendor_name": "Emerson Fisher Norway",
+            "quote_status": "ready",
+            "original_filename": "Quote_Emerson_Fisher_Norway.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-047-vendor-02.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-047/vendor-02",
+                "RFQ: Firewater pump mechanical seal kit (lot 48)",
+                "Vendor: Emerson Fisher Norway",
+                "Status profile: ready",
+                "Commercial total (USD): 18075.00",
+                "Payment terms: Net 30",
+                "Delivery lead: 10 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-048-A",
+                    "quantity": 3,
+                    "uom": "ea",
+                    "unit_price": 2725,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-048-B",
+                    "quantity": 4,
+                    "uom": "set",
+                    "unit_price": 1487.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-048",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 3950,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-047/vendor-03": {
+            "business_key": "rfq-047/vendor-03",
+            "rfq_key": "rfq-047",
+            "vendor_key": "vendor-03",
+            "rfq_index": 47,
+            "quote_index": 3,
+            "rfq_kind": "awarded",
+            "rfq_title": "Firewater pump mechanical seal kit (lot 48)",
+            "vendor_name": "Alfa Laval Aalborg",
+            "quote_status": "ready",
+            "original_filename": "Quote_Alfa_Laval_Aalborg.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-047-vendor-03.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-047/vendor-03",
+                "RFQ: Firewater pump mechanical seal kit (lot 48)",
+                "Vendor: Alfa Laval Aalborg",
+                "Status profile: ready",
+                "Commercial total (USD): 18072.50",
+                "Payment terms: Net 30",
+                "Delivery lead: 11 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-048-A",
+                    "quantity": 4,
+                    "uom": "ea",
+                    "unit_price": 2762.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-048-B",
+                    "quantity": 2,
+                    "uom": "set",
+                    "unit_price": 1508.75,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-048",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 4005,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-047/vendor-04": {
+            "business_key": "rfq-047/vendor-04",
+            "rfq_key": "rfq-047",
+            "vendor_key": "vendor-04",
+            "rfq_index": 47,
+            "quote_index": 4,
+            "rfq_kind": "awarded",
+            "rfq_title": "Firewater pump mechanical seal kit (lot 48)",
+            "vendor_name": "Sulzer Chemtech",
+            "quote_status": "ready",
+            "original_filename": "Quote_Sulzer_Chemtech.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-047-vendor-04.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-047/vendor-04",
+                "RFQ: Firewater pump mechanical seal kit (lot 48)",
+                "Vendor: Sulzer Chemtech",
+                "Status profile: ready",
+                "Commercial total (USD): 11450.00",
+                "Payment terms: Net 30",
+                "Delivery lead: 12 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-048-A",
+                    "quantity": 1,
+                    "uom": "ea",
+                    "unit_price": 2800,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-048-B",
+                    "quantity": 3,
+                    "uom": "set",
+                    "unit_price": 1530,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-048",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 4060,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-048/vendor-00": {
+            "business_key": "rfq-048/vendor-00",
+            "rfq_key": "rfq-048",
+            "vendor_key": "vendor-00",
+            "rfq_index": 48,
+            "quote_index": 0,
+            "rfq_kind": "awarded",
+            "rfq_title": "Insulation & cladding - steam tracing package (lot 49)",
+            "vendor_name": "Grundfos Process Nordic",
+            "quote_status": "ready",
+            "original_filename": "Quote_Grundfos_Process_Nordic.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-048-vendor-00.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-048/vendor-00",
+                "RFQ: Insulation & cladding - steam tracing package (lot 49)",
+                "Vendor: Grundfos Process Nordic",
+                "Status profile: ready",
+                "Commercial total (USD): 13668.75",
+                "Payment terms: Net 45 EOM",
+                "Delivery lead: 9 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-049-A",
+                    "quantity": 2,
+                    "uom": "ea",
+                    "unit_price": 2687.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-049-B",
+                    "quantity": 3,
+                    "uom": "set",
+                    "unit_price": 1466.25,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-049",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 3895,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-048/vendor-01": {
+            "business_key": "rfq-048/vendor-01",
+            "rfq_key": "rfq-048",
+            "vendor_key": "vendor-01",
+            "rfq_index": 48,
+            "quote_index": 1,
+            "rfq_kind": "awarded",
+            "rfq_title": "Insulation & cladding - steam tracing package (lot 49)",
+            "vendor_name": "Atlas Copco Compressors",
+            "quote_status": "ready",
+            "original_filename": "Quote_Atlas_Copco_Compressors.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-048-vendor-01.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-048/vendor-01",
+                "RFQ: Insulation & cladding - steam tracing package (lot 49)",
+                "Vendor: Atlas Copco Compressors",
+                "Status profile: ready",
+                "Commercial total (USD): 18075.00",
+                "Payment terms: Net 45 EOM",
+                "Delivery lead: 10 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-049-A",
+                    "quantity": 3,
+                    "uom": "ea",
+                    "unit_price": 2725,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-049-B",
+                    "quantity": 4,
+                    "uom": "set",
+                    "unit_price": 1487.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-049",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 3950,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-048/vendor-02": {
+            "business_key": "rfq-048/vendor-02",
+            "rfq_key": "rfq-048",
+            "vendor_key": "vendor-02",
+            "rfq_index": 48,
+            "quote_index": 2,
+            "rfq_kind": "awarded",
+            "rfq_title": "Insulation & cladding - steam tracing package (lot 49)",
+            "vendor_name": "Linde Engineering",
+            "quote_status": "ready",
+            "original_filename": "Quote_Linde_Engineering.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-048-vendor-02.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-048/vendor-02",
+                "RFQ: Insulation & cladding - steam tracing package (lot 49)",
+                "Vendor: Linde Engineering",
+                "Status profile: ready",
+                "Commercial total (USD): 18072.50",
+                "Payment terms: Net 45 EOM",
+                "Delivery lead: 11 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-049-A",
+                    "quantity": 4,
+                    "uom": "ea",
+                    "unit_price": 2762.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-049-B",
+                    "quantity": 2,
+                    "uom": "set",
+                    "unit_price": 1508.75,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-049",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 4005,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-049/vendor-00": {
+            "business_key": "rfq-049/vendor-00",
+            "rfq_key": "rfq-049",
+            "vendor_key": "vendor-00",
+            "rfq_index": 49,
+            "quote_index": 0,
+            "rfq_kind": "awarded",
+            "rfq_title": "Bolt tensioning service - turnaround (lot 50)",
+            "vendor_name": "Hayward Tyler (IMO) Pumps",
+            "quote_status": "ready",
+            "original_filename": "Quote_Hayward_Tyler_IMO_Pumps.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-049-vendor-00.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-049/vendor-00",
+                "RFQ: Bolt tensioning service - turnaround (lot 50)",
+                "Vendor: Hayward Tyler (IMO) Pumps",
+                "Status profile: ready",
+                "Commercial total (USD): 18075.00",
+                "Payment terms: Net 30",
+                "Delivery lead: 10 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-050-A",
+                    "quantity": 3,
+                    "uom": "ea",
+                    "unit_price": 2725,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-050-B",
+                    "quantity": 4,
+                    "uom": "set",
+                    "unit_price": 1487.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-050",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 3950,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-049/vendor-01": {
+            "business_key": "rfq-049/vendor-01",
+            "rfq_key": "rfq-049",
+            "vendor_key": "vendor-01",
+            "rfq_index": 49,
+            "quote_index": 1,
+            "rfq_kind": "awarded",
+            "rfq_title": "Bolt tensioning service - turnaround (lot 50)",
+            "vendor_name": "SIHI Liquid Ring",
+            "quote_status": "ready",
+            "original_filename": "Quote_SIHI_Liquid_Ring.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-049-vendor-01.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-049/vendor-01",
+                "RFQ: Bolt tensioning service - turnaround (lot 50)",
+                "Vendor: SIHI Liquid Ring",
+                "Status profile: ready",
+                "Commercial total (USD): 18072.50",
+                "Payment terms: Net 30",
+                "Delivery lead: 11 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-050-A",
+                    "quantity": 4,
+                    "uom": "ea",
+                    "unit_price": 2762.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-050-B",
+                    "quantity": 2,
+                    "uom": "set",
+                    "unit_price": 1508.75,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-050",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 4005,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-049/vendor-02": {
+            "business_key": "rfq-049/vendor-02",
+            "rfq_key": "rfq-049",
+            "vendor_key": "vendor-02",
+            "rfq_index": 49,
+            "quote_index": 2,
+            "rfq_kind": "awarded",
+            "rfq_title": "Bolt tensioning service - turnaround (lot 50)",
+            "vendor_name": "Burkert Fluid Control",
+            "quote_status": "ready",
+            "original_filename": "Quote_Burkert_Fluid_Control.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-049-vendor-02.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-049/vendor-02",
+                "RFQ: Bolt tensioning service - turnaround (lot 50)",
+                "Vendor: Burkert Fluid Control",
+                "Status profile: ready",
+                "Commercial total (USD): 11450.00",
+                "Payment terms: Net 30",
+                "Delivery lead: 12 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-050-A",
+                    "quantity": 1,
+                    "uom": "ea",
+                    "unit_price": 2800,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-050-B",
+                    "quantity": 3,
+                    "uom": "set",
+                    "unit_price": 1530,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-050",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 4060,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-049/vendor-03": {
+            "business_key": "rfq-049/vendor-03",
+            "rfq_key": "rfq-049",
+            "vendor_key": "vendor-03",
+            "rfq_index": 49,
+            "quote_index": 3,
+            "rfq_kind": "awarded",
+            "rfq_title": "Bolt tensioning service - turnaround (lot 50)",
+            "vendor_name": "Swagelok Bergen",
+            "quote_status": "ready",
+            "original_filename": "Quote_Swagelok_Bergen.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-049-vendor-03.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-049/vendor-03",
+                "RFQ: Bolt tensioning service - turnaround (lot 50)",
+                "Vendor: Swagelok Bergen",
+                "Status profile: ready",
+                "Commercial total (USD): 15995.00",
+                "Payment terms: Net 30",
+                "Delivery lead: 13 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-050-A",
+                    "quantity": 2,
+                    "uom": "ea",
+                    "unit_price": 2837.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-050-B",
+                    "quantity": 4,
+                    "uom": "set",
+                    "unit_price": 1551.25,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-050",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 4115,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-050/vendor-00": {
+            "business_key": "rfq-050/vendor-00",
+            "rfq_key": "rfq-050",
+            "vendor_key": "vendor-00",
+            "rfq_index": 50,
+            "quote_index": 0,
+            "rfq_kind": "awarded",
+            "rfq_title": "Temporary steam boiler rental (12 MW) (lot 51)",
+            "vendor_name": "Clariant Catalysts",
+            "quote_status": "ready",
+            "original_filename": "Quote_Clariant_Catalysts.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-050-vendor-00.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-050/vendor-00",
+                "RFQ: Temporary steam boiler rental (12 MW) (lot 51)",
+                "Vendor: Clariant Catalysts",
+                "Status profile: ready",
+                "Commercial total (USD): 18072.50",
+                "Payment terms: Net 30",
+                "Delivery lead: 11 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-051-A",
+                    "quantity": 4,
+                    "uom": "ea",
+                    "unit_price": 2762.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-051-B",
+                    "quantity": 2,
+                    "uom": "set",
+                    "unit_price": 1508.75,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-051",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 4005,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-050/vendor-01": {
+            "business_key": "rfq-050/vendor-01",
+            "rfq_key": "rfq-050",
+            "vendor_key": "vendor-01",
+            "rfq_index": 50,
+            "quote_index": 1,
+            "rfq_kind": "awarded",
+            "rfq_title": "Temporary steam boiler rental (12 MW) (lot 51)",
+            "vendor_name": "Johnson Matthey NORAM",
+            "quote_status": "ready",
+            "original_filename": "Quote_Johnson_Matthey_NORAM.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-050-vendor-01.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-050/vendor-01",
+                "RFQ: Temporary steam boiler rental (12 MW) (lot 51)",
+                "Vendor: Johnson Matthey NORAM",
+                "Status profile: ready",
+                "Commercial total (USD): 11450.00",
+                "Payment terms: Net 30",
+                "Delivery lead: 12 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-051-A",
+                    "quantity": 1,
+                    "uom": "ea",
+                    "unit_price": 2800,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-051-B",
+                    "quantity": 3,
+                    "uom": "set",
+                    "unit_price": 1530,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-051",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 4060,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-050/vendor-02": {
+            "business_key": "rfq-050/vendor-02",
+            "rfq_key": "rfq-050",
+            "vendor_key": "vendor-02",
+            "rfq_index": 50,
+            "quote_index": 2,
+            "rfq_kind": "awarded",
+            "rfq_title": "Temporary steam boiler rental (12 MW) (lot 51)",
+            "vendor_name": "FlowServe Nordics AS",
+            "quote_status": "ready",
+            "original_filename": "Quote_FlowServe_Nordics_AS.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-050-vendor-02.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-050/vendor-02",
+                "RFQ: Temporary steam boiler rental (12 MW) (lot 51)",
+                "Vendor: FlowServe Nordics AS",
+                "Status profile: ready",
+                "Commercial total (USD): 15995.00",
+                "Payment terms: Net 30",
+                "Delivery lead: 13 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-051-A",
+                    "quantity": 2,
+                    "uom": "ea",
+                    "unit_price": 2837.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-051-B",
+                    "quantity": 4,
+                    "uom": "set",
+                    "unit_price": 1551.25,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-051",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 4115,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-050/vendor-03": {
+            "business_key": "rfq-050/vendor-03",
+            "rfq_key": "rfq-050",
+            "vendor_key": "vendor-03",
+            "rfq_index": 50,
+            "quote_index": 3,
+            "rfq_kind": "awarded",
+            "rfq_title": "Temporary steam boiler rental (12 MW) (lot 51)",
+            "vendor_name": "Emerson Fisher Norway",
+            "quote_status": "ready",
+            "original_filename": "Quote_Emerson_Fisher_Norway.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-050-vendor-03.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-050/vendor-03",
+                "RFQ: Temporary steam boiler rental (12 MW) (lot 51)",
+                "Vendor: Emerson Fisher Norway",
+                "Status profile: ready",
+                "Commercial total (USD): 15940.00",
+                "Payment terms: Net 30",
+                "Delivery lead: 14 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-051-A",
+                    "quantity": 3,
+                    "uom": "ea",
+                    "unit_price": 2875,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-051-B",
+                    "quantity": 2,
+                    "uom": "set",
+                    "unit_price": 1572.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-051",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 4170,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-050/vendor-04": {
+            "business_key": "rfq-050/vendor-04",
+            "rfq_key": "rfq-050",
+            "vendor_key": "vendor-04",
+            "rfq_index": 50,
+            "quote_index": 4,
+            "rfq_kind": "awarded",
+            "rfq_title": "Temporary steam boiler rental (12 MW) (lot 51)",
+            "vendor_name": "Alfa Laval Aalborg",
+            "quote_status": "ready",
+            "original_filename": "Quote_Alfa_Laval_Aalborg.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-050-vendor-04.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-050/vendor-04",
+                "RFQ: Temporary steam boiler rental (12 MW) (lot 51)",
+                "Vendor: Alfa Laval Aalborg",
+                "Status profile: ready",
+                "Commercial total (USD): 20656.25",
+                "Payment terms: Net 30",
+                "Delivery lead: 6 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-051-A",
+                    "quantity": 4,
+                    "uom": "ea",
+                    "unit_price": 2912.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-051-B",
+                    "quantity": 3,
+                    "uom": "set",
+                    "unit_price": 1593.75,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-051",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 4225,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-051/vendor-00": {
+            "business_key": "rfq-051/vendor-00",
+            "rfq_key": "rfq-051",
+            "vendor_key": "vendor-00",
+            "rfq_index": 51,
+            "quote_index": 0,
+            "rfq_kind": "awarded",
+            "rfq_title": "Scaffold & containment - sulfur pit (lot 52)",
+            "vendor_name": "Donaldson Process Filtration",
+            "quote_status": "ready",
+            "original_filename": "Quote_Donaldson_Process_Filtration.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-051-vendor-00.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-051/vendor-00",
+                "RFQ: Scaffold & containment - sulfur pit (lot 52)",
+                "Vendor: Donaldson Process Filtration",
+                "Status profile: ready",
+                "Commercial total (USD): 11450.00",
+                "Payment terms: Net 45 EOM",
+                "Delivery lead: 12 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-052-A",
+                    "quantity": 1,
+                    "uom": "ea",
+                    "unit_price": 2800,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-052-B",
+                    "quantity": 3,
+                    "uom": "set",
+                    "unit_price": 1530,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-052",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 4060,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-051/vendor-01": {
+            "business_key": "rfq-051/vendor-01",
+            "rfq_key": "rfq-051",
+            "vendor_key": "vendor-01",
+            "rfq_index": 51,
+            "quote_index": 1,
+            "rfq_kind": "awarded",
+            "rfq_title": "Scaffold & containment - sulfur pit (lot 52)",
+            "vendor_name": "Grundfos Process Nordic",
+            "quote_status": "ready",
+            "original_filename": "Quote_Grundfos_Process_Nordic.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-051-vendor-01.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-051/vendor-01",
+                "RFQ: Scaffold & containment - sulfur pit (lot 52)",
+                "Vendor: Grundfos Process Nordic",
+                "Status profile: ready",
+                "Commercial total (USD): 15995.00",
+                "Payment terms: Net 45 EOM",
+                "Delivery lead: 13 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-052-A",
+                    "quantity": 2,
+                    "uom": "ea",
+                    "unit_price": 2837.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-052-B",
+                    "quantity": 4,
+                    "uom": "set",
+                    "unit_price": 1551.25,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-052",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 4115,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-051/vendor-02": {
+            "business_key": "rfq-051/vendor-02",
+            "rfq_key": "rfq-051",
+            "vendor_key": "vendor-02",
+            "rfq_index": 51,
+            "quote_index": 2,
+            "rfq_kind": "awarded",
+            "rfq_title": "Scaffold & containment - sulfur pit (lot 52)",
+            "vendor_name": "Atlas Copco Compressors",
+            "quote_status": "ready",
+            "original_filename": "Quote_Atlas_Copco_Compressors.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-051-vendor-02.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-051/vendor-02",
+                "RFQ: Scaffold & containment - sulfur pit (lot 52)",
+                "Vendor: Atlas Copco Compressors",
+                "Status profile: ready",
+                "Commercial total (USD): 15940.00",
+                "Payment terms: Net 45 EOM",
+                "Delivery lead: 14 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-052-A",
+                    "quantity": 3,
+                    "uom": "ea",
+                    "unit_price": 2875,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-052-B",
+                    "quantity": 2,
+                    "uom": "set",
+                    "unit_price": 1572.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-052",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 4170,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-052/vendor-00": {
+            "business_key": "rfq-052/vendor-00",
+            "rfq_key": "rfq-052",
+            "vendor_key": "vendor-00",
+            "rfq_index": 52,
+            "quote_index": 0,
+            "rfq_kind": "cancelled",
+            "rfq_title": "NDT phased-array - welds on HP piping (lot 53)",
+            "vendor_name": "Worley Chemetics",
+            "quote_status": "normalizing",
+            "original_filename": "Quote_Worley_Chemetics.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-052-vendor-00.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-052/vendor-00",
+                "RFQ: NDT phased-array - welds on HP piping (lot 53)",
+                "Vendor: Worley Chemetics",
+                "Status profile: normalizing",
+                "Commercial total (USD): 15995.00",
+                "Payment terms: Net 30",
+                "Delivery lead: 13 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-053-A",
+                    "quantity": 2,
+                    "uom": "ea",
+                    "unit_price": 2837.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-053-B",
+                    "quantity": 4,
+                    "uom": "set",
+                    "unit_price": 1551.25,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-053",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 4115,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-053/vendor-00": {
+            "business_key": "rfq-053/vendor-00",
+            "rfq_key": "rfq-053",
+            "vendor_key": "vendor-00",
+            "rfq_index": 53,
+            "quote_index": 0,
+            "rfq_kind": "cancelled",
+            "rfq_title": "Relief valve recertification (in-situ) (lot 54)",
+            "vendor_name": "BASF Catalysts",
+            "quote_status": "normalizing",
+            "original_filename": "Quote_BASF_Catalysts.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-053-vendor-00.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-053/vendor-00",
+                "RFQ: Relief valve recertification (in-situ) (lot 54)",
+                "Vendor: BASF Catalysts",
+                "Status profile: normalizing",
+                "Commercial total (USD): 15940.00",
+                "Payment terms: Net 30",
+                "Delivery lead: 14 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-054-A",
+                    "quantity": 3,
+                    "uom": "ea",
+                    "unit_price": 2875,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-054-B",
+                    "quantity": 2,
+                    "uom": "set",
+                    "unit_price": 1572.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-054",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 4170,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-053/vendor-01": {
+            "business_key": "rfq-053/vendor-01",
+            "rfq_key": "rfq-053",
+            "vendor_key": "vendor-01",
+            "rfq_index": 53,
+            "quote_index": 1,
+            "rfq_kind": "cancelled",
+            "rfq_title": "Relief valve recertification (in-situ) (lot 54)",
+            "vendor_name": "Clariant Catalysts",
+            "quote_status": "failed",
+            "original_filename": "Quote_Clariant_Catalysts.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-053-vendor-01.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-053/vendor-01",
+                "RFQ: Relief valve recertification (in-situ) (lot 54)",
+                "Vendor: Clariant Catalysts",
+                "Status profile: failed",
+                "Commercial total (USD): 20656.25",
+                "Payment terms: Net 30",
+                "Delivery lead: 6 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-054-A",
+                    "quantity": 4,
+                    "uom": "ea",
+                    "unit_price": 2912.5,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-054-B",
+                    "quantity": 3,
+                    "uom": "set",
+                    "unit_price": 1593.75,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-054",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 4225,
+                    "currency": "USD"
+                }
+            ]
+        },
+        "rfq-055/vendor-00": {
+            "business_key": "rfq-055/vendor-00",
+            "rfq_key": "rfq-055",
+            "vendor_key": "vendor-00",
+            "rfq_index": 55,
+            "quote_index": 0,
+            "rfq_kind": "cancelled",
+            "rfq_title": "Catalyst sampling probes + quills (lot 56)",
+            "vendor_name": "Wood PLC Norway",
+            "quote_status": "normalizing",
+            "original_filename": "Quote_Wood_PLC_Norway.pdf",
+            "file_type": "application/pdf",
+            "pdf_path": "files/rfq-055-vendor-00.pdf",
+            "document_lines": [
+                "Atomy-Q seed quotation fixture",
+                "Business key: rfq-055/vendor-00",
+                "RFQ: Catalyst sampling probes + quills (lot 56)",
+                "Vendor: Wood PLC Norway",
+                "Status profile: normalizing",
+                "Commercial total (USD): 13690.00",
+                "Payment terms: Net 30",
+                "Delivery lead: 7 weeks"
+            ],
+            "line_seed_data": [
+                {
+                    "description": "Line 1 - Tag NFC-056-A",
+                    "quantity": 1,
+                    "uom": "ea",
+                    "unit_price": 2950,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 2 - Tag NFC-056-B",
+                    "quantity": 4,
+                    "uom": "set",
+                    "unit_price": 1615,
+                    "currency": "USD"
+                },
+                {
+                    "description": "Line 3 - Service bundle NFC-056",
+                    "quantity": 1,
+                    "uom": "lot",
+                    "unit_price": 4280,
+                    "currency": "USD"
+                }
+            ]
+        }
+    }
+}

--- a/apps/atomy-q/API/database/seeders/PetrochemicalTenantSeeder.php
+++ b/apps/atomy-q/API/database/seeders/PetrochemicalTenantSeeder.php
@@ -16,6 +16,8 @@ use App\Models\Tenant;
 use App\Models\User;
 use App\Models\Vendor;
 use App\Models\VendorInvitation;
+use App\Support\SeedData\Quotations\PetrochemicalSeedQuotationCatalog;
+use App\Support\SeedData\Quotations\SeedQuotationManifest;
 use Database\Factories\ProjectFactory;
 use Database\Factories\QuoteSubmissionFactory;
 use Database\Factories\UserFactory;
@@ -23,6 +25,7 @@ use Database\Factories\VendorFactory;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 
 /**
@@ -49,6 +52,9 @@ final class PetrochemicalTenantSeeder extends Seeder
     private string $scoringModelId = "";
 
     private string $scoringPolicyId = "";
+
+    /** @var array<string, array<string, mixed>>|null */
+    private ?array $seedQuotationManifestEntries = null;
 
     public function run(): void
     {
@@ -852,21 +858,31 @@ final class PetrochemicalTenantSeeder extends Seeder
             $errorsCount = 2;
         }
 
+        $businessKey = PetrochemicalSeedQuotationCatalog::businessKey(
+            $rfqIndex,
+            $quoteIndex,
+        );
+        $entry = $this->seedQuotationManifestEntries()[$businessKey] ?? null;
+
+        if (!is_array($entry)) {
+            throw new \RuntimeException(
+                "Missing seed quotation fixture for [{$businessKey}].",
+            );
+        }
+
+        $storagePath = $this->copyFixtureIntoQuoteStorage($entry);
+
         QuoteSubmission::query()->create([
             "id" => (string) Str::ulid(),
             "tenant_id" => $this->tenantId,
             "rfq_id" => $rfq->id,
             "vendor_id" => $vendor->id,
-            "vendor_name" => $vendor->display_name,
+            "vendor_name" => (string) $entry["vendor_name"],
             "uploaded_by" => $rfq->owner_id,
             "status" => $status,
-            "file_path" =>
-                "/uploads/quotes/" . $rfq->id . "-" . $quoteIndex . ".pdf",
-            "file_type" => "application/pdf",
-            "original_filename" =>
-                "Quote_" .
-                preg_replace("/\W+/", "_", $vendor->legal_name) .
-                ".pdf",
+            "file_path" => $storagePath,
+            "file_type" => (string) $entry["file_type"],
+            "original_filename" => (string) $entry["original_filename"],
             "submitted_at" => $submittedAt,
             "confidence" => $confidence,
             "line_items_count" => $lineItemsCount,
@@ -879,6 +895,43 @@ final class PetrochemicalTenantSeeder extends Seeder
             "parsed_at" => $parsedAt,
             "retry_count" => $retryCount,
         ]);
+    }
+
+    /**
+     * @param array<string, mixed> $entry
+     */
+    private function copyFixtureIntoQuoteStorage(array $entry): string
+    {
+        $pdfPath = (string) ($entry["pdf_path"] ?? "");
+
+        if ($pdfPath === "") {
+            throw new \RuntimeException(
+                "Seed quotation fixture manifest entry is missing [pdf_path].",
+            );
+        }
+
+        $source = base_path("database/seed-data/quotations/" . $pdfPath);
+        $target = "quote-submissions/" . basename($pdfPath);
+
+        Storage::disk("local")->put($target, (string) file_get_contents($source));
+
+        return $target;
+    }
+
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    private function seedQuotationManifestEntries(): array
+    {
+        if ($this->seedQuotationManifestEntries !== null) {
+            return $this->seedQuotationManifestEntries;
+        }
+
+        $manifest = SeedQuotationManifest::read(
+            base_path("database/seed-data/quotations/manifest.json"),
+        );
+
+        return $this->seedQuotationManifestEntries = $manifest["entries"];
     }
 
     private function seedComparisonApprovalAward(

--- a/apps/atomy-q/API/tests/Feature/Console/GenerateSeedQuotationFixturesCommandTest.php
+++ b/apps/atomy-q/API/tests/Feature/Console/GenerateSeedQuotationFixturesCommandTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+final class GenerateSeedQuotationFixturesCommandTest extends TestCase
+{
+    private string $fixtureRoot;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->fixtureRoot = base_path('database/seed-data/quotations');
+
+        File::deleteDirectory($this->fixtureRoot);
+    }
+
+    public function testFixtureCommandManifestContainsExpectedBusinessKeys(): void
+    {
+        $this->artisan('atomy:generate-seed-quotation-fixtures')
+            ->expectsOutputToContain('Wrote manifest')
+            ->assertExitCode(0);
+
+        $manifestPath = $this->fixtureRoot . '/manifest.json';
+        $pdfPath = $this->fixtureRoot . '/files/rfq-008-vendor-00.pdf';
+
+        self::assertFileExists($manifestPath);
+        self::assertFileExists($pdfPath);
+        self::assertGreaterThan(200, filesize($pdfPath));
+
+        /** @var array{entries: array<string, array<string, mixed>>} $manifest */
+        $manifest = json_decode(
+            (string) file_get_contents($manifestPath),
+            true,
+            512,
+            JSON_THROW_ON_ERROR,
+        );
+
+        self::assertCount(153, $manifest['entries']);
+        self::assertArrayHasKey('rfq-008/vendor-00', $manifest['entries']);
+    }
+}

--- a/apps/atomy-q/API/tests/Feature/Database/PetrochemicalTenantSeederQuotationFixturesTest.php
+++ b/apps/atomy-q/API/tests/Feature/Database/PetrochemicalTenantSeederQuotationFixturesTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Database;
+
+use App\Models\QuoteSubmission;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+final class PetrochemicalTenantSeederQuotationFixturesTest extends TestCase
+{
+    private string $testStorageRoot;
+
+    public function createApplication(): \Illuminate\Foundation\Application
+    {
+        $app = parent::createApplication();
+        $app['config']->set('database.default', 'sqlite');
+        $app['config']->set('database.connections.sqlite', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+            'foreign_key_constraints' => true,
+        ]);
+
+        $this->testStorageRoot = sys_get_temp_dir() . '/atomy-q-seed-quotation-fixtures-storage';
+        File::deleteDirectory($this->testStorageRoot);
+        File::ensureDirectoryExists($this->testStorageRoot);
+        $app['config']->set('filesystems.disks.local.root', $this->testStorageRoot);
+
+        return $app;
+    }
+
+    protected function tearDown(): void
+    {
+        File::deleteDirectory($this->testStorageRoot);
+
+        parent::tearDown();
+    }
+
+    public function testPetrochemicalSeederCopiesCanonicalQuotePdfsIntoLocalStorage(): void
+    {
+        $this->artisan('atomy:generate-seed-quotation-fixtures')->assertExitCode(0);
+        $this->artisan('migrate:fresh', ['--seed' => true])->assertExitCode(0);
+
+        $submission = QuoteSubmission::query()->firstOrFail();
+
+        self::assertStringStartsWith('quote-submissions/', (string) $submission->file_path);
+        Storage::disk('local')->assertExists((string) $submission->file_path);
+    }
+}


### PR DESCRIPTION
## Summary
- add a one-off API command and support classes to generate deterministic petrochemical quotation fixture PDFs plus a manifest
- commit the canonical fixture set under `apps/atomy-q/API/database/seed-data/quotations/`
- make `PetrochemicalTenantSeeder` reuse those fixtures via local `quote-submissions/...` storage and cover the flow with command and seeder tests

## Test Plan
- `cd apps/atomy-q/API && php artisan test --filter "GenerateSeedQuotationFixturesCommandTest|PetrochemicalTenantSeederQuotationFixturesTest|QuoteIngestionIntelligenceTest|QuoteIngestionPipelineTest"`
- `cd apps/atomy-q/API && php artisan atomy:generate-seed-quotation-fixtures`
